### PR TITLE
Stylus and css modules together

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/base.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/base.js
@@ -47,11 +47,25 @@ function appEntry() {
   return fs.existsSync(Path.join(context, "app.js")) ? "./app.js" : "./app.jsx";
 }
 
+function getArchetypeConfig() {
+  var archetypeConfigPath = Path.join(process.cwd(), "archetype", "config.js");
+  var archetypeConfig;
+
+  try {
+    archetypeConfig = require(archetypeConfigPath);
+  } catch (err) {
+    archetypeConfig = {};
+  }
+
+  return archetypeConfig;
+}
+
 var entry = appEntry();
 var multiBundle = _.isObject(entry);
 
 var baseConfig = {
   __wmlMultiBundle: multiBundle,
+  __archetypeConfig: getArchetypeConfig(),
   cache: true,
   context: context,
   debug: false,

--- a/packages/electrode-archetype-react-app-dev/config/webpack/base.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/base.js
@@ -47,25 +47,11 @@ function appEntry() {
   return fs.existsSync(Path.join(context, "app.js")) ? "./app.js" : "./app.jsx";
 }
 
-function getArchetypeConfig() {
-  var archetypeConfigPath = Path.join(process.cwd(), "archetype", "config.js");
-  var archetypeConfig;
-
-  try {
-    archetypeConfig = require(archetypeConfigPath);
-  } catch (err) {
-    archetypeConfig = {};
-  }
-
-  return archetypeConfig;
-}
-
 var entry = appEntry();
 var multiBundle = _.isObject(entry);
 
 var baseConfig = {
   __wmlMultiBundle: multiBundle,
-  __archetypeConfig: getArchetypeConfig(),
   cache: true,
   context: context,
   debug: false,

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract.js
@@ -28,6 +28,7 @@ var AppMode = archetype.AppMode;
  * case 3: *both* *.css & *.styl exists => CSS-Modules + CSS-Next takes priority
  *          with a warning message
  * case 4: *none* *.css & *.styl exists => CSS-Modules + CSS-Next takes priority
+ * case 5: *cssStylusSupport* config is true => Use both Stylus and CSS Modules
  */
 
 var cssNextExists = (glob.sync(Path.resolve(AppMode.src.client, "**", "*.css")).length > 0);
@@ -47,8 +48,10 @@ if (stylusExists && !cssNextExists) {
 
 module.exports = function () {
   return function (config) {
+    var cssStylusSupport = config.cssStylusSupport;
     var stylusQuery = cssLoader + "?-autoprefixer!" + stylusLoader;
     var cssQuery = cssLoader + "?modules&-autoprefixer!" + postcssLoader;
+    var cssStylusQuery = cssLoader + "?modules&-autoprefixer!" + postcssLoader + "!" + stylusLoader;
 
     // By default, this archetype assumes you are using CSS-Modules + CSS-Next
     var loaders = [{
@@ -57,7 +60,13 @@ module.exports = function () {
       loader: ExtractTextPlugin.extract(styleLoader, cssQuery, {publicPath: ""})
     }];
 
-    if (!cssModuleSupport) {
+    if (config.cssStylusSupport) {
+      loaders.push({
+        name: "extract-css-stylus",
+        test: /\.styl$/,
+        loader: ExtractTextPlugin.extract(styleLoader, cssStylusQuery, {publicPath: "" })
+      });
+    } else if (!cssModuleSupport) {
       loaders.push({
         name: "extract-stylus",
         test: /\.styl$/,

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract.js
@@ -43,7 +43,7 @@ if (stylusExists && !cssNextExists) {
 
 module.exports = function () {
   return function (config) {
-    var cssModuleStylusSupport = config.__archetypeConfig.cssModuleStylusSupport;
+    var cssModuleStylusSupport = archetype.options.cssModuleStylusSupport;
     var stylusQuery = cssLoader + "?-autoprefixer!" + stylusLoader;
     var cssQuery = cssLoader + "?modules&-autoprefixer!" + postcssLoader;
     var cssStylusQuery = cssLoader + "?modules&-autoprefixer!" + postcssLoader + "!" + stylusLoader;

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract.js
@@ -18,23 +18,6 @@ var postcssLoader = require.resolve("postcss-loader");
 
 var AppMode = archetype.AppMode;
 
-function getCssModuleStylusSupport() {
-  var configPath = Path.resolve("config", "css-config.js");
-  var cssModuleStylusSupport = false;
-
-  try {
-    var cssModuleStylusConfig = require(configPath);
-
-    if (cssModuleStylusConfig && cssModuleStylusConfig.cssModuleStylusSupport === true) {
-      cssModuleStylusSupport = true;
-    }
-  } catch (err) {
-   //
-  }
-
-  return cssModuleStylusSupport;
-}
-
 /**
  * [cssModuleSupport By default, this archetype assumes you are using CSS-Modules + CSS-Next]
  *
@@ -53,7 +36,6 @@ var stylusExists = (glob.sync(Path.resolve(AppMode.src.client, "**", "*.styl")).
 
 // By default, this archetype assumes you are using CSS-Modules + CSS-Next
 var cssModuleSupport = true;
-var cssModuleStylusSupport = getCssModuleStylusSupport();
 
 if (stylusExists && !cssNextExists) {
   cssModuleSupport = false;
@@ -61,6 +43,7 @@ if (stylusExists && !cssNextExists) {
 
 module.exports = function () {
   return function (config) {
+    var cssModuleStylusSupport = config.__archetypeConfig.cssModuleStylusSupport;
     var stylusQuery = cssLoader + "?-autoprefixer!" + stylusLoader;
     var cssQuery = cssLoader + "?modules&-autoprefixer!" + postcssLoader;
     var cssStylusQuery = cssLoader + "?modules&-autoprefixer!" + postcssLoader + "!" + stylusLoader;

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract.js
@@ -18,6 +18,23 @@ var postcssLoader = require.resolve("postcss-loader");
 
 var AppMode = archetype.AppMode;
 
+function getCssModuleStylusSupport() {
+  var configPath = Path.resolve("config", "css-config.js");
+  var cssModuleStylusSupport = false;
+
+  try {
+    var cssModuleStylusConfig = require(configPath);
+
+    if (cssModuleStylusConfig && cssModuleStylusConfig.cssModuleStylusSupport === true) {
+      cssModuleStylusSupport = true;
+    }
+  } catch (err) {
+   //
+  }
+
+  return cssModuleStylusSupport;
+}
+
 /**
  * [cssModuleSupport By default, this archetype assumes you are using CSS-Modules + CSS-Next]
  *
@@ -28,7 +45,7 @@ var AppMode = archetype.AppMode;
  * case 3: *both* *.css & *.styl exists => CSS-Modules + CSS-Next takes priority
  *          with a warning message
  * case 4: *none* *.css & *.styl exists => CSS-Modules + CSS-Next takes priority
- * case 5: *cssStylusSupport* config is true => Use both Stylus and CSS Modules
+ * case 5: *cssModuleStylusSupport* config is true => Use both Stylus and CSS Modules
  */
 
 var cssNextExists = (glob.sync(Path.resolve(AppMode.src.client, "**", "*.css")).length > 0);
@@ -36,19 +53,14 @@ var stylusExists = (glob.sync(Path.resolve(AppMode.src.client, "**", "*.styl")).
 
 // By default, this archetype assumes you are using CSS-Modules + CSS-Next
 var cssModuleSupport = true;
+var cssModuleStylusSupport = getCssModuleStylusSupport();
 
 if (stylusExists && !cssNextExists) {
   cssModuleSupport = false;
-} else if (stylusExists && cssNextExists) {
-  /* eslint-disable no-console */
-  console.log(`\n\n **** you have demo.css & demo.styl please delete *.styl
-    and upgrade to using *.css for CSS-Modules + CSS-Next support **** \n\n`);
-  /* eslint-enable no-console */
 }
 
 module.exports = function () {
   return function (config) {
-    var cssStylusSupport = config.cssStylusSupport;
     var stylusQuery = cssLoader + "?-autoprefixer!" + stylusLoader;
     var cssQuery = cssLoader + "?modules&-autoprefixer!" + postcssLoader;
     var cssStylusQuery = cssLoader + "?modules&-autoprefixer!" + postcssLoader + "!" + stylusLoader;
@@ -60,7 +72,7 @@ module.exports = function () {
       loader: ExtractTextPlugin.extract(styleLoader, cssQuery, {publicPath: ""})
     }];
 
-    if (config.cssStylusSupport) {
+    if (cssModuleStylusSupport) {
       loaders.push({
         name: "extract-css-stylus",
         test: /\.styl$/,

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract.js
@@ -43,7 +43,7 @@ if (stylusExists && !cssNextExists) {
 
 module.exports = function () {
   return function (config) {
-    var cssModuleStylusSupport = archetype.options.cssModuleStylusSupport;
+    var cssModuleStylusSupport = archetype.webpack.cssModuleStylusSupport;
     var stylusQuery = cssLoader + "?-autoprefixer!" + stylusLoader;
     var cssQuery = cssLoader + "?modules&-autoprefixer!" + postcssLoader;
     var cssStylusQuery = cssLoader + "?modules&-autoprefixer!" + postcssLoader + "!" + stylusLoader;

--- a/packages/electrode-archetype-react-app/config/archetype.js
+++ b/packages/electrode-archetype-react-app/config/archetype.js
@@ -137,20 +137,20 @@ function loadDev() {
     devDir,
     devPkg,
     devRequire,
-    webpack: Object.assign({}, archetypeOptions.webpack, {
+    webpack: Object.assign({}, {
       devHostname: "localhost",
       devPort: getInt(process.env.WEBPACK_DEV_PORT, 2992),
       testPort: getInt(process.env.WEBPACK_TEST_PORT, 3001),
       modulesDirectories: []
-    }),
-    config: Object.assign({}, archetypeOptions.configPaths, {
+    }, archetypeOptions.webpack),
+    config: Object.assign({}, {
       babel: `${configDir}/babel`,
       eslint: `${configDir}/eslint`,
       istanbul: `${configDir}/istanbul`,
       karma: `${configDir}/karma`,
       mocha: `${configDir}/mocha`,
       webpack: `${configDir}/webpack`
-    })
+    }, archetypeOptions.configPaths)
   });
 }
 

--- a/packages/electrode-archetype-react-app/config/archetype.js
+++ b/packages/electrode-archetype-react-app/config/archetype.js
@@ -107,7 +107,6 @@ module.exports = {
   dir: Path.resolve(__dirname, ".."),
   pkg,
   Path,
-  options: archetypeOptions,
   AppMode: makeAppMode(),
   prodDir,
   eTmpDir: ".etmp",

--- a/packages/electrode-archetype-react-app/config/archetype.js
+++ b/packages/electrode-archetype-react-app/config/archetype.js
@@ -100,12 +100,14 @@ function getArchetypeOptions() {
   return archetypeOptions;
 }
 
+const archetypeOptions = getArchetypeOptions();
+
 
 module.exports = {
   dir: Path.resolve(__dirname, ".."),
   pkg,
   Path,
-  options: getArchetypeOptions(),
+  options: archetypeOptions,
   AppMode: makeAppMode(),
   prodDir,
   eTmpDir: ".etmp",
@@ -135,20 +137,20 @@ function loadDev() {
     devDir,
     devPkg,
     devRequire,
-    webpack: {
+    webpack: Object.assign({}, archetypeOptions.webpack, {
       devHostname: "localhost",
       devPort: getInt(process.env.WEBPACK_DEV_PORT, 2992),
       testPort: getInt(process.env.WEBPACK_TEST_PORT, 3001),
       modulesDirectories: []
-    },
-    config: {
+    }),
+    config: Object.assign({}, archetypeOptions.configPaths, {
       babel: `${configDir}/babel`,
       eslint: `${configDir}/eslint`,
       istanbul: `${configDir}/istanbul`,
       karma: `${configDir}/karma`,
       mocha: `${configDir}/mocha`,
       webpack: `${configDir}/webpack`
-    }
+    })
   });
 }
 

--- a/packages/electrode-archetype-react-app/config/archetype.js
+++ b/packages/electrode-archetype-react-app/config/archetype.js
@@ -87,11 +87,25 @@ function checkUserBabelRc() {
   return false;
 }
 
+function getArchetypeOptions() {
+  var archetypeOptionsPath = Path.join(process.cwd(), "archetype", "config.js");
+  var archetypeOptions;
+
+  try {
+    archetypeOptions = require(archetypeOptionsPath) || {};
+  } catch (err) {
+    archetypeOptions = {};
+  }
+
+  return archetypeOptions;
+}
+
 
 module.exports = {
   dir: Path.resolve(__dirname, ".."),
   pkg,
   Path,
+  options: getArchetypeOptions(),
   AppMode: makeAppMode(),
   prodDir,
   eTmpDir: ".etmp",


### PR DESCRIPTION
@jchip @ananavati @aweary 

This PR adds the ability for an app to use both stylus and css modules together. While adding in this feature, I found that there is no reliable way to detect that both css modules and stylus should be used (since a project could contain only stylus files but still want to use css modules), so I have added in reading from a `config/css-config` file. I believe we can also utilize the same config file to allow options like a custom `generatedScopeName`. 