### PR TITLE
initialize Redux store with SSR disabled

### DIFF
--- a/server/plugins/webapp/index.js
+++ b/server/plugins/webapp/index.js
@@ -111,6 +111,15 @@ function makeRouteHandler(options, userContent) {
     const mode = request.query.__mode || "";
     const renderJs = RENDER_JS && mode !== "nojs";
     const renderSs = RENDER_SS && mode !== "noss";
+    // Persist disabled SSR in request if flag not set
+    // For the benefit of electrode-redux-router-engine
+    if (!renderSs) {
+      if (request.server && request.server.app) {
+        request.app.disableSSR = true;
+      } else if(req.app) {
+        request.app.disableSSR = true;
+      }
+    }
     const chunkNames = chunkSelector(request);
     const devCSSBundle = chunkNames.css ?
       `${devBundleBase}${chunkNames.css}.style.css` :
@@ -214,7 +223,7 @@ function makeRouteHandler(options, userContent) {
     };
 
     const doRender = () => {
-      return renderSs ? renderSSRContent(userContent) : renderPage("");
+      return renderSSRContent(userContent);
     };
 
     Promise.try(doRender)

--- a/server/plugins/webapp/index.js
+++ b/server/plugins/webapp/index.js
@@ -106,7 +106,7 @@ function makeRouteHandler(options, userContent) {
   const criticalCSS = getCriticalCSS(options.criticalCSS);
 
   /* Create a route handler */
-  /* eslint max-statements: [2, 20] */
+  /* eslint max-statements: [2, 23] */
   return (request, reply) => {
     const mode = request.query.__mode || "";
     const renderJs = RENDER_JS && mode !== "nojs";
@@ -116,7 +116,7 @@ function makeRouteHandler(options, userContent) {
     if (!renderSs) {
       if (request.server && request.server.app) {
         request.app.disableSSR = true;
-      } else if(req.app) {
+      } else if (request.app) {
         request.app.disableSSR = true;
       }
     }


### PR DESCRIPTION
Passing the disableSSR flag in the request, so it can be used downstream by redux router engine to proceed with SSR or just stop at initializing the redux store.