### PR TITLE
Refactor Webpack config to allow apps to override config partials

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/babel.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/babel.js
@@ -6,7 +6,9 @@ var AppMode = archetype.AppMode;
 var Path = archetype.Path;
 var _ = require("lodash");
 
-module.exports = function (babel) {
+
+
+module.exports = Object.defineProperties(function (babel) {
   // regex \b for word boundaries
   var babelExcludeRegex = new RegExp(`(node_modules|\\b${Path.join(AppMode.src.client, "vendor")}\\b)`);
   return function (config) {
@@ -35,4 +37,8 @@ module.exports = function (babel) {
       }
     });
   };
-};
+}, { 
+  sequence: {
+    value: 0
+  }
+});

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract.js
@@ -41,7 +41,7 @@ if (stylusExists && !cssNextExists) {
   cssModuleSupport = false;
 }
 
-module.exports = function () {
+module.exports = Object.defineProperties(function () {
   return function (config) {
     var cssModuleStylusSupport = archetype.webpack.cssModuleStylusSupport;
     var stylusQuery = cssLoader + "?-autoprefixer!" + stylusLoader;
@@ -99,4 +99,8 @@ module.exports = function () {
       ]
     });
   };
-};
+}, {
+  sequence: {
+    value: 0
+  }
+});

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/fonts.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/fonts.js
@@ -5,7 +5,7 @@ var mergeWebpackConfig = require("webpack-partial").default;
 var urlLoader = require.resolve("url-loader");
 var fileLoader = require.resolve("file-loader");
 
-module.exports = function () {
+module.exports = Object.defineProperties(function () {
   return function (config) {
     return mergeWebpackConfig(config, {
       module: {
@@ -24,4 +24,8 @@ module.exports = function () {
       }
     });
   };
-};
+}, {
+  sequence: {
+    value: 0
+  }
+});

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/images.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/images.js
@@ -13,7 +13,7 @@ function getCdnLoader() {
   return loader && require.resolve(loader) || "file-loader";
 }
 
-module.exports = function() {
+module.exports = Object.defineProperties(function() {
   return function(config) {
     return mergeWebpackConfig(config, {
       module: {
@@ -25,4 +25,8 @@ module.exports = function() {
       }
     });
   };
-};
+}, {
+  sequence: {
+    value: 0
+  }
+});

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/isomorphic.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/isomorphic.js
@@ -4,7 +4,7 @@ var archetype = require("../../archetype");
 var IsomorphicLoaderPlugin = require("isomorphic-loader/lib/webpack-plugin");
 var mergeWebpackConfig = require("webpack-partial").default;
 
-module.exports = function () {
+module.exports = Object.defineProperties(function () {
   return function (config) {
     return mergeWebpackConfig(config, {
       plugins: [
@@ -18,4 +18,8 @@ module.exports = function () {
       ]
     });
   };
-};
+}, {
+  sequence: {
+    value: 0
+  }
+});

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/json.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/json.js
@@ -2,7 +2,7 @@
 
 var mergeWebpackConfig = require("webpack-partial").default;
 
-module.exports = function () {
+module.exports = Object.defineProperties(function () {
   return function (config) {
     return mergeWebpackConfig(config, {
       module: {
@@ -16,4 +16,8 @@ module.exports = function () {
       }
     });
   };
-};
+}, {
+  sequence: {
+    value: 0
+  }
+});

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/pwa.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/pwa.js
@@ -68,7 +68,7 @@ function createEntryConfigFromScripts(importScripts, entry) {
   }, newEntry);
 }
 
-module.exports = function () {
+module.exports = Object.defineProperties(function () {
   return function (config) {
     var swConfig = optionalRequire(swConfigPath, true) || {};
     var severConfig = optionalRequire(serverConfigPath, true) || {};
@@ -184,4 +184,8 @@ module.exports = function () {
       plugins: plugins
     });
   };
-};
+}, {
+  sequence: {
+    value: 0
+  }
+});

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/simple-progress.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/simple-progress.js
@@ -5,7 +5,7 @@ var webpack = require("webpack");
 
 var lastPct;
 
-module.exports = function () {
+const partial = function () {
   return function (config) {
     return mergeWebpackConfig(config, {
       plugins: [
@@ -34,3 +34,5 @@ module.exports = function () {
     });
   };
 };
+
+module.exports = partial;


### PR DESCRIPTION
## Context
Our team was struggling with moving over a project using SASS  to work within the confines of CSS modules and the existing configuration options (via webpack.config.*.js files in our project root) wouldn't allow us to replace the css loader, causing all kinds of hacks and work arounds, to make SASS viable. Writing our own archetype seems to be the given solution, but I'd rather not have to maintain my own archetype when I otherwise agree with the rest of the conventions provided `electrode-archetype-react-app`.

## Solution: Webpack Partial Overrides
### TL;DR; Define your own, project specific Webpack partials, and have them replace what's defined in the archetype.

I have a modification to the base webpack config file that allows projects using electrode to specify webpack partials in the projects config directory(`config/webpack/partial/`) with the same names as partials in  `node-modules/electrode-archetype-react-app-dev/config/webpack/partials` which replaces what's in the archetype.

I've added a sequence property to each of the partials that were `required()` by `config/webpack/base.js` so that when it globs the ./partial directory it only grabs those partials with the correct sequence, (in this case 0 since it's base config object). This is a pretty MVP feature, but I  figure that sequence could be used down the line to define which partials are required at which stage of the webpack config construction process.  Overriding files in a projects config directory, would also need this sequence property.

This will require some documentation which I'm happy to write, but I wanted to get the code in front some of the core contributors to see if this is something worth developing.  I've tried to touch the partial files as little as possible so they continue to work as expected with the rest of the webpack config files. Tests are passing 🎉 