### PR TITLE
fix DLL plugin

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/webpack.config.dll.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/webpack.config.dll.js
@@ -28,6 +28,7 @@ extensions[baseConfigPath] = function (config) {
 
   statsPlugin.opts.filename = "../../dll/server/stats.dll.json";
   isomorphicPlugin.options.assetsFile = "../../dll/isomorphic-assets.dll.json";
+  config.entry ={};
 
   return config;
 };


### PR DESCRIPTION
The config for the DLL plugin needs the DLL bundles as entries, so clearing the entry value before merging.
![screen shot 2017-02-14 at 1 04 01 pm](https://cloud.githubusercontent.com/assets/5844098/22949164/1f464ece-f2b6-11e6-8b07-e2a1bc78da4d.png)
 