### PR TITLE
[minor][feat] Allow inline scripts to be marked with a nonce for CSP protection

### DIFF
--- a/packages/electrode-react-webapp/README.md
+++ b/packages/electrode-react-webapp/README.md
@@ -100,7 +100,7 @@ What you can do with the options:
     -   `host` `(String)` The host that webpack-dev-server runs on
     -   `port` `(String)` The port that webpack-dev-server runs on
 -   `prodBundleBase` `(String)` Base path to locate the JavaScript, CSS and manifest bundles. Defaults to "/js/". Should end with "/".
--   `cspNoncePropPath` `(String)` The path from the request object to a CSP nonce value. This nonce, if present, will be included on any `script` elements that contain scripts (e.g. any SSR preloaded state). For example, if you have a hapi plugin that puts a nonce value at `request.plugins.myCspGenerator.nonce` you would set `cspNonceProp` to `plugins.myCspGenerator.nonce`. If this property is undefined, or if the value at that location is undefined, no nonce will be added to the script elements.
+-  `cspNonceValue` `(Function|Object|undefined)` Used to retrieve a CSP nonce value. If this is a function it will be passed the request and the nonce type (`'script'` or `'style'`), and must return the corresponding nonce. If this is an object, it may have properties `script`, `style` or both, and the value for each should be the path from the request object to the nonce value (For example, if you have a hapi plugin that puts a nonce value at `request.plugins.myCspGenerator.nonce` you might set `cspNonceValue` to `{ script: 'plugins.myCspGenerator.nonce' }`).  The nonce, if present, will be included on any `script` or `style` elements that directly contain scripts or style (e.g. any SSR preloaded state). If this property is undefined, or if the value at that location is undefined, no nonce will be added.
 
 ### `htmlFile` view details
 

--- a/packages/electrode-react-webapp/README.md
+++ b/packages/electrode-react-webapp/README.md
@@ -100,6 +100,7 @@ What you can do with the options:
     -   `host` `(String)` The host that webpack-dev-server runs on
     -   `port` `(String)` The port that webpack-dev-server runs on
 -   `prodBundleBase` `(String)` Base path to locate the JavaScript, CSS and manifest bundles. Defaults to "/js/". Should end with "/".
+-   `cspNoncePropPath` `(String)` The path from the request object to a CSP nonce value. This nonce, if present, will be included on any `script` elements that contain scripts (e.g. any SSR preloaded state). For example, if you have a hapi plugin that puts a nonce value at `request.plugins.myCspGenerator.nonce` you would set `cspNonceProp` to `plugins.myCspGenerator.nonce`. If this property is undefined, or if the value at that location is undefined, no nonce will be added to the script elements.
 
 ### `htmlFile` view details
 

--- a/packages/electrode-react-webapp/lib/react-webapp.js
+++ b/packages/electrode-react-webapp/lib/react-webapp.js
@@ -104,7 +104,7 @@ function makeRouteHandler(routeOptions, userContent) {
           x =>
             typeof x === "string"
               ? `<script${paddedNonce}>${x}</script>\n`
-              : x.map(n => `<script src="${n.src}">xxx</script>`).join("\n")
+              : x.map(n => `<script src="${n.src}"></script>`).join("\n")
         )
         .join("\n");
     };

