### PR TITLE
update license-generator

### DIFF
--- a/packages/generator-electrode/component/index.js
+++ b/packages/generator-electrode/component/index.js
@@ -10,6 +10,8 @@ var parseAuthor = require('parse-author');
 var ReactComponentGenerator = yeoman.Base.extend({
   constructor: function () {
     yeoman.Base.apply(this, arguments);
+    this.quotes = this.options.quotes;
+    this.githubUrl = this.options.githubUrl || "https://github.com";
   },
   initializing: function () {
     this.pkg = this.fs.readJSON(this.destinationPath('package.json'), {});
@@ -26,6 +28,7 @@ var ReactComponentGenerator = yeoman.Base.extend({
       var info = parseAuthor(this.pkg.author);
       this.props.developerName = info.name;
     }
+    this.props.quoteType = this.quotes;
   },
   prompting: {
     greeting: function () {
@@ -77,7 +80,8 @@ var ReactComponentGenerator = yeoman.Base.extend({
         name: "quoteType",
         message: "Use double quotes or single quotes?",
         choices: ["\"", "'"],
-        default: "\""
+        default: "\"",
+        when: !this.props.quoteType
       }, {
         type: "input",
         name: "ghRepo",

--- a/packages/generator-electrode/component/templates/_package.json
+++ b/packages/generator-electrode/component/templates/_package.json
@@ -5,16 +5,16 @@
   "main": "lib/index.js",
   "author": {
     "name": "<%= developerName %>",
-    "url": "https://github.com/<%= ghUser %>"
+    "url": "<%= githubUrl %>/<%= ghUser %>"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/<%= packageGitHubOrg %>/<%= ghRepo %>.git"
+    "url": "<%= githubUrl %>/<%= packageGitHubOrg %>/<%= ghRepo %>.git"
   },
   "bugs": {
-    "url": "https://github.com/<%= packageGitHubOrg %>/<%= ghRepo %>/issues"
+    "url": "<%= githubUrl %>/<%= packageGitHubOrg %>/<%= ghRepo %>/issues"
   },
-  "homepage": "https://github.com/<%= packageGitHubOrg %>/<%= ghRepo %>",
+  "homepage": "<%= githubUrl %>/<%= packageGitHubOrg %>/<%= ghRepo %>",
   "dependencies": {},
   "devDependencies": {
     "electrode-archetype-react-component": "^1.0.0",

--- a/packages/generator-electrode/generators/app/index.js
+++ b/packages/generator-electrode/generators/app/index.js
@@ -388,7 +388,7 @@ module.exports = generators.Base.extend({
           name: this.props.authorName,
           email: this.props.authorEmail,
           website: this.props.authorUrl,
-          license: this.props.license || ''
+          license: this.props.license || ""
         }
       }, {
           local: require.resolve('generator-license/app')

--- a/packages/generator-electrode/generators/app/index.js
+++ b/packages/generator-electrode/generators/app/index.js
@@ -60,6 +60,8 @@ module.exports = generators.Base.extend({
     this.isExtended = this.options.isExtended || false;
     this.serverType = this.options.serverType || HapiJS;
     this.githubUrl = this.options.githubUrl || "";
+    this.license = this.options.license;
+    this.quotes = this.options.quotes;
   },
 
   initializing: function () {
@@ -95,6 +97,8 @@ module.exports = generators.Base.extend({
     }
     this.props.serverType = this.serverType || HapiJS;
     this.props.githubUrl = this.githubUrl;
+    this.props.quoteType = this.quotes;
+    this.props.license = this.license;
   },
 
   prompting: {
@@ -379,12 +383,16 @@ module.exports = generators.Base.extend({
       });
 
     if (this.options.license && !this.pkg.license) {
+      let licenseOptions = {
+        name: this.props.authorName,
+        email: this.props.authorEmail,
+        website: this.props.authorUrl
+      };
+      if (this.props.license) {
+        licenseOptions.license = this.props.license;
+      }
       this.composeWith('license', {
-        options: {
-          name: this.props.authorName,
-          email: this.props.authorEmail,
-          website: this.props.authorUrl
-        }
+        options: licenseOptions
       }, {
           local: require.resolve('generator-license/app')
         });

--- a/packages/generator-electrode/generators/app/index.js
+++ b/packages/generator-electrode/generators/app/index.js
@@ -383,16 +383,13 @@ module.exports = generators.Base.extend({
       });
 
     if (this.options.license && !this.pkg.license) {
-      let licenseOptions = {
-        name: this.props.authorName,
-        email: this.props.authorEmail,
-        website: this.props.authorUrl
-      };
-      if (this.props.license) {
-        licenseOptions.license = this.props.license;
-      }
       this.composeWith('license', {
-        options: licenseOptions
+        options: {
+          name: this.props.authorName,
+          email: this.props.authorEmail,
+          website: this.props.authorUrl,
+          license: this.props.license || ''
+        }
       }, {
           local: require.resolve('generator-license/app')
         });

--- a/packages/generator-electrode/generators/git/index.js
+++ b/packages/generator-electrode/generators/git/index.js
@@ -18,7 +18,7 @@ module.exports = generators.Base.extend({
       desc: 'GitHub username or organization'
     });
     // Set a gitHub uRL if being passed
-    this.githubUrl = this.options.githubUrl || "";
+    this.githubUrl = this.options.githubUrl || "https://github.com";
   },
 
   initializing: function () {

--- a/packages/generator-electrode/package.json
+++ b/packages/generator-electrode/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "chalk": "^1.0.0",
-    "generator-license": "^4.0.0",
+    "generator-license": "^5.0.0",
     "generator-travis": "^1.3.0",
     "git-remote-origin-url": "^2.0.0",
     "github-username": "^2.1.0",


### PR DESCRIPTION
Updating `generator-license` to give us the ability to pass the license type and override the licensing prompt.
-set ability to set default `quoteType` and skip prompting.
Component Generator: 
- skip quotes if passed.
-ability to process custom git Url.