### PR TITLE
[patch][bug] Escape __PRELOADED_STATE__. Fix for #441

### DIFF
--- a/packages/electrode-redux-router-engine/lib/redux-router-engine.js
+++ b/packages/electrode-redux-router-engine/lib/redux-router-engine.js
@@ -11,6 +11,17 @@ const ReactRouter = require("react-router");
 const Provider = require("react-redux").Provider;
 const Path = require("path");
 
+const BAD_CHARS_REGEXP = /[<\u2028\u2029]/g;
+const REPLACEMENTS_FOR_BAD_CHARS = {
+  "<": "\\u003C",
+  "\u2028": "\\u2028",
+  "\u2029": "\\u2029"
+};
+
+function escapeBadChars(sourceString) {
+  return sourceString.replace(BAD_CHARS_REGEXP, (match) => REPLACEMENTS_FOR_BAD_CHARS[match]);
+}
+
 class ReduxRouterEngine {
   constructor(options) {
     assert(options.routes, "Must provide react-router routes for redux-router-engine");
@@ -22,7 +33,7 @@ class ReduxRouterEngine {
 
     if (!options.stringifyPreloadedState) {
       this.options.stringifyPreloadedState =
-        (state) => `window.__PRELOADED_STATE__ = ${JSON.stringify(state)};`;
+        (state) => `window.__PRELOADED_STATE__ = ${escapeBadChars(JSON.stringify(state))};`;
     }
 
     if (!this.options.logError) {

--- a/packages/electrode-redux-router-engine/package.json
+++ b/packages/electrode-redux-router-engine/package.json
@@ -46,5 +46,20 @@
   "peerDependencies": {
     "react": "^15.3.1 || ^0.14.8",
     "react-dom": "^15.3.1 || ^0.14.8"
+  },
+  "nyc": {
+    "all": true,
+    "reporter": [
+      "lcov",
+      "text",
+      "text-summary"
+    ],
+    "exclude": [
+      "coverage",
+      "*clap.js",
+      "gulpfile.js",
+      "dist",
+      "test"
+    ]
   }
 }


### PR DESCRIPTION
This is a fix for issue 441.

This solves the issue by replacing "<"'s in the PRELOADED_STATE string with \u003C . The original blog post that alerted me to this problem pointed at a package ( https://github.com/yahoo/serialize-javascript ) that would do the escaping.  It did other things that weren't needed here, and rather than bringing in a 100 line package that did what 5 lines could do, I implemented what was needed here.  In the process, I also noted that they were solving another problem, which is that the \u2028 and \u2029 line and paragraph endings will also mess up the expected results, and so I added that here as well.

If you would prefer to pull in the whole serialize package, I'm happy to do that as an alternative.

```
=============================== Coverage summary ===============================
Statements   : 100% ( 79/79 )
Branches     : 100% ( 46/46 )
Functions    : 100% ( 16/16 )
Lines        : 100% ( 78/78 )
================================================================================
```