### PR TITLE
Allow non-GET methods on electrode-react-webapp routes

### DIFF
--- a/packages/electrode-react-webapp/lib/express/index.js
+++ b/packages/electrode-react-webapp/lib/express/index.js
@@ -16,23 +16,29 @@ const registerRoutes = (app, options, next) => {
         const routeHandler = ReactWebapp.makeRouteHandler(
           registerOptions, ReactWebapp.resolveContent(v.content));
 
-        app.get(path, (request, response) => {
-          const handleStatus = (data) => {
-            const status = data.status;
-            if (status === HTTP_REDIRECT) {
-              response.redirect(data.path);
-            } else {
-              response.send({message: "error"}).code(status);
-            }
-          };
+      	const methods = v.methods || ["GET"];
+        _.each(methods, (method) => {
+          if(method === "*") { 
+            method = "ALL";
+          }
+          app[method.toLowerCase()](path, (request, response) => {
+            const handleStatus = (data) => {
+              const status = data.status;
+              if (status === HTTP_REDIRECT) {
+                response.redirect(data.path);
+              } else {
+                response.send({message: "error"}).code(status);
+              }
+            };
 
-          return routeHandler({mode: request.query.__mode || "", request})
-            .then((data) => {
-              return data.status ? handleStatus(data) : response.send(data);
-            })
-            .catch((err) => {
-              response.send(err.html).code(err.status || HTTP_ERROR_500);
-            });
+            return routeHandler({mode: request.query.__mode || "", request})
+              .then((data) => {
+                return data.status ? handleStatus(data) : response.send(data);
+              })
+              .catch((err) => {
+                response.send(err.html).code(err.status || HTTP_ERROR_500);
+              });
+          });
         });
       });
     })

--- a/packages/electrode-react-webapp/lib/express/index.js
+++ b/packages/electrode-react-webapp/lib/express/index.js
@@ -16,12 +16,13 @@ const registerRoutes = (app, options, next) => {
         const routeHandler = ReactWebapp.makeRouteHandler(
           registerOptions, ReactWebapp.resolveContent(v.content));
 
-      	const methods = v.methods || ["GET"];
+        /*eslint max-nested-callbacks: [0, 4]*/
+        const methods = v.methods || ["GET"];
         _.each(methods, (method) => {
-          if(method === "*") { 
+          if (method === "*") {
             method = "ALL";
           }
-          app[method.toLowerCase()](path, (request, response) => {
+          app[method.toLowerCase()](path, (request, response) => { //eslint-disable-line
             const handleStatus = (data) => {
               const status = data.status;
               if (status === HTTP_REDIRECT) {

--- a/packages/electrode-react-webapp/lib/hapi/index.js
+++ b/packages/electrode-react-webapp/lib/hapi/index.js
@@ -17,7 +17,7 @@ const registerRoutes = (server, options, next) => {
         );
 
         server.route({
-          method: "GET",
+          method: v.method || "GET",
           path,
           config: v.config || {},
           handler: (request, reply) => {


### PR DESCRIPTION
This change lets users configure an optional `methods` attribute for `electrode-react-webapp` paths. This lets me render `POST` requests on server.

    "webapp": {
      "module": "electrode-react-webapp/lib/hapi",
      "options": {
        "pageTitle": "title",
        "paths": {
          "/{args*}": {
            "method": ["GET", "POST"],
            "content": {
              "module": "./server/views/index-view"
            }
          }
        }
      }
    }

This needs a Koa implementation, and I have not tested the Express implementation. Works for Hapi.