### PR TITLE
[bug][patch] : Lock to wds@2.5.1

### DIFF
--- a/packages/electrode-archetype-react-app-dev/package.json
+++ b/packages/electrode-archetype-react-app-dev/package.json
@@ -110,7 +110,7 @@
     "web-app-manifest-loader": "^0.1.1",
     "webpack": "^2.2.0",
     "webpack-config-composer": "^1.0.2",
-    "webpack-dev-server": "^2.2.0",
+    "webpack-dev-server": "2.5.1",
     "webpack-disk-plugin": "0.0.2",
     "webpack-stats-plugin": "^0.1.1",
     "winston": "^2.3.1",


### PR DESCRIPTION
The latest webpack-dev-server causes incompatibility with webpack v2.7.0. Locking to version 2.5.1 which is the current compatible version.