--- a/packages/electrode-react-webapp/lib/react-webapp.js
+++ b/packages/electrode-react-webapp/lib/react-webapp.js
@@ -62,6 +62,8 @@ function makeRouteHandler(routeOptions, userContent) {
       : `${devBundleBase}bundle.dev.js`;
     const jsChunk = _.find(assets.js, asset => _.includes(asset.chunkNames, chunkNames.js));
     const cssChunk = _.find(assets.css, asset => _.includes(asset.chunkNames, chunkNames.css));
+    const cspNonce = _.get(options.request, routeOptions.cspNoncePropPath, undefined);
+    const paddedNonce = cspNonce ? ` nonce="${cspNonce}"` : "";
 
     const bundleCss = () => {
       return WEBPACK_DEV ? devCSSBundle : (cssChunk && `${prodBundleBase}${cssChunk.name}`) || "";
@@ -101,8 +103,8 @@ function makeRouteHandler(routeOptions, userContent) {
         .map(
           x =>
             typeof x === "string"
-              ? `<script>${x}</script>\n`
-              : x.map(n => `<script src="${n.src}"></script>`).join("\n")
+              ? `<script${paddedNonce}>${x}</script>\n`
+              : x.map(n => `<script src="${n.src}">xxx</script>`).join("\n")
         )
         .join("\n");
     };
@@ -155,7 +157,7 @@ function makeRouteHandler(routeOptions, userContent) {
           case BODY_BUNDLE_MARKER:
             return makeBodyBundles();
           case PREFETCH_MARKER:
-            return `<script>${content.prefetch}</script>`;
+            return `<script${paddedNonce}>${content.prefetch}</script>`;
           case META_TAGS_MARKER:
             return helmet.meta.toString() + iconStats;
           case CRITICAL_CSS_MARKER:
@@ -199,7 +201,8 @@ const setupOptions = options => {
     iconStats: "dist/server/iconstats.json",
     criticalCSS: "dist/js/critical.css",
     buildArtifacts: ".build",
-    prodBundleBase: "/js/"
+    prodBundleBase: "/js/",
+    cspNoncePropPath: undefined
   };
 
   const pluginOptions = _.defaultsDeep({}, options, pluginOptionsDefaults);

--- a/packages/electrode-react-webapp/lib/utils.js
+++ b/packages/electrode-react-webapp/lib/utils.js
@@ -73,11 +73,13 @@ function getIconStats(iconStatsPath) {
   return iconStats;
 }
 
-function getCriticalCSS(path) {
+function getCriticalCSS(path, nonceValue) {
+  const paddedNonce = nonceValue ? ` nonce="${nonceValue}"` : "";
+
   const criticalCSSPath = Path.resolve(process.cwd(), path);
   try {
     const criticalCSS = fs.readFileSync(criticalCSSPath).toString();
-    return `<style>${criticalCSS}</style>`;
+    return `<style${paddedNonce}>${criticalCSS}</style>`;
   } catch (err) {
     return "";
   }

--- a/packages/electrode-react-webapp/test/spec/index.spec.js
+++ b/packages/electrode-react-webapp/test/spec/index.spec.js
@@ -435,7 +435,7 @@ describe("Test electrode-react-webapp", () => {
   });
 
   it("should add a nonce value, if configuration specifies a path and a value is present", () => {
-    configOptions.cspNoncePropPath = "plugins.cspPlugin.nonceValue";
+    configOptions.cspNonceValue = { script: "plugins.cspPlugin.nonceValue" };
     function cspPlugin(server, options, next) {
       server.ext('onRequest', (request, reply) => {
           request.plugins.cspPlugin = {
@@ -468,8 +468,30 @@ describe("Test electrode-react-webapp", () => {
     });
   });
 
+  it("should add a nonce value as provided by a function in the config", () => {
+    configOptions.cspNonceValue = function (request, type) {
+      return `==${type}`;
+    };
+
+    return electrodeServer(config).then(server => {
+       return server
+        .inject({
+          method: "GET",
+          url: "/"
+        })
+        .then(res => {
+          expect(res.result).to.contain("<script nonce=\"==script\">console.log('Hello');</script>");
+          stopServer(server);
+        })
+        .catch(err => {
+          stopServer(server);
+          throw err;
+        });
+    });
+  });
+
   it("should not add a nonce value, if configuration specifies a path and no value present", () => {
-    configOptions.cspNoncePropPath = "plugins.cspPlugin.nonceValue";
+    configOptions.cspNonceValue = { script: "plugins.cspPlugin.nonceValue" };
     function cspPlugin(server, options, next) {
       server.ext('onRequest', (request, reply) => {
           request.plugins.cspPlugin = {};
@@ -499,4 +521,65 @@ describe("Test electrode-react-webapp", () => {
         });
     });
   });
+
+  it("should inject critical css with a nonce value when provided", () => {
+    configOptions.criticalCSS = "test/data/critical.css";
+    configOptions.cspNonceValue = { style: "plugins.cspPlugin.nonceValue" };
+    function cspPlugin(server, options, next) {
+      server.ext('onRequest', (request, reply) => {
+          request.plugins.cspPlugin = {
+            nonceValue: '==ABCD'
+          };
+          return reply.continue();
+      });
+      next();
+    }
+    cspPlugin.attributes = {
+      name: 'cspPlugin'
+    };
+
+    return electrodeServer(config).then(server => {
+      // Add a trivial csp generator for testing purposes.
+      server.register(cspPlugin);
+      return server
+        .inject({
+          method: "GET",
+          url: "/"
+        })
+        .then(res => {
+          expect(res.statusCode).to.equal(200);
+          expect(res.result).to.contain("<style nonce=\"==ABCD\">body {color: green;}\n</style>");
+          stopServer(server);
+        })
+        .catch(err => {
+          stopServer(server);
+          throw err;
+        });
+    });
+  });
+
+  it("should inject critical css with a nonce value provided by a function", () => {
+    configOptions.criticalCSS = "test/data/critical.css";
+    configOptions.cspNonceValue = function (request, type) {
+      return `==${type}`;
+    };
+
+    return electrodeServer(config).then(server => {
+      return server
+        .inject({
+          method: "GET",
+          url: "/"
+        })
+        .then(res => {
+          expect(res.statusCode).to.equal(200);
+          expect(res.result).to.contain("<style nonce=\"==style\">body {color: green;}\n</style>");
+          stopServer(server);
+        })
+        .catch(err => {
+          stopServer(server);
+          throw err;
+        });
+    });
+  });
+
 });


### PR DESCRIPTION
Modified react-webapp to notice when a nonce value has been provided, and if so attaches
it to any <script> tags and the critical css tag that are generated. See also https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP

Fix for #474 

Note: Internal feedback suggested that in some cases a function would be a more general way to get the none value, so added this as an alternative.  Modified docs and tests to test both with a string and the function.