### PR TITLE
archetype-react-app: [major][feat]Chrome Headless Feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ node_js:
   - v4
   - v6
   - v8
-dist: trusty
+dist: trusty # needs Ubuntu Trusty
+sudo: false  # no need for virtualization.
+addons:
+  chrome: stable # have Travis install chrome stable.
 notifications:
   email:
     - XChen@walmartlabs.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - v4
   - v6
   - v8
+dist: trusty
 notifications:
   email:
     - XChen@walmartlabs.com

--- a/packages/electrode-archetype-react-app-dev/config/karma/browser-settings.js
+++ b/packages/electrode-archetype-react-app-dev/config/karma/browser-settings.js
@@ -6,18 +6,13 @@ const logger = require("electrode-archetype-react-app/lib/logger");
 module.exports = function(settings) {
   const browser = archetype.karma.browser.toLowerCase();
   if (browser === "chrome") {
-    settings.browsers = ["Chrome", "Chrome_without_security"];
-    settings.customLaunchers = {
-      Chrome_without_security: {
-        base: "Chrome",
-        flags: ["--disable-web-security"]
-      }
-    };
+    settings.browsers = ["ChromeHeadless"];
+
     logger.info("Using Chrome Headless to run Karma test");
   } else if (browser === "phantomjs") {
     settings.frameworks.push("phantomjs-shim");
     settings.browser = ["PhantomJS"];
-    // eslint-disable-next-line max-len
+
     logger.warn(
       "Using PhantomJS to run Karma test. It's been deprecated and may be removed in the future."
     );


### PR DESCRIPTION
Using karma chrome launcher to start the chrome headless and the updated karma config.

Currently we are using the ChromeHeadless launcher, if we need to pass any custom flags in the future, we can also customize our own launcher by using `customLaunchers`.

reference: https://developers.google.com/web/updates/2017/06/headless-karma-mocha-chai

![screen shot 2017-06-20 at 2 28 48 pm](https://user-images.githubusercontent.com/10135897/27357795-8028b5cc-55c8-11e7-9939-990a6e86f37e.png)
