### PR TITLE
Add react-toast-dep

### DIFF
--- a/samples/universal-react-node/package.json
+++ b/samples/universal-react-node/package.json
@@ -36,7 +36,8 @@
     "electrode-react-webapp": "^1.1.0",
     "electrode-redux-router-engine": "^1.0.0",
     "electrode-server": "^1.0.0",
-    "electrode-static-paths": "^1.0.0"
+    "electrode-static-paths": "^1.0.0",
+    "react-notify-toast": "^0.1.3"
   },
   "devDependencies": {
     "electrode-archetype-react-app-dev": "^1.5.0",


### PR DESCRIPTION
We are importing `react-toast-dep` but it isn't a dependency. https://github.com/electrode-io/electrode/blob/master/samples/universal-react-node/client/components/home.jsx#L4 

@ananavati @donsalari 