### PR TITLE
Using library versions from component

### DIFF
--- a/packages/electrode-archetype-react-component/archetype-gulpfile.js
+++ b/packages/electrode-archetype-react-component/archetype-gulpfile.js
@@ -8,9 +8,9 @@ const exec = gulpHelper.exec;
 
 function setupPath() {
   const nmBin = "node_modules/.bin";
-  gulpHelper.envPath.addToFront(Path.resolve(nmBin));
-  gulpHelper.envPath.addToFront(Path.join(archetype.devPath, nmBin));
   gulpHelper.envPath.addToFront(Path.join(__dirname, nmBin));
+  gulpHelper.envPath.addToFront(Path.join(archetype.devPath, nmBin));
+  gulpHelper.envPath.addToFront(Path.resolve(nmBin));
 }
 
 function setProductionEnv() {


### PR DESCRIPTION
Given the current order, if a project using the component archetype then the versions from the archetype win.  This is an issue, especially when using latest eslint configurations.  in the archetype eslint 1.*  wins, which is super old and does not support string severity.