### PR TITLE
Pass userConfig to loadConfigs

### DIFF
--- a/packages/generator-electrode/generators/app/templates/server/express-server.js
+++ b/packages/generator-electrode/generators/app/templates/server/express-server.js
@@ -51,7 +51,7 @@ const startServer = () => new Promise((resolve, reject) => {
 });
 
 module.exports = function electrodeServer(userConfig, callback) {
-  const promise = Promise.resolve({})
+  const promise = Promise.resolve(userConfig)
     .then(loadConfigs)
     .then(setStaticPaths)
     .then(setRouteHandler)


### PR DESCRIPTION
Looks like the generator is not passing through the userConfigs from the calling of the server to loadConfigs.  loadConfigs signature takes in userConfigs, but as it is right now always gets an empty config object.  The entry point for the module is passed the userConfigs, so this pull is just actually getting it to the loadConfigs method, via the Promise.resolve.