### PR TITLE
Fix Windows coverage errors and Windows Sinon error

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/test-base.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/test-base.js
@@ -1,5 +1,9 @@
 "use strict";
 
+const sinonRegex = process.platform === "win32" ?
+  /node_modules\\sinon\\/ :
+  /node_modules\/sinon\//;
+
 module.exports = {
   module: {
     /*
@@ -10,7 +14,7 @@ module.exports = {
      * https://github.com/sinonjs/sinon/pull/600#issuecomment-162529457
      */
     noParse: [
-      /node_modules\/sinon\//
+      sinonRegex
     ]
   },
   devServer: {

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/test-base.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/test-base.js
@@ -1,8 +1,6 @@
 "use strict";
 
-const sinonRegex = process.platform === "win32" ?
-  /node_modules\\sinon\\/ :
-  /node_modules\/sinon\//;
+const Path = require("path");
 
 module.exports = {
   module: {
@@ -14,7 +12,7 @@ module.exports = {
      * https://github.com/sinonjs/sinon/pull/600#issuecomment-162529457
      */
     noParse: [
-      sinonRegex
+      new RegExp(Path.normalize("node_modules/sinon/").replace(/\\/g, "\\\\"))
     ]
   },
   devServer: {

--- a/packages/electrode-archetype-react-app/arch-gulpfile.js
+++ b/packages/electrode-archetype-react-app/arch-gulpfile.js
@@ -562,7 +562,7 @@ Individual .babelrc files were generated for you in src/client and src/server
     "test-server-cov": () => {
       if (shell.test("-d", "test/server")) {
         AppMode.setEnv(AppMode.src.dir);
-        return exec(`istanbul cover _mocha`,
+        return exec(`istanbul cover node_modules/mocha/bin/_mocha`,
           `-- -c --opts ${config.mocha}/mocha.opts test/server`);
       }
       return undefined;


### PR DESCRIPTION
**Tested on Windows 10 and Mac OS10.12.4**

**Context**
Cannot run `npm test` on Electrode apps on Windows devices without these to errors:
1. #92 Istanbul coverage failing on windows
2. #80 Was applied to the component archetype but not the app archetype

**Fixes**
1. Fix windows coverage errors #92 with solution https://github.com/gotwarlost/istanbul/issues/90
2. Determine regex value based on whether the device platform is Windows. (#82)

**I would really like to apply this fix to the newest 1.x version because we are currently using 1.10.0 in production and can't run our tests on any Windows devices.  We can't update to 2.x yet because there are quite a few known bugs.  Should 1.* updates be made to the webpack-1.0 branch?*