### PR TITLE
generator-electrode: [patch][bug]generator-default-developer-name

### DIFF
--- a/packages/generator-electrode/component/index.js
+++ b/packages/generator-electrode/component/index.js
@@ -216,14 +216,15 @@ var ReactComponentGenerator = yeoman.Base.extend({
         this.props.homepage = this.githubUrl + "/" + this.packageGitHubOrg + "/" + this.ghRepo;
         this.props.serverType = "HapiJS";
         this.props.githubUrl = this.githubUrl;
-        this.props.authorName = this.developerName;
+        this.props.authorName = this.developerName || this.user.git.name();
         this.props.authorEmail = this.ghUser + "@" + this.packageGitHubOrg + ".com";
         this.props.authorUrl = this.githubUrl + "/" + this.ghUser;
         this.props.pwa = false;
         this.props.autoSsr = false;
         this.props.license = "nolicense";
-        this.props.githubAccount = this.ghUser;
+        this.props.githubAccount = this.ghUser || this.user.git.name();
         this.props.keywords = "electrode";
+
         let options = {
           isDemoApp: true,
           props: this.props


### PR DESCRIPTION
This is a fix for redundant prompting `Author Name` and `GitHub username or organization ()`.

Scenario: during electrode:component prompts, hit enter (default value) all the way without specify the author name field name and github username, we should dismiss the redundant `Author Name` and `GitHub username or organization ()` question from electrode:app.

Solution: adding a default value for both.