### PR TITLE
archetype-react-app: [minor][bug] Invalid host header fixes

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/archetype.js
+++ b/packages/electrode-archetype-react-app-dev/config/archetype.js
@@ -16,10 +16,10 @@ module.exports = {
   devPkg,
   devRequire,
   webpack: Object.assign({}, {
-    devHostname: process.env.WEBPACK_DEV_HOST || "localhost",
+    devHostname: process.env.WEBPACK_HOST || "localhost",
     devPort: utils.getInt(process.env.WEBPACK_DEV_PORT, 2992),
     testPort: utils.getInt(process.env.WEBPACK_TEST_PORT, 3001),
-    devProtocol: process.env.WEBPACK_DEV_HTTPS,
+    https: process.env.WEBPACK_DEV_HTTPS,
     modulesDirectories: [],
     enableBabelPolyfill: false
   }, archetypeOptions.webpack),

--- a/packages/electrode-archetype-react-app-dev/config/archetype.js
+++ b/packages/electrode-archetype-react-app-dev/config/archetype.js
@@ -16,7 +16,7 @@ module.exports = {
   devPkg,
   devRequire,
   webpack: Object.assign({}, {
-    devHostname: process.env.WEBPACK_HOST || "localhost",
+    devHostname: process.env.WEBPACK_HOST || process.env.WEBPACK_DEV_HOST || "localhost",
     devPort: utils.getInt(process.env.WEBPACK_DEV_PORT, 2992),
     testPort: utils.getInt(process.env.WEBPACK_TEST_PORT, 3001),
     https: process.env.WEBPACK_DEV_HTTPS,

--- a/packages/electrode-archetype-react-app-dev/config/archetype.js
+++ b/packages/electrode-archetype-react-app-dev/config/archetype.js
@@ -16,9 +16,10 @@ module.exports = {
   devPkg,
   devRequire,
   webpack: Object.assign({}, {
-    devHostname: process.env.WEBPACK_HOST || "localhost",
+    devHostname: process.env.WEBPACK_DEV_HOST || "localhost",
     devPort: utils.getInt(process.env.WEBPACK_DEV_PORT, 2992),
     testPort: utils.getInt(process.env.WEBPACK_TEST_PORT, 3001),
+    devProtocol: process.env.WEBPACK_DEV_HTTPS,
     modulesDirectories: [],
     enableBabelPolyfill: false
   }, archetypeOptions.webpack),

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
@@ -12,7 +12,7 @@ module.exports = function () {
     reporter: webpackDevReporter,
     https: Boolean(process.env.WEBPACK_DEV_HTTPS)
   };
-  
+
   if (process.env.WEBPACK_HOST) {
     devServerConfig.host = process.env.WEBPACK_HOST;
     devServerConfig.headers = {

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
@@ -8,7 +8,7 @@ const webpackDevReporter = require("../util/webpack-dev-reporter");
 const devProtocol = process.env.WEBPACK_DEV_HTTPS ? "https://" : "http://";
 
 module.exports = function () {
-  const devServerConfig = {
+  let devServerConfig = {
     reporter: webpackDevReporter,
     https: Boolean(process.env.WEBPACK_DEV_HTTPS)
   };

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
@@ -5,17 +5,18 @@ const webpack = require("webpack");
 const archetype = require("electrode-archetype-react-app/config/archetype");
 const webpackDevReporter = require("../util/webpack-dev-reporter");
 
-const devProtocol = process.env.WEBPACK_DEV_HTTPS ? "https://" : "http://";
+const devProtocol = archetype.webpack.devProtocol ? "https://" : "http://";
 
 module.exports = function () {
-  let devServerConfig = {
+  const devServerConfig = {
     reporter: webpackDevReporter,
-    https: Boolean(process.env.WEBPACK_DEV_HTTPS)
+    https: Boolean(archetype.webpack.devProtocol)
   };
-  if (process.env.WEBPACK_HOST) {
-    devServerConfig.host = process.env.WEBPACK_HOST;
+
+  if (process.env.WEBPACK_DEV_HOST) {
+    devServerConfig.public = `${archetype.webpack.devHostname}:${archetype.webpack.devPort}`;
     devServerConfig.headers = {
-      "Access-Control-Allow-Origin": `${devProtocol}${process.env.WEBPACK_HOST}`
+      "Access-Control-Allow-Origin": `${devProtocol}${archetype.webpack.devHostname}:${archetype.webpack.devPort}`
     };
   } else {
     devServerConfig.disableHostCheck = true;

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
@@ -8,11 +8,25 @@ const webpackDevReporter = require("../util/webpack-dev-reporter");
 const devProtocol = process.env.WEBPACK_DEV_HTTPS ? "https://" : "http://";
 
 module.exports = function () {
+  const devServerConfig = {
+    reporter: webpackDevReporter,
+    https: Boolean(process.env.WEBPACK_DEV_HTTPS)
+  };
+  
+  if (process.env.WEBPACK_HOST) {
+    devServerConfig.host = process.env.WEBPACK_HOST;
+    devServerConfig.headers = {
+      "Access-Control-Allow-Origin": `${devProtocol}${process.env.WEBPACK_HOST}`
+    };
+  } else {
+    devServerConfig.disableHostCheck = true;
+    devServerConfig.headers = {
+      "Access-Control-Allow-Origin": "*"
+    };
+  }
+
   const config = {
-    devServer: {
-      reporter: webpackDevReporter,
-      https: Boolean(process.env.WEBPACK_DEV_HTTPS)
-    },
+    devServer: devServerConfig,
     output: {
       publicPath: `${devProtocol}${archetype.webpack.devHostname}:${archetype.webpack.devPort}/js/`,
       filename: "[name].bundle.dev.js"

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
@@ -5,12 +5,12 @@ const webpack = require("webpack");
 const archetype = require("electrode-archetype-react-app/config/archetype");
 const webpackDevReporter = require("../util/webpack-dev-reporter");
 
-const devProtocol = archetype.webpack.devProtocol ? "https://" : "http://";
+const devProtocol = archetype.webpack.https ? "https://" : "http://";
 
 module.exports = function () {
   const devServerConfig = {
     reporter: webpackDevReporter,
-    https: Boolean(archetype.webpack.devProtocol)
+    https: Boolean(archetype.webpack.https)
   };
 
   if (process.env.WEBPACK_DEV_HOST) {

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
@@ -12,7 +12,6 @@ module.exports = function () {
     reporter: webpackDevReporter,
     https: Boolean(process.env.WEBPACK_DEV_HTTPS)
   };
-
   if (process.env.WEBPACK_HOST) {
     devServerConfig.host = process.env.WEBPACK_HOST;
     devServerConfig.headers = {

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
@@ -13,7 +13,7 @@ module.exports = function () {
     https: Boolean(archetype.webpack.https)
   };
 
-  if (process.env.WEBPACK_DEV_HOST) {
+  if (process.env.WEBPACK_DEV_HOST || process.env.WEBPACK_HOST) {
     devServerConfig.public = `${archetype.webpack.devHostname}:${archetype.webpack.devPort}`;
     devServerConfig.headers = {
       "Access-Control-Allow-Origin": `${devProtocol}${archetype.webpack.devHostname}:${archetype.webpack.devPort}`


### PR DESCRIPTION
A security fix for an insecure configuration for oss app archetype.
Error info: invalid host header.
Fixes: 
Specify Host header to the webpack-dev-server if it exists. Otherwise disable host check.

Demo:
![screen shot 2017-05-15 at 4 31 45 pm](https://cloud.githubusercontent.com/assets/10135897/26083676/06ae2cfc-398c-11e7-8adc-2aa474e897bf.png)

Root cause:
https://github.com/webpack/webpack-dev-server/releases/tag/v2.4.3
https://github.com/webpack/webpack-dev-middleware/releases/tag/v1.10.2