### PR TITLE
archetype-react-app: run webpack and test watch in parallel (#102)

### DIFF
--- a/packages/electrode-archetype-react-app/arch-gulpfile.js
+++ b/packages/electrode-archetype-react-app/arch-gulpfile.js
@@ -522,7 +522,7 @@ INFO: Individual .babelrc files were generated for you in src/client and src/ser
     },
 
     "test-server": () => [["lint-server", "lint-server-test"], "test-server-cov"],
-    "test-watch-all": ["wds.test", "test-frontend-dev-watch"],
+    "test-watch-all": [["wds.test", "test-frontend-dev-watch"]],
 
     "test-ci": ["test-frontend-ci"],
     "test-cov": ["test-frontend-cov", "test-server-cov"],


### PR DESCRIPTION
The wds.* commands do not return.  Rather than force a return through backgrounding and have the problem of terminating after user terminates the parent task, just run the wds.test and watch command in parallel.  All other occurrences of wds.* commands are in parallel.