### PR TITLE
[bug][patch] : lock to wds@2.5.1

### DIFF
--- a/packages/electrode-archetype-react-component-dev/package.json
+++ b/packages/electrode-archetype-react-component-dev/package.json
@@ -98,7 +98,7 @@
     "url-loader": "^0.5.6",
     "webpack": "^2.3.1",
     "webpack-config-composer": "^1.0.2",
-    "webpack-dev-server": "^2.4.2",
+    "webpack-dev-server": "2.5.1",
     "xclap": "^0.2.0",
     "xsh": "^0.3.2"
   },


### PR DESCRIPTION
Resolving incompatibility of webpack-dev-server v2.6.0 with webpack v2.7.0