### PR TITLE
[PATCH] Fix broken Add Routes link

### DIFF
--- a/docs/chapter1/intermediate/build-a-server-plugin.md
+++ b/docs/chapter1/intermediate/build-a-server-plugin.md
@@ -121,5 +121,5 @@ Set your token for heroku deployment:
 heroku config:set token='your-token-here'
 ```
 
-A great tool for testing your server requests is [Postman](https://www.getpostman.com/). Its user interface for viewing response objects and errors is incredible. For now, you will have to trust us as we build out Your Awesome App. Navigate to [Intermediate: Add Routes](/chapter1/intermediate/add-routes.md), to add routing to the app and extend our UI to display our contributor array.
+A great tool for testing your server requests is [Postman](https://www.getpostman.com/). Its user interface for viewing response objects and errors is incredible. For now, you will have to trust us as we build out Your Awesome App. Navigate to [Intermediate: Add Routes](/docs/chapter1/intermediate/react-routes/add-routes.md), to add routing to the app and extend our UI to display our contributor array.
 


### PR DESCRIPTION
- update the `Intermediate: Add Routes` link to point to `/docs/chapter1/intermediate/react-routes/add-routes.md`