### PR TITLE
generator-electrode: [docs] [patch] fix typo

### DIFF
--- a/packages/generator-electrode/README.md
+++ b/packages/generator-electrode/README.md
@@ -139,7 +139,7 @@ test-component/
 ### Adding Components to the Repo
 
 The component structure shown above supports multiple packages under the `packages` folder.
-You can add another component to your project by running `yo electrode:component-add` from withing the `packages` directory.
+You can add another component to your project by running `yo electrode:component-add` from within the `packages` directory.
 
 ```
 $ cd packages


### PR DESCRIPTION
Fixing `withing` to `within` typo in README.