### PR TITLE
react-web-app: [feat] [minor] Allow an external base URL for resources on production runs (#359)

### DIFF
--- a/packages/electrode-react-webapp/README.md
+++ b/packages/electrode-react-webapp/README.md
@@ -96,6 +96,7 @@ What you can do with the options:
    * `devServer` `(Object)` Options for webpack's DevServer
        - `host` `(String)` The host that webpack-dev-server runs on
        - `port` `(String)` The port that webpack-dev-server runs on
+   * `prodBundleBase` `(String)` Base path to locate the JavaScript, CSS and manifest bundles. Defaults to "/js/". Should end with "/".
 
 ### Content details
 

--- a/packages/electrode-react-webapp/lib/react-webapp.js
+++ b/packages/electrode-react-webapp/lib/react-webapp.js
@@ -152,14 +152,14 @@ function makeRouteHandler(routeOptions, userContent) {
     );
 
     const bundleCss = () => {
-      return WEBPACK_DEV ? devCSSBundle : cssChunk && `${prodBundleBase}/js/${cssChunk.name}` || "";
+      return WEBPACK_DEV ? devCSSBundle : cssChunk && `${prodBundleBase}${cssChunk.name}` || "";
     };
 
     const bundleJs = () => {
       if (!renderJs) {
         return "";
       }
-      return WEBPACK_DEV ? devJSBundle : jsChunk && `${prodBundleBase}/js/${jsChunk.name}` || "";
+      return WEBPACK_DEV ? devJSBundle : jsChunk && `${prodBundleBase}${jsChunk.name}` || "";
     };
 
     const bundleManifest = () => {
@@ -168,7 +168,7 @@ function makeRouteHandler(routeOptions, userContent) {
       }
 
       return WEBPACK_DEV ? `${devBundleBase}${assets.manifest}` :
-        `${prodBundleBase}/js/${assets.manifest}`;
+        `${prodBundleBase}${assets.manifest}`;
     };
 
     const callUserContent = (content) => {
@@ -271,7 +271,7 @@ const setupOptions = (options) => {
     iconStats: "dist/server/iconstats.json",
     criticalCSS: "dist/js/critical.css",
     buildArtifacts: ".build",
-    prodBundleBase: ""
+    prodBundleBase: "/js/"
   };
 
   const pluginOptions = _.defaultsDeep({}, options, pluginOptionsDefaults);

--- a/packages/electrode-react-webapp/lib/react-webapp.js
+++ b/packages/electrode-react-webapp/lib/react-webapp.js
@@ -116,6 +116,7 @@ function makeRouteHandler(routeOptions, userContent) {
   const html = fs.readFileSync(routeOptions.htmlFile).toString();
   const assets = routeOptions.__internals.assets;
   const devBundleBase = routeOptions.__internals.devBundleBase;
+  const prodBundleBase = routeOptions.prodBundleBase;
   const chunkSelector = routeOptions.__internals.chunkSelector;
   const iconStats = getIconStats(routeOptions.iconStats);
   const criticalCSS = getCriticalCSS(routeOptions.criticalCSS);
@@ -151,14 +152,14 @@ function makeRouteHandler(routeOptions, userContent) {
     );
 
     const bundleCss = () => {
-      return WEBPACK_DEV ? devCSSBundle : cssChunk && `/js/${cssChunk.name}` || "";
+      return WEBPACK_DEV ? devCSSBundle : cssChunk && `${prodBundleBase}/js/${cssChunk.name}` || "";
     };
 
     const bundleJs = () => {
       if (!renderJs) {
         return "";
       }
-      return WEBPACK_DEV ? devJSBundle : jsChunk && `/js/${jsChunk.name}` || "";
+      return WEBPACK_DEV ? devJSBundle : jsChunk && `${prodBundleBase}/js/${jsChunk.name}` || "";
     };
 
     const bundleManifest = () => {
@@ -166,7 +167,8 @@ function makeRouteHandler(routeOptions, userContent) {
         return "";
       }
 
-      return WEBPACK_DEV ? `${devBundleBase}${assets.manifest}` : `/js/${assets.manifest}`;
+      return WEBPACK_DEV ? `${devBundleBase}${assets.manifest}` :
+        `${prodBundleBase}/js/${assets.manifest}`;
     };
 
     const callUserContent = (content) => {
@@ -268,7 +270,8 @@ const setupOptions = (options) => {
     stats: "dist/server/stats.json",
     iconStats: "dist/server/iconstats.json",
     criticalCSS: "dist/js/critical.css",
-    buildArtifacts: ".build"
+    buildArtifacts: ".build",
+    prodBundleBase: ""
   };
 
   const pluginOptions = _.defaultsDeep({}, options, pluginOptionsDefaults);

--- a/packages/electrode-react-webapp/test/data/stats-test-one-bundle.json
+++ b/packages/electrode-react-webapp/test/data/stats-test-one-bundle.json
@@ -1,0 +1,27 @@
+{
+  "assetsByChunkName": {
+    "bundle": [
+      "bundle.f07a873ce87fc904a6a5.js",
+      "style.f07a873ce87fc904a6a5.css"
+    ]
+  },
+  "assets": [{
+     "name": "style.f07a873ce87fc904a6a5.css",
+      "size": 888,
+      "chunks": [
+        0
+      ],
+      "chunkNames": [
+        "main"
+      ]
+  }, {
+    "name": "bundle.f07a873ce87fc904a6a5.js",
+    "size": 888,
+    "chunks": [
+      0
+    ],
+    "chunkNames": [
+      "main"
+    ]
+  }]
+}

--- a/packages/electrode-react-webapp/test/spec/index.spec.js
+++ b/packages/electrode-react-webapp/test/spec/index.spec.js
@@ -162,7 +162,7 @@ describe("Test electrode-react-webapp", () => {
   });
 
   it("should handle multiple entry points with a prodBundleBase", () => {
-    configOptions.prodBundleBase = "http://awesome-cdn.com/multi";
+    configOptions.prodBundleBase = "http://awesome-cdn.com/multi/";
     configOptions.bundleChunkSelector = "test/data/chunk-selector.js";
     configOptions.stats = "test/data/stats-test-multibundle.json";
 
@@ -173,8 +173,8 @@ describe("Test electrode-react-webapp", () => {
           url: "/bar"
         }).then((res) => {
           expect(res.statusCode).to.equal(200);
-          expect(res.result).to.contain("<script src=\"http://awesome-cdn.com/multi/js/bar.bundle.f07a873ce87fc904a6a5.js\"");
-          expect(res.result).to.contain("<link rel=\"stylesheet\" href=\"http://awesome-cdn.com/multi/js/bar.style.f07a873ce87fc904a6a5.css\"");
+          expect(res.result).to.contain("<script src=\"http://awesome-cdn.com/multi/bar.bundle.f07a873ce87fc904a6a5.js\"");
+          expect(res.result).to.contain("<link rel=\"stylesheet\" href=\"http://awesome-cdn.com/multi/bar.style.f07a873ce87fc904a6a5.css\"");
           stopServer(server);
         })
         .catch((err) => {
@@ -250,7 +250,7 @@ describe("Test electrode-react-webapp", () => {
   });
 
   it("should inject a pwa manfiest with a prodBundleBase", () => {
-    configOptions.prodBundleBase = "http://awesome-cdn.com/subdir";
+    configOptions.prodBundleBase = "http://awesome-cdn.com/subdir/";
     configOptions.stats = "test/data/stats-test-pwa.json";
 
     return electrodeServer(config)
@@ -260,7 +260,7 @@ describe("Test electrode-react-webapp", () => {
           url: "/"
         }).then((res) => {
           expect(res.statusCode).to.equal(200);
-          expect(res.result).to.contain("<link rel=\"manifest\" href=\"http://awesome-cdn.com/subdir/js/manifest.json\" />");
+          expect(res.result).to.contain("<link rel=\"manifest\" href=\"http://awesome-cdn.com/subdir/manifest.json\" />");
           stopServer(server);
         })
         .catch((err) => {
@@ -313,7 +313,7 @@ describe("Test electrode-react-webapp", () => {
   });
 
   it("should inject a script reference with a provided prodBundleBase", () => {
-    configOptions.prodBundleBase = "http://awesome-cdn.com/myapp";
+    configOptions.prodBundleBase = "http://awesome-cdn.com/myapp/";
     configOptions.stats = "test/data/stats-test-one-bundle.json";
 
     return electrodeServer(config)
@@ -323,7 +323,7 @@ describe("Test electrode-react-webapp", () => {
           url: "/"
         }).then((res) => {
           expect(res.statusCode).to.equal(200);
-          expect(res.result).to.contain("<script src=\"http://awesome-cdn.com/myapp/js/bundle.f07a873ce87fc904a6a5.js\">");
+          expect(res.result).to.contain("<script src=\"http://awesome-cdn.com/myapp/bundle.f07a873ce87fc904a6a5.js\">");
           stopServer(server);
         })
         .catch((err) => {

--- a/packages/electrode-react-webapp/test/spec/index.spec.js
+++ b/packages/electrode-react-webapp/test/spec/index.spec.js
@@ -161,6 +161,29 @@ describe("Test electrode-react-webapp", () => {
       });
   });
 
+  it("should handle multiple entry points with a prodBundleBase", () => {
+    configOptions.prodBundleBase = "http://awesome-cdn.com/multi";
+    configOptions.bundleChunkSelector = "test/data/chunk-selector.js";
+    configOptions.stats = "test/data/stats-test-multibundle.json";
+
+    return electrodeServer(config)
+      .then((server) => {
+        return server.inject({
+          method: "GET",
+          url: "/bar"
+        }).then((res) => {
+          expect(res.statusCode).to.equal(200);
+          expect(res.result).to.contain("<script src=\"http://awesome-cdn.com/multi/js/bar.bundle.f07a873ce87fc904a6a5.js\"");
+          expect(res.result).to.contain("<link rel=\"stylesheet\" href=\"http://awesome-cdn.com/multi/js/bar.style.f07a873ce87fc904a6a5.css\"");
+          stopServer(server);
+        })
+        .catch((err) => {
+          stopServer(server);
+          throw err;
+        });
+      });
+  });
+
   it("should handle multiple entry points - default", () => {
     configOptions.bundleChunkSelector = "test/data/chunk-selector.js";
     configOptions.stats = "test/data/stats-test-multibundle.json";
@@ -226,6 +249,27 @@ describe("Test electrode-react-webapp", () => {
       });
   });
 
+  it("should inject a pwa manfiest with a prodBundleBase", () => {
+    configOptions.prodBundleBase = "http://awesome-cdn.com/subdir";
+    configOptions.stats = "test/data/stats-test-pwa.json";
+
+    return electrodeServer(config)
+      .then((server) => {
+        return server.inject({
+          method: "GET",
+          url: "/"
+        }).then((res) => {
+          expect(res.statusCode).to.equal(200);
+          expect(res.result).to.contain("<link rel=\"manifest\" href=\"http://awesome-cdn.com/subdir/js/manifest.json\" />");
+          stopServer(server);
+        })
+        .catch((err) => {
+          stopServer(server);
+          throw err;
+        });
+      });
+  });
+
   it("should inject pwa icons", () => {
     configOptions.iconStats = "test/data/icon-stats-test-pwa.json";
 
@@ -267,4 +311,26 @@ describe("Test electrode-react-webapp", () => {
         });
       });
   });
+
+  it("should inject a script reference with a provided prodBundleBase", () => {
+    configOptions.prodBundleBase = "http://awesome-cdn.com/myapp";
+    configOptions.stats = "test/data/stats-test-one-bundle.json";
+
+    return electrodeServer(config)
+      .then((server) => {
+        return server.inject({
+          method: "GET",
+          url: "/"
+        }).then((res) => {
+          expect(res.statusCode).to.equal(200);
+          expect(res.result).to.contain("<script src=\"http://awesome-cdn.com/myapp/js/bundle.f07a873ce87fc904a6a5.js\">");
+          stopServer(server);
+        })
+        .catch((err) => {
+          stopServer(server);
+          throw err;
+        });
+      });
+  });
+
 });


### PR DESCRIPTION
This is a proposed fix for https://github.com/electrode-io/electrode/issues/359

Note: I am unsure whether to categorize this as "feat" or "bug".  It seems like a feature to me, but it is so tiny that it hardly seems to justify that designation!

Details below.

### Problem
In some cases, it is desirable to have the main JavaScript, CSS and pwa manifests reside on a CDN server while running in production mode.  This is not possible given the current implementation of `electrode-react-webapp`.

### Solution
This adds a new configuration option, `prodBundleBase`, which defaults to "", but can be configured in the confippet configuration system for plugins.

When specified, this will be prefixed to the url fragment for the main JavaScript bundle(s), css files and pwa manifest files.

### Implementation notes
This adds several tests to validate that all the URL's are properly updated.

Note that there are two tests, not in react-web-app, that are failing.  These fail in a "vanilla" checkout.
