### PR TITLE
Add environment variable for webpack dev HTTPS

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
@@ -5,13 +5,16 @@ const webpack = require("webpack");
 const archetype = require("electrode-archetype-react-app/config/archetype");
 const webpackDevReporter = require("../util/webpack-dev-reporter");
 
+const devProtocol = process.env.WEBPACK_DEV_HTTPS ? "https://" : "http://";
+
 module.exports = function () {
   const config = {
     devServer: {
-      reporter: webpackDevReporter
+      reporter: webpackDevReporter,
+      https: Boolean(process.env.WEBPACK_DEV_HTTPS)
     },
     output: {
-      publicPath: `http://${archetype.webpack.devHostname}:${archetype.webpack.devPort}/js/`,
+      publicPath: `${devProtocol}://${archetype.webpack.devHostname}:${archetype.webpack.devPort}/js/`,
       filename: "[name].bundle.dev.js"
     },
     plugins: [

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
@@ -14,7 +14,7 @@ module.exports = function () {
       https: Boolean(process.env.WEBPACK_DEV_HTTPS)
     },
     output: {
-      publicPath: `${devProtocol}://${archetype.webpack.devHostname}:${archetype.webpack.devPort}/js/`,
+      publicPath: `${devProtocol}${archetype.webpack.devHostname}:${archetype.webpack.devPort}/js/`,
       filename: "[name].bundle.dev.js"
     },
     plugins: [

--- a/packages/electrode-react-webapp/lib/react-webapp.js
+++ b/packages/electrode-react-webapp/lib/react-webapp.js
@@ -256,7 +256,7 @@ const setupOptions = (options) => {
   const pluginOptions = _.defaultsDeep({}, options, pluginOptionsDefaults);
   const chunkSelector = resolveChunkSelector(pluginOptions);
   const devProtocol = process.env.WEBPACK_DEV_HTTPS ? "https://" : "http://";
-  const devBundleBase = `${devProtocol}://${pluginOptions.devServer.host}:${pluginOptions.devServer.port}/js/`;
+  const devBundleBase = `${devProtocol}${pluginOptions.devServer.host}:${pluginOptions.devServer.port}/js/`; // eslint-disable-line max-len
   const statsPath = getStatsPath(pluginOptions.stats, pluginOptions.buildArtifacts);
 
   return Promise.try(() => loadAssetsFromStats(statsPath))

--- a/packages/electrode-react-webapp/lib/react-webapp.js
+++ b/packages/electrode-react-webapp/lib/react-webapp.js
@@ -243,7 +243,8 @@ const setupOptions = (options) => {
     htmlFile: Path.join(__dirname, "index.html"),
     devServer: {
       host: process.env.WEBPACK_HOST || "127.0.0.1",
-      port: process.env.WEBPACK_DEV_PORT || "2992"
+      port: process.env.WEBPACK_DEV_PORT || "2992",
+      https: Boolean(process.env.WEBPACK_DEV_HTTPS)
     },
     paths: {},
     stats: "dist/server/stats.json",
@@ -254,7 +255,8 @@ const setupOptions = (options) => {
 
   const pluginOptions = _.defaultsDeep({}, options, pluginOptionsDefaults);
   const chunkSelector = resolveChunkSelector(pluginOptions);
-  const devBundleBase = `http://${pluginOptions.devServer.host}:${pluginOptions.devServer.port}/js/`;
+  const devProtocol = process.env.WEBPACK_DEV_HTTPS ? "https://" : "http://";
+  const devBundleBase = `${devProtocol}://${pluginOptions.devServer.host}:${pluginOptions.devServer.port}/js/`;
   const statsPath = getStatsPath(pluginOptions.stats, pluginOptions.buildArtifacts);
 
   return Promise.try(() => loadAssetsFromStats(statsPath))


### PR DESCRIPTION
In our development environment we need to run the webpack asset server with HTTPS.

Would you be open to accepting a pull request to allow this to be configured in Electrode?

Run in https mode like this:

```sh
WEBPACK_DEV_HTTPS=true npm start
```

or add to your `package.json`:

```json
{
  "scripts": {
    "start": "if test \"$NODE_ENV\" = \"production\"; then npm run prod; else WEBPACK_DEV_HTTPS=true gulp dev; fi"
  }
}
```

cc @FreaKzero