### PR TITLE
Move {{PREFETCH_BUNDLES}} marker after {{SSR_CONTENT}}

### DIFF
--- a/packages/electrode-react-webapp/lib/index.html
+++ b/packages/electrode-react-webapp/lib/index.html
@@ -6,11 +6,11 @@
     {{META_TAGS}}
     {{PAGE_TITLE}}
     {{CRITICAL_CSS}}
-    {{PREFETCH_BUNDLES}}
     {{WEBAPP_HEADER_BUNDLES}}
 </head>
 <body>
 <div class="js-content">{{SSR_CONTENT}}</div>
+{{PREFETCH_BUNDLES}}
 {{WEBAPP_BODY_BUNDLES}}
 <script>if (window.webappStart) webappStart();</script>
 <noscript>


### PR DESCRIPTION
**Motivation**

It's slightly unclear why serialized state is placed into `<head>`. The store state might be pretty big sometimes and it looks like it's more critical to parse CSS and page HTML first. 

It would be great to know if there is a strong reason, and possibly make it more obvious why {{PREFETCH_BUNDLES}} is placed before {{SSR_CONTENT}}. 