### PR TITLE
Extract styles from all chunks

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract.js
@@ -88,7 +88,7 @@ module.exports = function () {
       plugins: [
         new ExtractTextPlugin(config.__wmlMultiBundle
           ? "[name].style.[hash].css"
-          : "style.[hash].css"),
+          : "style.[hash].css", { allChunks: true }),
 
         /*
         preserve: default: false. Keep the original unsplit file as well.


### PR DESCRIPTION
We were having an issue where the main bundle was including over 100kb (gzipped) of styles in our main entry chunk. This was due to styles that were being required from other chunks, which weren't being extracted.

This change ensures that `ExtractTextPlugin` extracts styles from all chunks, not just the entry chunk. This significantly reduced our main entry chunk size.

cc @jchip it'd be great to get this in and released soon if possible. If there's any reason _not_ to make this change I can adjust this PR to make it optional based on a config property. Thanks!