### PR TITLE
Add karma-intl-shim to the karma config of electrode-archetype-react-app-dev

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/karma/karma.conf.js
+++ b/packages/electrode-archetype-react-app-dev/config/karma/karma.conf.js
@@ -15,7 +15,7 @@ PREPROCESSORS[MAIN_PATH] = ["webpack", "sourcemap"];
 module.exports = function (config) {
   config.set({
     basePath: process.cwd(),
-    frameworks: ["mocha", "phantomjs-shim"],
+    frameworks: ["mocha", "phantomjs-shim", "intl-shim"],
     files: [
       MAIN_PATH
     ],


### PR DESCRIPTION
The `karma-intl-shim` is already imported into the electrode-archetype-react-app-dev package, but not actually applied to the Karma config. 

If there's a way to configure this from my project, I'd love to know, but as it stands it looks like the karma config isn't configurable unless I write a new gulp task. Is that correct?

For easy searching, Here's the error that I received from PhantomJS when I tried to run tests with localized components: `Invariant Violation: [React Intl] The `Intl` APIs must be available in the runtime, and do not appear to be built-in. An `Intl` polyfill should be loaded.`