### PR TITLE
re-enable dll tasks

### DIFF
--- a/packages/electrode-archetype-react-app/arch-gulpfile.js
+++ b/packages/electrode-archetype-react-app/arch-gulpfile.js
@@ -289,11 +289,8 @@ function makeTasks(gulp) {
     },
 
     // TODO: fix DLL for webpack 2.0
-    // "build-dist": [".clean.dist", ".clean.dll", "build-dist-dll", "build-dist-min", "build-dist:flatten-l10n",
-    //   "build-dist:merge-isomorphic-assets", "copy-dll", "build-dist:clean-tmp"],
-
-    "build-dist": [".clean.dist", "build-dist-min", "build-dist:flatten-l10n",
-      "build-dist:merge-isomorphic-assets", "build-dist:clean-tmp"],
+    "build-dist": [".clean.dist", ".clean.dll", "build-dist-min", "build-dist-dll", "build-dist:flatten-l10n",
+     "build-dist:merge-isomorphic-assets", "copy-dll", "build-dist:clean-tmp"],
 
     "build-dist-dev-static": {
       desc: false,


### PR DESCRIPTION
The DLL plugin can be used to create client side DLL bundles in the app. 
In the `universal-react-node` application, I have added a `dll.config.js` file.

```js
module.exports = {
  components: [
    "isomorphic-fetch"
  ],
  vendor1: [
    "lodash",
    "react",
    "react-dom"
  ],
  vendor2: [
    "redux"
  ]
};
```

During the `gulp build` task I am now able to see the following bundles and their respective maps.

![screen shot 2017-02-09 at 3 26 29 pm](https://cloud.githubusercontent.com/assets/5844098/22807790/a0dc0776-eedd-11e6-8769-abc75d4ab8e3.png)
