### PR TITLE
Pass webpack-dev host and port

### DIFF
--- a/packages/electrode-archetype-react-app/arch-gulpfile.js
+++ b/packages/electrode-archetype-react-app/arch-gulpfile.js
@@ -499,7 +499,8 @@ INFO: Individual .babelrc files were generated for you in src/client and src/ser
       task: mkCmd("webpack-dev-server",
         `--config ${config.webpack}/webpack.config.dev.js`,
         `--progress --colors`,
-        `--port ${archetype.webpack.devPort}`)
+        `--port ${archetype.webpack.devPort}`,
+        `--host ${archetype.webpack.devHostname}`)
     },
 
     "wds.hot": {
@@ -507,7 +508,8 @@ INFO: Individual .babelrc files were generated for you in src/client and src/ser
       task: mkCmd("webpack-dev-server",
         `--config ${config.webpack}/webpack.config.hot.js`,
         `--hot --progress --colors --inline`,
-        `--port ${archetype.webpack.devPort}`)
+        `--port ${archetype.webpack.devPort}`,
+        `--host ${archetype.webpack.devHostname}`)
     },
 
     "wds.test": {
@@ -515,7 +517,8 @@ INFO: Individual .babelrc files were generated for you in src/client and src/ser
       task: mkCmd("webpack-dev-server",
         `--config ${config.webpack}/webpack.config.test.js`,
         `--progress --colors`,
-        `--port ${archetype.webpack.testPort}`)
+        `--port ${archetype.webpack.testPort}`,
+        `--host ${archetype.webpack.devHostname}`)
     },
 
     "test-server": () => [["lint-server", "lint-server-test"], "test-server-cov"],

--- a/packages/electrode-archetype-react-app/config/archetype.js
+++ b/packages/electrode-archetype-react-app/config/archetype.js
@@ -122,7 +122,7 @@ function loadDev() {
     devPkg,
     devRequire,
     webpack: Object.assign({}, {
-      devHostname: "localhost",
+      devHostname: process.env.WEBPACK_HOST || "localhost",
       devPort: getInt(process.env.WEBPACK_DEV_PORT, 2992),
       testPort: getInt(process.env.WEBPACK_TEST_PORT, 3001),
       modulesDirectories: []

--- a/packages/electrode-react-webapp/lib/react-webapp.js
+++ b/packages/electrode-react-webapp/lib/react-webapp.js
@@ -238,8 +238,8 @@ const setupOptions = (options) => {
     serverSideRendering: true,
     htmlFile: Path.join(__dirname, "index.html"),
     devServer: {
-      host: "127.0.0.1",
-      port: "2992"
+      host: process.env.WEBPACK_HOST || "127.0.0.1",
+      port: process.env.WEBPACK_DEV_PORT || "2992"
     },
     paths: {},
     stats: "dist/server/stats.json",


### PR DESCRIPTION
This makes it so WEBPACK_HOST and WEBPACK_DEV_PORT are passed to the applicable parts of the application when starting up using `gulp dev`. Without this, it defaults to localhost and 2992 making it impossible to develop unless the developer has access to the local machine.

This is related to https://github.com/electrode-io/electrode/issues/154