### PR TITLE
Use socketPort from defaults

### DIFF
--- a/packages/electrode-webpack-reporter/lib/webpack-reporter.js
+++ b/packages/electrode-webpack-reporter/lib/webpack-reporter.js
@@ -40,7 +40,7 @@ class WebpackReporter extends EventEmitter {
       this._reporterHtml = fs.readFileSync(Path.resolve(Path.join(__dirname, "reporter.html"))).toString()
         .replace("{{CSS}}", removeCwd(distCss))
         .replace("{{JS}}", removeCwd(distJs))
-        .replace(/{{SOCKET_PORT}}/g, options.socketPort)
+        .replace(/{{SOCKET_PORT}}/g, this.options.socketPort)
     } else if (!options.skipReportRoutes) {
       throw new Error("webpack-reporter unable to setup routes - check dist has server/stat.json or run build");
     }


### PR DESCRIPTION
It looks like this was a recent unintentional omission.  Without this fix `gulp dev` on a freshly created app is giving me:
```
  [ 'TypeError: Cannot read property \'socketPort\' of undefined',
     '    at new WebpackReporter (/Users/johnmclaughlin/git/rcel/node_modules/electrode-webpack-reporter/lib/webpack-reporter.js:44:45)',
     '    at module.exports.options (/Users/johnmclaughlin/git/rcel/node_modules/electrode-archetype-react-app-dev/config/webpack/partial/html-reporter.js:8:22)',
     '    at /Users/johnmclaughlin/git/rcel/node_modules/webpack-config-composer/lib/index.js:105:17',
     '    at Array.forEach (native)',
     '    at WebpackConfigComposer.compose (/Users/johnmclaughlin/git/rcel/node_modules/webpack-config-composer/lib/index.js:94:16)',
     '    at compose (/Users/johnmclaughlin/git/rcel/node_modules/electrode-archetype-react-app-dev/config/webpack/util/generate-config.js:19:34)',
     '    at generateConfig (/Users/johnmclaughlin/git/rcel/node_modules/electrode-archetype-react-app-dev/config/webpack/util/generate-config.js:30:14)',
     '    at makeConfig (/Users/johnmclaughlin/git/rcel/node_modules/electrode-archetype-react-app-dev/config/webpack/webpack.config.dev.js:27:10)',
     '    at Object.<anonymous> (/Users/johnmclaughlin/git/rcel/node_modules/electrode-archetype-react-app-dev/config/webpack/webpack.config.dev.js:30:18)',
     '    at Module._compile (module.js:409:26)' ] }