### PR TITLE
Material example is not referencing the main bundle

### DIFF
--- a/samples/universal-material-ui/server/plugins/webapp/index.js
+++ b/samples/universal-material-ui/server/plugins/webapp/index.js
@@ -163,8 +163,8 @@ const registerRoutes = (server, options, next) => {
       const devServer = pluginOptions.devServer;
       pluginOptions.__internals = {
         assets,
-        devJSBundle: `http://${devServer.host}:${devServer.port}/js/bundle.dev.js`,
-        devCSSBundle: `http://${devServer.host}:${devServer.port}/js/style.css`
+        devJSBundle: `http://${devServer.host}:${devServer.port}/js/main.bundle.dev.js`,
+        devCSSBundle: `http://${devServer.host}:${devServer.port}/js/main.style.css`
       };
 
       _.each(options.paths, (v, path) => {


### PR DESCRIPTION
Change the webapp to point to the correct bundle.  Maybe core electrode server was updated to make a main bundle and this app was not fixed.