### PR TITLE
Accept Parameters to check if the Generator has been extended

### DIFF
--- a/packages/generator-electrode/generators/app/index.js
+++ b/packages/generator-electrode/generators/app/index.js
@@ -57,15 +57,9 @@ module.exports = generators.Base.extend({
       desc: 'Content to insert in the README.md file'
     });
     //Flag to check if the OSS generator is being called as a subgenerator
-    if (this.options && this.options.isExtended) {
-      this.isExtended = true;
-    }
-    if (this.options && this.options.serverType) {
-      this.serverType = this.options.serverType;
-    }
-    if (this.options && this.options.githubUrl) {
-      this.githubUrl = this.options.githubUrl;
-    }
+    this.isExtended = this.options.isExtended || false;
+    this.serverType = this.options.serverType || HapiJS;
+    this.githubUrl = this.options.githubUrl || "";
   },
 
   initializing: function () {
@@ -99,9 +93,8 @@ module.exports = generators.Base.extend({
       this.props.authorEmail = info.email;
       this.props.authorUrl = info.url;
     }
-    if (this.serverType) {
-      this.props.serverType = this.serverType || HapiJS;
-    }
+    this.props.serverType = this.serverType || HapiJS;
+    this.props.githubUrl = this.githubUrl;
   },
 
   prompting: {
@@ -378,7 +371,8 @@ module.exports = generators.Base.extend({
     this.composeWith('electrode:git', {
       options: {
         name: this.props.name,
-        githubAccount: this.props.githubAccount
+        githubAccount: this.props.githubAccount,
+        githubUrl: this.props.githubUrl
       }
     }, {
         local: require.resolve('../git')

--- a/packages/generator-electrode/generators/app/index.js
+++ b/packages/generator-electrode/generators/app/index.js
@@ -14,11 +14,11 @@ var githubUsername = require('github-username');
 const ExpressJS = 'ExpressJS';
 const HapiJS = 'HapiJS';
 const KoaJS = 'KoaJS';
+var isExtended = false;
 
 module.exports = generators.Base.extend({
   constructor: function () {
     generators.Base.apply(this, arguments);
-
     this.option('travis', {
       type: Boolean,
       required: false,
@@ -240,7 +240,7 @@ module.exports = generators.Base.extend({
     if (isHapi) {
       ignoreArray.push('**/src/server/express-server.js');
       ignoreArray.push('**/src/server/koa-server.js');
-    } else if (isExpress)  {
+    } else if (isExpress) {
       ignoreArray.push('**/src/server/koa-server.js');
     } else {
       ignoreArray.push('**/src/server/express-server.js');
@@ -254,7 +254,7 @@ module.exports = generators.Base.extend({
     this.fs.copyTpl(
       this.templatePath(_pkg),
       this.destinationPath(_pkg),
-      {isHapi, isExpress, isPWA, isAutoSSR}
+      { isHapi, isExpress, isPWA, isAutoSSR }
     );
 
     var defaultPkg = this.fs.readJSON(this.destinationPath(_pkg));
@@ -316,7 +316,7 @@ module.exports = generators.Base.extend({
     this.fs.copyTpl(
       this.templatePath('src/server'),
       this.destinationPath('src/server'),
-      {isHapi, isExpress},
+      { isHapi, isExpress },
       {},
       {
         globOptions: {
@@ -328,7 +328,7 @@ module.exports = generators.Base.extend({
     this.fs.copyTpl(
       this.templatePath('src/client'),
       this.destinationPath('src/client'),
-      {pwa: isPWA},
+      { pwa: isPWA },
       {}, // template options
       { // copy options
         globOptions: {
@@ -369,8 +369,8 @@ module.exports = generators.Base.extend({
         githubAccount: this.props.githubAccount
       }
     }, {
-      local: require.resolve('../git')
-    });
+        local: require.resolve('../git')
+      });
 
     if (this.options.license && !this.pkg.license) {
       this.composeWith('license', {
@@ -380,8 +380,8 @@ module.exports = generators.Base.extend({
           website: this.props.authorUrl
         }
       }, {
-        local: require.resolve('generator-license/app')
-      });
+          local: require.resolve('generator-license/app')
+        });
     }
 
     if (!this.fs.exists(this.destinationPath('README.md'))) {
@@ -395,8 +395,8 @@ module.exports = generators.Base.extend({
           content: this.options.readme
         }
       }, {
-        local: require.resolve('../readme')
-      });
+          local: require.resolve('../readme')
+        });
     }
 
     if (!this.fs.exists(this.destinationPath('config/default.js'))) {
@@ -408,8 +408,8 @@ module.exports = generators.Base.extend({
           isAutoSsr: this.props.autoSsr
         }
       }, {
-        local: require.resolve('../config')
-      });
+          local: require.resolve('../config')
+        });
     }
 
     if (!this.fs.exists(this.destinationPath('server/plugins/webapp'))) {
@@ -419,15 +419,17 @@ module.exports = generators.Base.extend({
           isAutoSsr: this.props.autoSsr
         }
       }, {
-        local: require.resolve('../webapp')
-      });
+          local: require.resolve('../webapp')
+        });
     }
   },
 
   install: function () {
-    this.installDependencies({
-      bower: false
-    });
+    if (!isExtended) {
+      this.installDependencies({
+        bower: false
+      });
+    }
   },
 
   end: function () {

--- a/packages/generator-electrode/generators/app/index.js
+++ b/packages/generator-electrode/generators/app/index.js
@@ -60,6 +60,9 @@ module.exports = generators.Base.extend({
     if (this.options && this.options.isExtended) {
       this.isExtended = true;
     }
+    if (this.options && this.options.githubUrl) {
+      this.githubUrl = this.options.githubUrl;
+    }
   },
 
   initializing: function () {

--- a/packages/generator-electrode/generators/app/index.js
+++ b/packages/generator-electrode/generators/app/index.js
@@ -14,7 +14,6 @@ var githubUsername = require('github-username');
 const ExpressJS = 'ExpressJS';
 const HapiJS = 'HapiJS';
 const KoaJS = 'KoaJS';
-var isExtended = false;
 
 module.exports = generators.Base.extend({
   constructor: function () {
@@ -57,6 +56,10 @@ module.exports = generators.Base.extend({
       required: false,
       desc: 'Content to insert in the README.md file'
     });
+    //Flag to check if the OSS generator is being called as a subgenerator
+    if (this.options && this.options.isExtended) {
+      this.isExtended = true;
+    }
   },
 
   initializing: function () {
@@ -89,6 +92,9 @@ module.exports = generators.Base.extend({
       this.props.authorName = info.name;
       this.props.authorEmail = info.email;
       this.props.authorUrl = info.url;
+    }
+    if (this.isExtended) {
+      this.props.serverType = HapiJS;
     }
   },
 
@@ -425,7 +431,7 @@ module.exports = generators.Base.extend({
   },
 
   install: function () {
-    if (!isExtended) {
+    if (!this.isExtended) {
       this.installDependencies({
         bower: false
       });

--- a/packages/generator-electrode/generators/app/index.js
+++ b/packages/generator-electrode/generators/app/index.js
@@ -60,6 +60,9 @@ module.exports = generators.Base.extend({
     if (this.options && this.options.isExtended) {
       this.isExtended = true;
     }
+    if (this.options && this.options.serverType) {
+      this.serverType = this.options.serverType;
+    }
     if (this.options && this.options.githubUrl) {
       this.githubUrl = this.options.githubUrl;
     }
@@ -96,8 +99,8 @@ module.exports = generators.Base.extend({
       this.props.authorEmail = info.email;
       this.props.authorUrl = info.url;
     }
-    if (this.isExtended) {
-      this.props.serverType = HapiJS;
+    if (this.serverType) {
+      this.props.serverType = this.serverType || HapiJS;
     }
   },
 

--- a/packages/generator-electrode/generators/config/index.js
+++ b/packages/generator-electrode/generators/config/index.js
@@ -32,17 +32,20 @@ module.exports = generators.Base.extend({
 
   writing: function () {
     let routeMatch = (this.options.serverType === 'HapiJS') ? "/{args*}" : "*";
-    this.fs.copyTpl(
-      this.templatePath('default.js'),
-      this.destinationPath('config/default.js'),
-      {
-        projectName: this.options.name,
-        routeValue: routeMatch,
-        pwa: this.options.pwa,
-        serverType: this.options.serverType,
-        isAutoSsr: this.options.autoSsr
-      }
-    );
+    //do not overwrite if file already exists
+    if (!this.fs.exists(this.destinationPath('config/default.js'))) {
+      this.fs.copyTpl(
+        this.templatePath('default.js'),
+        this.destinationPath('config/default.js'),
+        {
+          projectName: this.options.name,
+          routeValue: routeMatch,
+          pwa: this.options.pwa,
+          serverType: this.options.serverType,
+          isAutoSsr: this.options.autoSsr
+        }
+      );
+    }
 
     if (this.options.pwa) {
       this.fs.copyTpl(

--- a/packages/generator-electrode/generators/git/index.js
+++ b/packages/generator-electrode/generators/git/index.js
@@ -60,10 +60,7 @@ module.exports = generators.Base.extend({
 
     //overwrite with given repo path if present
     if (this.options.githubUrl) {
-      let repoPath = this.options.githubUrl;
-      repoPath += this.options.githubAccount ? '/' + this.options.githubAccount : '';
-      repoPath += '/' + this.options.name;
-      this.pkg.repository.url = repoPath;
+      this.pkg.repository.url = [this.options.githubUrl, this.options.githubAccount, this.options.name].filter((x) => x).join("/");
     }
     this.fs.writeJSON(this.destinationPath('package.json'), this.pkg);
   },

--- a/packages/generator-electrode/generators/git/index.js
+++ b/packages/generator-electrode/generators/git/index.js
@@ -18,9 +18,7 @@ module.exports = generators.Base.extend({
       desc: 'GitHub username or organization'
     });
     // Set a gitHub uRL if being passed
-    if (this.githubUrl) {
-      this.git = this.githubUrl;
-    }
+    this.githubUrl = this.options.githubUrl || "";
   },
 
   initializing: function () {

--- a/packages/generator-electrode/generators/git/index.js
+++ b/packages/generator-electrode/generators/git/index.js
@@ -17,6 +17,10 @@ module.exports = generators.Base.extend({
       required: true,
       desc: 'GitHub username or organization'
     });
+    // Set a gitHub uRL if being passed
+    if (this.githubUrl) {
+      this.git = this.githubUrl;
+    }
   },
 
   initializing: function () {
@@ -54,6 +58,13 @@ module.exports = generators.Base.extend({
       this.pkg.repository.url = repository;
     }
 
+    //overwrite with given repo path if present
+    if (this.options.githubUrl) {
+      let repoPath = this.options.githubUrl;
+      repoPath += this.options.githubAccount ? '/' + this.options.githubAccount : '';
+      repoPath += '/' + this.options.name;
+      this.pkg.repository.url = repoPath;
+    }
     this.fs.writeJSON(this.destinationPath('package.json'), this.pkg);
   },
 
@@ -62,11 +73,16 @@ module.exports = generators.Base.extend({
       cwd: this.destinationPath()
     });
 
-    if (!this.originUrl) {
+    // prioritize given repo URL if present
+    if (this.options.githubUrl) {
+      this.spawnCommandSync('git', ['remote', 'add', 'origin', this.pkg.repository.url], {
+        cwd: this.destinationPath()
+      });
+    } else if (!this.originUrl) {
       var repoSSH = this.pkg.repository;
       var url = this.pkg.repository && this.pkg.repository.url;
       if (url && url.indexOf('.git') === -1) {
-        repoSSH = 'git@github.com:' + this.pkg.repository + '.git';
+        repoSSH = 'git@github.com:' + this.pkg.repository.url + '.git';
       }
       this.spawnCommandSync('git', ['remote', 'add', 'origin', repoSSH], {
         cwd: this.destinationPath()

--- a/packages/generator-electrode/generators/webapp/index.js
+++ b/packages/generator-electrode/generators/webapp/index.js
@@ -34,11 +34,18 @@ module.exports = generators.Base.extend({
         globOptions: {
           ignore: [
             isHapi ? '**/server/plugins/webapp/express-middleware.js' : '**/server/plugins/webapp/hapi-plugin.js',
-            '**/server/plugins/pwa.js'
+            '**/server/plugins/pwa.js', '**/server/views/index-view.js'
           ]
         }
       }
     );
+
+    if (!this.fs.exists(this.destinationPath('src/server/views/index-view.jsx'))) {
+      this.fs.copy(
+        this.templatePath('src/server/views/index-view.js'),
+        this.destinationPath(this.options.generateInto, 'src/server/views/index-view.jsx')
+      );
+    }
 
     if (this.options.pwa) {
       this.fs.copy(


### PR DESCRIPTION
Accepts and checks for parameters for a `gitHubUrl` and a flag `isExtended` and `serverType`.
The generator that is using the electrode-OSS generator can now pass these values to the OSS generator.
The `githubUrl` will override the repo url for `package.json` and the .`git`.
`serverType` with set the props and will hide the prompt asking for the server type. This helps control the kind of server you want to use in your project.
`isExtended` is currently only used to delay the dependency installation and we transfer control back to the calling generator to complete the installation.