### PR TITLE
Redux state should be preloaded after renderToString.

### DIFF
--- a/packages/electrode-redux-router-engine/lib/redux-router-engine.js
+++ b/packages/electrode-redux-router-engine/lib/redux-router-engine.js
@@ -117,17 +117,19 @@ class ReduxRouterEngine {
 
     return this._getReduxStoreInitializer(route, options).call(this, req, match)
       .then((store) => {
-        const r = { prefetch: stringifyPreloadedState(store.getState()) };
+        const r = {};
         const x = this._renderToString(req, store, match, withIds);
         if (x.then !== undefined) { // a Promise?
           return x.then((html) => {
             r.status = 200;
             r.html = html;
+            r.prefetch = stringifyPreloadedState(store.getState());
             return r;
           });
         } else {
           r.status = 200;
           r.html = x;
+          r.prefetch = stringifyPreloadedState(store.getState());
           return r;
         }
       });

--- a/packages/electrode-redux-router-engine/test/routes.jsx
+++ b/packages/electrode-redux-router-engine/test/routes.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Route, IndexRoute, Redirect } from "react-router";
+import { connect } from 'react-redux'
 
 class Home extends React.Component {
   render() {
@@ -9,7 +10,7 @@ class Home extends React.Component {
 
 class Page extends React.Component {
   render() {
-    return <div>Page</div>;
+    return <div>Page {this.props.children}</div>;
   }
 }
 
@@ -19,11 +20,21 @@ class Test extends React.Component {
   }
 }
 
+function TestRedux({inc}) {
+  inc();
+
+  return (
+    <div>Test Redux</div>
+  )
+}
+const ConnectedTestRedux = connect(null, dispatch => ({inc: () => dispatch({type: "INC_NUMBER"})}))(TestRedux)
+
 export default (
   <Route path="/test" component={Page}>
     <IndexRoute component={Home} />
     <Redirect from="source" to="target" />
     <Route path="/test-init" init={true} component={Test} />
     <Route path="/test-init2" init="test-init2" component={Test} />
+    <Route path="/test-redux" init="test-redux" component={ConnectedTestRedux} />
   </Route>
 );

--- a/packages/electrode-redux-router-engine/test/spec/redux-router-engine.spec.js
+++ b/packages/electrode-redux-router-engine/test/spec/redux-router-engine.spec.js
@@ -280,4 +280,21 @@ describe("redux-router-engine", function () {
     });
     return test().then(() => test());
   });
+
+  it("should have state preloaded after rendering", () => {
+    const req = {
+      path: "/test-redux",
+      method: "get",
+      log: () => {
+      },
+      app: {},
+      url: {}
+    };
+
+    const engine = new ReduxRouterEngine({ routes, createReduxStore, routesHandlerPath: Path.join(__dirname, "..") });
+
+    return engine.render(req).then((result) => {
+      expect(result.prefetch).include("1");
+    });
+  });
 });

--- a/packages/electrode-redux-router-engine/test/test-redux.js
+++ b/packages/electrode-redux-router-engine/test/test-redux.js
@@ -1,0 +1,14 @@
+/* eslint-disable */
+const createStore = require("redux").createStore;
+
+module.exports = function (req, match) {
+    const reducer = (state, action) => {
+        if (action.type === "INC_NUMBER") {
+            return state + 1;
+        }
+
+        return 0;
+    }
+    const initialState = 0;
+    return Promise.resolve(createStore(reducer, initialState));
+};


### PR DESCRIPTION
If a component have a dispatch call to update state, the `window.__PRELOADED_STATE__` does not prefetch with the updated state.

Component could call the store dispatch at
- Constructor
```
class Test extends React.Component {
  constructor(props) {
    super(props);
    store.dispatch(); // Call to update state.
  }
}
```
- Component will mount
```
class Test extends React.Component {
  componentWillMount() {
    store.dispatch(); // Call to update state.
  }
}
```
- Functional component
```
function Test() {
  store.dispatch(); // Call to update state.
  return <div>Test</div>
}
```

All above dispatch calls will not be reflected with the new state in the `window.__PRELOADED_STATE__` if we prefetch state before `renderToString()`

According to the code snippet from [http://redux.js.org/docs/recipes/ServerRendering.html#handling-the-request](http://redux.js.org/docs/recipes/ServerRendering.html#handling-the-request), the state is grab after renderToString.
```
// Render the component to a string
const html = renderToString(
  <Provider store={store}>
    <App />
  </Provider>
)

// Grab the initial state from our Redux store
const preloadedState = store.getState()
```

Additionally, I have provided a unit test `"should have state preloaded after rendering"` to simulate the problem in this PR.