### PR TITLE
Revert "#158: modify webpack test config to allow for correct relative paths"

### DIFF
--- a/packages/electrode-archetype-react-component/config/webpack/webpack.config.test.js
+++ b/packages/electrode-archetype-react-component/config/webpack/webpack.config.test.js
@@ -51,7 +51,7 @@ module.exports = {
   resolve: _.merge({}, prodCfg.resolve, {
     alias: {
       // Allow root import of `src/FOO` from ROOT/src.
-      src: process.cwd(),
+      src: path.join(process.cwd(), "src"),
       sinon: sinonPkg
     },
     modulesDirectories: [


### PR DESCRIPTION
Reverts electrode-io/electrode#159

This seems to be causing tests to hang when running `npm test`