### PR TITLE
electrode-archetype-react-app-dev: [patch][chore] Allow webpack config to override test entry point

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/karma/karma.conf.js
+++ b/packages/electrode-archetype-react-app-dev/config/karma/karma.conf.js
@@ -4,7 +4,7 @@ const Path = require("path");
 
 const webpackCfg = require("../webpack/webpack.config.test");
 
-const MAIN_PATH = require.resolve(webpackCfg.entry);
+const MAIN_PATH = webpackCfg.entry;
 
 const PREPROCESSORS = {};
 

--- a/packages/electrode-archetype-react-app-dev/config/karma/karma.conf.js
+++ b/packages/electrode-archetype-react-app-dev/config/karma/karma.conf.js
@@ -4,7 +4,7 @@ const Path = require("path");
 
 const webpackCfg = require("../webpack/webpack.config.test");
 
-const MAIN_PATH = require.resolve("./entry.js");
+const MAIN_PATH = require.resolve(webpackCfg.entry);
 
 const PREPROCESSORS = {};
 


### PR DESCRIPTION
My goal here is to co-locate my test files with my components. Something I thought was possible with electrode but it must have changed at some point.  My solution is to make the test entry file overridable via the Webpack config. It's worked for my case, and gives me a ton of control over my testing environment which is very valuable to my project.  

Based on the naming of the webpack parital `test-entry.js` my assumption is that this was the intention of the webpack config file, but it doesn't look like it's being applied properly in the `karma.conf.js`.

Is there a reason that the test entry file is hard coded? This is quite limiting, but if there's an alternative way you'd suggest overriding the entry file I'd be interested to hear the approach.