### PR TITLE
Addresses  undefined errors when running gulp check on newly generated components

### DIFF
--- a/packages/electrode-archetype-react-component/config/webpack/partial/coverage.js
+++ b/packages/electrode-archetype-react-component/config/webpack/partial/coverage.js
@@ -1,5 +1,5 @@
 "use strict";
-
+var archDevRequire = require("electrode-archetype-react-component-dev/require");
 var ispartaLoader = archDevRequire.resolve("isparta-loader");
 
 module.exports = function() {

--- a/packages/electrode-archetype-react-component/config/webpack/webpack.config.coverage.js
+++ b/packages/electrode-archetype-react-component/config/webpack/webpack.config.coverage.js
@@ -10,9 +10,10 @@ var baseProfile = require("./profile.base");
 var testBaseProfile = require("./profile.base.test");
 
 var generateConfig = require("./util/generate-config");
+var Path = require("path");
 
 function makeConfig() {
-  const browserCoverageProfile = {
+  const coverageProfile = {
     partials: {
       "_coverage": {
         order: 10100


### PR DESCRIPTION
Addresses #286 by declaring previously undeclared variables in component archetype