### PR TITLE
[gitbook][patch] display iframe url in address bar

### DIFF
--- a/book.json
+++ b/book.json
@@ -3,7 +3,7 @@
   "gitbook": "3.2.2",
   "title": "Electrode Developer's Guide",
   "description": "Electrode Platform Developer's Guide",
-  "plugins": ["edit-link", "prism", "-highlight", "github", "anchorjs"],
+  "plugins": ["edit-link", "prism", "-highlight", "github", "anchorjs", "add-path-to-parent"],
   "pluginsConfig": {
     "edit-link": {
       "base": "https://github.com/electrode-io/electrode/tree/master/docs",


### PR DESCRIPTION
Plugin: https://plugins.gitbook.com/plugin/add-path-to-parent
Resolve the issue for gitbook iframe url in address bar