### PR TITLE
Use optional-require to safely read config.js in styles partial

### DIFF
--- a/packages/electrode-archetype-react-component/config/webpack/partial/styles.js
+++ b/packages/electrode-archetype-react-component/config/webpack/partial/styles.js
@@ -3,6 +3,7 @@
 const Path = require("path");
 const glob = require("glob");
 
+const optionalRequire = require("optional-require")(require);
 const archDevRequire = require("electrode-archetype-react-component-dev/require");
 const mergeWebpackConfig = archDevRequire("webpack-partial").default;
 const atImport = archDevRequire("postcss-import");
@@ -13,7 +14,7 @@ const postcssLoader = archDevRequire.resolve("postcss-loader");
 const stylusLoader = archDevRequire.resolve("stylus-relative-loader");
 
 const configPath = Path.resolve("archetype", "config.js");
-const config = require(configPath);
+const config = optionalRequire(configPath, {default: {}});
 const cssModuleStylusSupport = config.cssModuleStylusSupport;
 
 /**

--- a/packages/electrode-archetype-react-component/config/webpack/partial/styles.js
+++ b/packages/electrode-archetype-react-component/config/webpack/partial/styles.js
@@ -15,7 +15,7 @@ const stylusLoader = archDevRequire.resolve("stylus-relative-loader");
 
 const configPath = Path.resolve("archetype", "config.js");
 const config = optionalRequire(configPath, {default: {}});
-const cssModuleStylusSupport = config.cssModuleStylusSupport;
+const cssModuleStylusSupport = !!config.cssModuleStylusSupport;
 
 /**
  * [cssModuleSupport By default, this archetype assumes you are using CSS-Modules + CSS-Next]


### PR DESCRIPTION
This fixes an issue where components without config files were failing to build.

cc @jchip a patch release with this would be great