### PR TITLE
bug-fix for stylus+ css-modules support

### DIFF
--- a/packages/electrode-archetype-react-component/config/webpack/webpack.config.js
+++ b/packages/electrode-archetype-react-component/config/webpack/webpack.config.js
@@ -13,7 +13,6 @@ const imageConfig = require("./partial/images.js");
 const jsonConfig = require("./partial/json.js");
 const optimizeConfig = require("./partial/optimize.js");
 const sourceMapsConfig = require("./partial/sourcemaps.js");
-const stylusConfig = require("./partial/stylus.js");
 
 const archetypeNodeModules = path.join(__dirname, "../../", "node_modules");
 const archetypeDevNodeModules = path.join(


### PR DESCRIPTION
The changes on (https://github.com/electrode-io/electrode/pull/211) had a "remnant" import which caused a error during webpack build.