### PR TITLE
generator-electrode: [bug][patch] Accept props as options

### DIFF
--- a/packages/generator-electrode/component-add/index.js
+++ b/packages/generator-electrode/component-add/index.js
@@ -68,7 +68,7 @@ module.exports = generators.Base.extend({
 
     // check for missing
     checkError();
-    this.props = {};
+    this.props = this.options.props || {};
   },
 
   prompting: {
@@ -112,7 +112,8 @@ module.exports = generators.Base.extend({
       isAddon: true,
       name: this.packageName,
       componentName: this.componentName,
-      demoAppName: this.demoAppName
+      demoAppName: this.demoAppName,
+      quotes: this.props.quotes
     };
     this.composeWith('electrode:component', { options }, {
       local: require.resolve('../component')


### PR DESCRIPTION
The `component-add` generator can accept and initialize props if they are passed to it.