### PR TITLE
Custom html markers proposed solution

### DIFF
--- a/packages/electrode-react-webapp/lib/react-webapp.js
+++ b/packages/electrode-react-webapp/lib/react-webapp.js
@@ -161,6 +161,9 @@ function makeRouteHandler(routeOptions, userContent) {
           case CRITICAL_CSS_MARKER:
             return criticalCSS;
           default:
+            if (content.markers && content.markers[m] !== undefined) {
+              return content;
+            }
             return `Unknown marker ${m}`;
         }
       });

--- a/packages/electrode-redux-router-engine/lib/redux-router-engine.js
+++ b/packages/electrode-redux-router-engine/lib/redux-router-engine.js
@@ -117,7 +117,11 @@ class ReduxRouterEngine {
 
     return this._getReduxStoreInitializer(route, options).call(this, req, match)
       .then((store) => {
-        const r = { prefetch: stringifyPreloadedState(store.getState()) };
+        const r = {
+          prefetch: stringifyPreloadedState(store.getState()),
+          store,
+          markers: {}
+        };
         const x = this._renderToString(req, store, match, withIds);
         if (x.then !== undefined) { // a Promise?
           return x.then((html) => {

--- a/packages/generator-electrode/generators/webapp/templates/src/server/views/index-view.js
+++ b/packages/generator-electrode/generators/webapp/templates/src/server/views/index-view.js
@@ -35,5 +35,10 @@ module.exports = (req) => {
     app.routesEngine = new ReduxRouterEngine({routes, createReduxStore});
   }
 
-  return app.routesEngine.render(req);
+  return Promise.resolve(app.routesEngine.render(req))
+    .then(content => {
+      // Add custom markers here to `content.markers`. 
+      // Example: content.markers['BODY_ADDITIONS'] = renderAdditions({store: content.store})
+      return content;
+    });
 };


### PR DESCRIPTION
This PR just shows the prove of concept for having custom HTML markers. 

**Motivation**

There are some cases (mostly side effects) requiring custom placeholder to render dynamic content. It's very tricky to add something on the page after `React.renderToString()`.

Examples, where custom markers would be very handy: 
- custom [react-side-effect](https://github.com/gaearon/react-side-effect) modules
- store dependent scripts
- any sort of dynamic code that doesn't belong to React

**Solution**

It turned out that it's relatively easy to add custom markers functionality to the electrode rendering workflow.

It makes sense to hear any concerns or opinions how to do it better. 