### PR TITLE
Add optional-require

### DIFF
--- a/packages/electrode-archetype-react-component-dev/package.json
+++ b/packages/electrode-archetype-react-component-dev/package.json
@@ -70,6 +70,7 @@
     "lodash-webpack-plugin": "^0.3.0",
     "mocha": "^2.4.5",
     "nodemon": "^1.8.1",
+    "optional-require": "^1.0.0",
     "phantomjs-prebuilt": "^2.1.13",
     "postcss-cssnext": "^2.7.0",
     "postcss-import": "^8.1.2",


### PR DESCRIPTION
@jchip 

We are using `optional-require` and didn't update the requirements. This should fix issues with newer releases of `1.x.x`.

https://github.com/electrode-io/electrode/blob/webpack-1.0/packages/electrode-archetype-react-component/config/webpack/partial/styles.js#L6