### PR TITLE
generator-electrode-component: [feat] [minor] add Prettier config to generator

### DIFF
--- a/packages/generator-electrode-component/app/index.js
+++ b/packages/generator-electrode-component/app/index.js
@@ -119,6 +119,7 @@ var ReactComponentGenerator = yeoman.generators.Base.extend({
       if (this.quoteType === "'") {
         this.template("eslintrc", ".eslintrc");
       }
+      this.template("lintstagedrc", ".lintstagedrc");
       this.template("_gulpfile.js", "gulpfile.js");
       this.template("_package.json", "package.json");
       this.template("_readme.md", "README.md");

--- a/packages/generator-electrode-component/app/templates/_package.json
+++ b/packages/generator-electrode-component/app/templates/_package.json
@@ -28,7 +28,9 @@
   "scripts": {
     "prepublish": "gulp prepublish",
     "start": "gulp demo",
-    "test": "gulp check"
+    "test": "gulp check",
+    "format": "prettier<% if (quoteType === "'") { %> --single-quote<% } %> --write \"{archetype,demo,src,test}/**/*.{js,jsx}\"",
+    "precommit": "lint-staged"
   },
   "keywords": [
     "react",

--- a/packages/generator-electrode-component/app/templates/lintstagedrc
+++ b/packages/generator-electrode-component/app/templates/lintstagedrc
@@ -1,0 +1,6 @@
+{
+  "{archetype,demo,src,test}/**/*.{js,jsx}": [
+    "prettier<% if (isSingleQuote) { %> --single-quote <% } %> --write",
+    "git add"
+  ]
+}

--- a/packages/generator-electrode-component/app/templates/lintstagedrc
+++ b/packages/generator-electrode-component/app/templates/lintstagedrc
@@ -1,6 +1,6 @@
 {
   "{archetype,demo,src,test}/**/*.{js,jsx}": [
-    "prettier<% if (isSingleQuote) { %> --single-quote <% } %> --write",
+    "prettier<% if (quoteType === "'") { %> --single-quote <% } %> --write",
     "git add"
   ]
 }

--- a/packages/generator-electrode-component/test/test-app.js
+++ b/packages/generator-electrode-component/test/test-app.js
@@ -23,7 +23,8 @@ describe("electrode::generator-electrode-component", function () {
   it("creates files", function (done) {
     assert.file([
       "package.json",
-      "gulpfile.js"
+      "gulpfile.js",
+      ".lintstagedrc"
     ]);
     done();
   });


### PR DESCRIPTION
This PR adds Prettier to the following generator configs:
* `yo electrode-component`

Part of the following PRs that add automatic code formatting via [Prettier](https://github.com/prettier/prettier):
* https://github.com/electrode-io/electrode/pull/349
* https://github.com/electrode-io/electrode/pull/350
* https://github.com/electrode-io/electrode/pull/351
* https://github.com/electrode-io/electrode/pull/352

After generating an Electrode application or component, the following features will be enabled:
* `npm run format`: Formats all `.js` and `.jsx` files in the application/component using Prettier
* precommit hook: All `.js` and `.jsx` files will automatically be formatted via Prettier upon commit via [husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/okonet/lint-staged). (See [Prettier docs](https://github.com/prettier/prettier#pre-commit-hook-for-changed-files) for description of how this works.)

Prettier formatting uses all defaults, except for `--single-quote`, which inherits from the quote type in the yeoman prompts.

The following generator commands have been updated to include these changes:
* `yo electrode`
* `yo electrode:component`
* `yo electrode-component`

cc/ @jchip 