### PR TITLE
Display errors in ReduxStore

### DIFF
--- a/packages/electrode-redux-router-engine/README.md
+++ b/packages/electrode-redux-router-engine/README.md
@@ -82,6 +82,7 @@ Where options could contain the following fields:
   - `logError` - **optional** callback to log any error
     - It should take `(req, err)` arguments
     - If it's a `function` then its `this` references the engine instance
+    - Defaulted to `console.log`
   - `renderToString` - **optional** callback to provide custom renderToString
     - It should take `(req, store, match, withIds)` arguments
 

--- a/packages/electrode-redux-router-engine/lib/redux-router-engine.js
+++ b/packages/electrode-redux-router-engine/lib/redux-router-engine.js
@@ -22,7 +22,8 @@ class ReduxRouterEngine {
     }
 
     if (!this.options.logError) {
-      this.options.logError = () => undefined;
+      this.options.logError = (req, err) =>
+        console.log("Electrode ReduxRouterEngine Error:", err); //eslint-disable-line
     }
 
     if (this.options.renderToString) {

--- a/packages/generator-electrode/generators/app/templates/client/components/home.jsx
+++ b/packages/generator-electrode/generators/app/templates/client/components/home.jsx
@@ -1,6 +1,6 @@
 import React, {PropTypes} from "react";
-import {connect} from "react-redux";
-<% if (pwa) { %>import Notifications from "react-notify-toast";<% } %>
+import {connect} from "react-redux";<%if(pwa){%>
+import Notifications from "react-notify-toast";<%}%>
 import {toggleCheck, incNumber, decNumber} from "../actions";
 
 class Home extends React.Component {
@@ -8,8 +8,8 @@ class Home extends React.Component {
     const props = this.props;
     const {checked, value} = props;
     return (
-      <div>
-        <% if (pwa) { %><Notifications /><% } %>
+      <div><%if(pwa){%>
+        <Notifications /><%}%>
         <h1>Hello <a href={"https://github.com/electrode-io"}>{"Electrode"}</a></h1>
         <div>
           <h2>Managing States with Redux</h2>


### PR DESCRIPTION
[Issue 16](https://github.com/electrode-io/electrode-server/issues/16) and [Issue 34](https://github.com/electrode-io/electrode/issues/34)
Errors inside index-view.js promises silently failed. logging errors for stack trace.



```
ReferenceError: i_am_undefined is not defined
    at ReduxRouterEngine.createReduxStore (/Users/a0k00e3/Desktop/errors/server/views/index-view.js:18:3)
    at ReduxRouterEngine._handleRender (/Users/a0k00e3/Desktop/errors/node_modules/electrode-redux-router-engine/lib/redux-router-engine.js:96:72)
    at _matchRoute.then (/Users/a0k00e3/Desktop/errors/node_modules/electrode-redux-router-engine/lib/redux-router-engine.js:60:23)
    at bound (domain.js:280:14)
    at runBound (domain.js:293:12)
    at tryCatcher (/Users/a0k00e3/Desktop/errors/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/a0k00e3/Desktop/errors/node_modules/bluebird/js/release/promise.js:510:31)
    at Promise._settlePromise (/Users/a0k00e3/Desktop/errors/node_modules/bluebird/js/release/promise.js:567:18)
    at Promise._settlePromiseCtx (/Users/a0k00e3/Desktop/errors/node_modules/bluebird/js/release/promise.js:604:10)
    at Async._drainQueue (/Users/a0k00e3/Desktop/errors/node_modules/bluebird/js/release/async.js:143:12)
    at Async._drainQueues (/Users/a0k00e3/Desktop/errors/node_modules/bluebird/js/release/async.js:148:10)
    at Immediate.Async.drainQueues (/Users/a0k00e3/Desktop/errors/node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:637:20)
    at tryOnImmediate (timers.js:610:5)
    at processImmediate [as _immediateCallback] (timers.js:582:5)
^C
```