### PR TITLE
generator-electrode: [patch] [chore] Set ES6 flag in gulpfile.

### DIFF
--- a/packages/generator-electrode/generators/app/templates/gulpfile.js
+++ b/packages/generator-electrode/generators/app/templates/gulpfile.js
@@ -1,2 +1,2 @@
-process.env.ES6_LINT = true;
+process.env.SERVER_ES6 = true;
 require("electrode-archetype-react-app")();

--- a/packages/generator-electrode/generators/app/templates/gulpfile.js
+++ b/packages/generator-electrode/generators/app/templates/gulpfile.js
@@ -1,1 +1,2 @@
+process.env.ES6_LINT = true;
 require("electrode-archetype-react-app")();

--- a/packages/generator-electrode/generators/app/templates/test/server/eslintrc
+++ b/packages/generator-electrode/generators/app/templates/test/server/eslintrc
@@ -1,6 +1,6 @@
 ---
 extends:
-  - "../../node_modules/electrode-archetype-react-app-dev/config/eslint/.eslintrc-mocha-test"
+  - "../../node_modules/electrode-archetype-react-app-dev/config/eslint/.eslintrc-mocha-test-es6"
 
 <% if (isSingleQuote) { %>
 rules:


### PR DESCRIPTION
- set ES6 test flag that is used by the `arch-gulpfile`.
- `test/server` eslint file extends from the new es6 server test file.