### PR TITLE
generator-electrode: [feat] [minor] add Prettier config to generators

### DIFF
--- a/packages/generator-electrode/component/index.js
+++ b/packages/generator-electrode/component/index.js
@@ -147,6 +147,7 @@ var ReactComponentGenerator = yeoman.Base.extend({
       if (this.quoteType === "'") {
         this.template("packages/component/eslintrc", this.rootPath + ".eslintrc");
       }
+      this.template("packages/component/lintstagedrc", this.rootPath + ".lintstagedrc");
       this.template("packages/component/_gulpfile.js", this.rootPath + "gulpfile.js");
       this.template("packages/component/_package.json", this.rootPath + "package.json");
       this.template("packages/component/_readme.md", this.rootPath + "README.md");

--- a/packages/generator-electrode/component/templates/packages/component/_package.json
+++ b/packages/generator-electrode/component/templates/packages/component/_package.json
@@ -28,7 +28,9 @@
   "scripts": {
     "prepublish": "gulp prepublish",
     "start": "gulp demo",
-    "test": "gulp check"
+    "test": "gulp check",
+    "format": "prettier<% if (quoteType === "'") { %> --single-quote<% } %> --write \"{demo-app,packages}/**/*.{js,jsx}\"",
+    "precommit": "lint-staged"
   },
   "keywords": [
     "react",

--- a/packages/generator-electrode/component/templates/packages/component/lintstagedrc
+++ b/packages/generator-electrode/component/templates/packages/component/lintstagedrc
@@ -1,0 +1,6 @@
+{
+  "{demo-app,packages}/**/*.{js,jsx}": [
+    "prettier<% if (quoteType === "'") { %> --single-quote <% } %> --write",
+    "git add"
+  ]
+}

--- a/packages/generator-electrode/generators/app/index.js
+++ b/packages/generator-electrode/generators/app/index.js
@@ -272,7 +272,7 @@ module.exports = generators.Base.extend({
     this.fs.copyTpl(
       this.templatePath(_pkg),
       this.destinationPath(_pkg),
-      { isHapi, isExpress, isPWA, isAutoSSR }
+      { isHapi, isExpress, isPWA, isAutoSSR, isSingleQuote }
     );
 
     var defaultPkg = this.fs.readJSON(this.destinationPath(_pkg));
@@ -326,7 +326,7 @@ module.exports = generators.Base.extend({
     // Let's extend package.json so we're not overwriting user previous fields
     this.fs.writeJSON(this.destinationPath('package.json'), pkg);
 
-    const rootConfigsToCopy = ['gulpfile.js', 'config', 'test'];
+    const rootConfigsToCopy = ['gulpfile.js', 'config', 'test', '.lintstagedrc'];
     if (isSingleQuote) rootConfigsToCopy.push('.eslintrc');
     rootConfigsToCopy.forEach((f) => {
       this.fs.copyTpl(

--- a/packages/generator-electrode/generators/app/templates/.lintstagedrc
+++ b/packages/generator-electrode/generators/app/templates/.lintstagedrc
@@ -1,0 +1,6 @@
+{
+  "{archetype,config,src,test}/**/*.{js,jsx}": [
+    "prettier<% if (isSingleQuote) { %> --single-quote <% } %> --write",
+    "git add"
+  ]
+}

--- a/packages/generator-electrode/generators/app/templates/_package.json
+++ b/packages/generator-electrode/generators/app/templates/_package.json
@@ -24,7 +24,9 @@
     "test": "gulp check",
     "coverage": "gulp check",
     "prod": "echo 'Starting standalone server in PROD mode'; NODE_ENV=production node ./lib/server/",
-    "heroku-postbuild": "gulp build"
+    "heroku-postbuild": "gulp build",
+    "format": "prettier<% if (isSingleQuote) { %> --single-quote<% } %> --write \"{archetype,config,src,test}/**/*.{js,jsx}\"",
+    "precommit": "lint-staged"
   },
   "dependencies": {
     "bluebird": "^3.4.6",

--- a/packages/generator-electrode/test/app.js
+++ b/packages/generator-electrode/test/app.js
@@ -53,6 +53,7 @@ describe('electrode:app', function () {
         '.editorconfig',
         '.gitignore',
         '.gitattributes',
+        '.lintstagedrc',
         'README.md'
       ]);
     });


### PR DESCRIPTION
This PR adds Prettier to the following generator configs:
* `yo electrode`
* `yo electrode:component`

Part of the following PRs that add automatic code formatting via [Prettier](https://github.com/prettier/prettier):
* https://github.com/electrode-io/electrode/pull/349
* https://github.com/electrode-io/electrode/pull/350
* https://github.com/electrode-io/electrode/pull/351
* https://github.com/electrode-io/electrode/pull/352

After generating an Electrode application or component, the following features will be enabled:
* `npm run format`: Formats all `.js` and `.jsx` files in the application/component using Prettier
* precommit hook: All `.js` and `.jsx` files will automatically be formatted via Prettier upon commit via [husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/okonet/lint-staged). (See [Prettier docs](https://github.com/prettier/prettier#pre-commit-hook-for-changed-files) for description of how this works.)

Prettier formatting uses all defaults, except for `--single-quote`, which inherits from the quote type in the yeoman prompts.

The following generator commands have been updated to include these changes:
* `yo electrode`
* `yo electrode:component`
* `yo electrode-component`

cc/ @jchip 