### PR TITLE
generator-electrode-component: modify editorconfig for consistency with linting rules

### DIFF
--- a/packages/generator-electrode-component/app/templates/editorconfig
+++ b/packages/generator-electrode-component/app/templates/editorconfig
@@ -1,14 +1,14 @@
 # This file is for unifying the coding style for different editors and IDEs
 # editorconfig.org
+
 root = true
 
 [*]
-end_of_line = lf
-charset = utf-8
-trim_trailing_whitespace = false
-insert_final_newline = true
-indent_style = tab
-
-[*.json]
 indent_style = space
 indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
**Context:**
The generator-electrode-component was enforcing tabbed indents over spaces, while the eslint configuration is set up to check for 2-space tabs.  The changes to the file make the editorconfig consistent with eslint rules and with the editorconfig found in the generator-electrode project.

**Solution:**
- Switched to 2 space indents
- Removed unnecessary json rules 
- Added md rule