### PR TITLE
Add missing dependencies to webpack-dev reporter

### DIFF
--- a/packages/electrode-webpack-reporter/package.json
+++ b/packages/electrode-webpack-reporter/package.json
@@ -31,7 +31,6 @@
     "react": "^15.4.0",
     "react-dom": "^15.4.0",
     "react-tap-event-plugin": "^2.0.1",
-    "react-tap-event-plugin": "^2.0.1",
     "react-router": "^2.6.1",
     "redux": "^3.6.0",
     "react-redux": "^4.4.5 || ^5.x.x"

--- a/packages/electrode-webpack-reporter/package.json
+++ b/packages/electrode-webpack-reporter/package.json
@@ -30,7 +30,11 @@
     "material-ui": "^0.17.0",
     "react": "^15.4.0",
     "react-dom": "^15.4.0",
-    "react-tap-event-plugin": "^2.0.1"
+    "react-tap-event-plugin": "^2.0.1",
+    "react-tap-event-plugin": "^2.0.1",
+    "react-router": "^2.6.1",
+    "redux": "^3.6.0",
+    "react-redux": "^4.4.5 || ^5.x.x"
   },
   "dependencies": {
     "ansi-to-html": "^0.6.0",


### PR DESCRIPTION
This fixes the errors encountered while running the command `npm run bootstrap`