### PR TITLE
Babel extend

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/babel.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/babel.js
@@ -15,17 +15,17 @@ module.exports = function (babel) {
     return mergeWebpackConfig(config, {
       module: {
         loaders: [
-          {
+          _.assign({}, {
             name: "babel",
             test: /\.jsx?$/,
             include: hmr && Path.resolve(AppMode.src.client),
-            exclude: archetype.webpack.babelExclude || babelExcludeRegex,
+            exclude: babelExcludeRegex,
             loaders: [
               hmr && "react-hot-loader",
               "babel-loader"
             ].filter(_.identity),
             query: babel
-          },
+          }, archetype.webpack.extendBabelLoader),
           {
             name: "json",
             test: /\.json$/,

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/babel.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/babel.js
@@ -19,7 +19,7 @@ module.exports = function (babel) {
             name: "babel",
             test: /\.jsx?$/,
             include: hmr && Path.resolve(AppMode.src.client),
-            exclude: babelExcludeRegex,
+            exclude: archetype.webpack.babelExclude || babelExcludeRegex,
             loaders: [
               hmr && "react-hot-loader",
               "babel-loader"


### PR DESCRIPTION
@ananavati @aweary @donsalari @jchip 

This PR allows for extending our babel loader as needed. Different projects may need different `excludes`, `query`, or other options, so I think it makes sense to be able to update those values given by a config. The `extendBabelLoader` config will live in `archetype/config.js` under the `webpack` key for projects that need it. 