### PR TITLE
Update Extract partial to use unopinionated glob

### DIFF
--- a/packages/electrode-archetype-react-app/config/webpack/partial/extract.js
+++ b/packages/electrode-archetype-react-app/config/webpack/partial/extract.js
@@ -28,8 +28,8 @@ var postcssLoader = archetype.devRequire.resolve("postcss-loader");
  * case 4: *none* *.css & *.styl exists => CSS-Modules + CSS-Next takes priority
  */
 
-var cssNextExists = (glob.sync(Path.join(process.cwd() + "/client/styles/*.css")).length > 0);
-var stylusExists = (glob.sync(Path.join(process.cwd() + "/client/styles/*.styl")).length > 0);
+var cssNextExists = (glob.sync(Path.join(process.cwd() + "/client/**/*.css")).length > 0);
+var stylusExists = (glob.sync(Path.join(process.cwd() + "/client/**/*.styl")).length > 0);
 
 // By default, this archetype assumes you are using CSS-Modules + CSS-Next
 var cssModuleSupport = true;


### PR DESCRIPTION
Based on a discussion with @ananavati in https://gitter.im/electrode-io/electrode.

~I think the [Develop Styles](http://www.electrode.io/docs/develop_styles.html) documentation should also be updated by this PR to reflect this change, but I don't see it in this repository.~ Done: electrode-io/electrode-io.github.io#377

Note: This is a non-breaking change. In sufficiently large/deep applications, this could potentially have a performance impact since it traverses all paths of the `client` directory. The impact is likely negligible though.