### PR TITLE
generator-electrode: [patch][bug] The latest generator electrode@2.2.1 should be using electrode-demo-helper@2.0.0 now

### DIFF
--- a/packages/generator-electrode/package.json
+++ b/packages/generator-electrode/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "chalk": "^1.0.0",
-    "electrode-demo-helper": "^1.0.1",
+    "electrode-demo-helper": "^2.0.0",
     "generator-license": "^5.0.0",
     "generator-travis": "^1.3.0",
     "git-remote-origin-url": "^2.0.0",


### PR DESCRIPTION
The latest generator electrode@2.2.1 should use electrode-demo-helper@2.0.0 now.