### PR TITLE
[patch][bug]Fix the inclusion of test/ directory as part of code coverage reporting

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/coverage.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/coverage.js
@@ -9,9 +9,9 @@ module.exports = function() {
         {
           _name: "isparta-loader",
           loader: iiLoader,
-          test: /(test|client)\/.*\.jsx?$/,
+          test: /client\/.*\.jsx?$/,
           enforce: "pre",
-          exclude: /(node_modules|\bclient\/vendor\b)/
+          exclude: /(node_modules|\btest\/|\bclient\/vendor\b)/
         }
       ]
     }


### PR DESCRIPTION
Fix the inclusion of test/ directory as part of code coverage reporting
Before:
<img width="1083" alt="screen shot 2017-07-18 at 5 37 19 pm" src="https://user-images.githubusercontent.com/10135897/28345717-d17b1ea0-6be0-11e7-9314-248529dd9fee.png">

After:
<img width="959" alt="screen shot 2017-07-18 at 5 41 41 pm" src="https://user-images.githubusercontent.com/10135897/28345721-d5692bec-6be0-11e7-8aca-24052e40cf10.png">
