### PR TITLE
[minor][feat] update component generator UI & using random name for component-add

### DIFF
--- a/packages/generator-electrode/component-add/index.js
+++ b/packages/generator-electrode/component-add/index.js
@@ -104,26 +104,13 @@ module.exports = generators.Base.extend({
     },
 
     askFor: function() {
-      function randomComponentName() {
-        var charSet = "abcdefghijklmnopqrstuvwxyz";
-        var randomString = "";
-
-        // Generate 7-digit random component name
-        for (var i = 0; i < 7; i++) {
-            var randomPoz = Math.floor(Math.random() * charSet.length);
-            randomString += charSet.substring(randomPoz,randomPoz + 1);
-        }
-
-        return randomString + "-component";
-      };
-
       var prompts = [
         {
           type: "input",
           name: "name",
           message: "Component Name",
           when: !this.props.name,
-          default: randomComponentName()
+          default: "untitled" + Math.floor(Math.random() * 1000)
         },
         {
           type: "input",

--- a/packages/generator-electrode/component-add/index.js
+++ b/packages/generator-electrode/component-add/index.js
@@ -19,8 +19,8 @@ var demoHelperPath = require.resolve("electrode-demo-helper");
 * so check if cwd ends in packages. also that there is a demo-app folder present
 * demo app folder path should be at the same level as packages.
 * then check if 'demo-app/package.json' and 'demo-app/src/client/components/home.jsx' exist.
-* The folder structure is now sufficiently verified. 
-* generate the component in the cwd and npmi 
+* The folder structure is now sufficiently verified.
+* generate the component in the cwd and npmi
 * modify the demo-app package to add new package.
 * modify the demo-app component home.jsx to import the new packages/component and use class in the div
 */
@@ -104,13 +104,26 @@ module.exports = generators.Base.extend({
     },
 
     askFor: function() {
+      function randomComponentName() {
+        var charSet = "abcdefghijklmnopqrstuvwxyz";
+        var randomString = "";
+
+        // Generate 7-digit random component name
+        for (var i = 0; i < 7; i++) {
+            var randomPoz = Math.floor(Math.random() * charSet.length);
+            randomString += charSet.substring(randomPoz,randomPoz + 1);
+        }
+
+        return randomString + "-component";
+      };
+
       var prompts = [
         {
           type: "input",
           name: "name",
           message: "Component Name",
           when: !this.props.name,
-          default: "wysiwyg-component"
+          default: randomComponentName()
         },
         {
           type: "input",

--- a/packages/generator-electrode/component-add/index.js
+++ b/packages/generator-electrode/component-add/index.js
@@ -110,7 +110,7 @@ module.exports = generators.Base.extend({
           name: "name",
           message: "Component Name",
           when: !this.props.name,
-          default: "untitled" + Math.floor(Math.random() * 1000)
+          default: "untitled" + Math.floor(Math.random() * 1000) + "-component"
         },
         {
           type: "input",

--- a/packages/generator-electrode/component/index.js
+++ b/packages/generator-electrode/component/index.js
@@ -187,8 +187,20 @@ var ReactComponentGenerator = yeoman.Base.extend({
         this.rootPath + "src/components/" + this.projectName + ".jsx"
       );
       this.template(
+        "packages/component/src/components/_accordion.jsx",
+        this.rootPath + "src/components/accordion.jsx"
+      );
+      this.template(
         "packages/component/src/styles/_component.css",
         this.rootPath + "src/styles/" + this.projectName + ".css"
+      );
+      this.template(
+        "packages/component/src/styles/_accordion.css",
+        this.rootPath + "src/styles/accordion.css"
+      );
+      this.template(
+        "packages/component/src/styles/_raleway.css",
+        this.rootPath + "src/styles/raleway.css"
       );
 
       // demo folder files

--- a/packages/generator-electrode/component/templates/packages/component/src/components/_accordion.jsx
+++ b/packages/generator-electrode/component/templates/packages/component/src/components/_accordion.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+import propTypes from "prop-types";
+import styles from "../../src/styles/accordion.css";
+
+export default class Accordion extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      active: false
+    };
+    this.toggle = this.toggle.bind(this);
+  }
+
+  toggle() {
+    this.setState({
+      active: !this.state.active
+    });
+  }
+
+  render() {
+    const stateStyle = this.state.active ? styles.active : styles.inactive;
+
+    return (
+      <section>
+        <a onClick={this.toggle}>
+          {this.props.summary}
+        </a>
+        <p className={stateStyle}>
+          {this.props.details}
+        </p>
+      </section>
+    );
+  }
+}
+
+Accordion.propTypes = {
+  summary: propTypes.string.isRequired,
+  details: propTypes.string.isRequired
+};

--- a/packages/generator-electrode/component/templates/packages/component/src/components/_component.jsx
+++ b/packages/generator-electrode/component/templates/packages/component/src/components/_component.jsx
@@ -2,13 +2,30 @@ import React from "react";
 import { FormattedMessage } from "react-intl";
 
 import styles from "../../src/styles/<%= projectName %>.css";
-import messages from "../lang/default-messages";
+import "../../src/styles/raleway.css";
+import Accordion from "./accordion";
 
 export default class <%= componentName %> extends React.Component {
   render() {
+    const data = {
+      definition: "> Archetype",
+      definitionDetails: "Electrode Component Archetype helps developers to quickly build react components.",
+      structure: "> Structure",
+      structureDetails: "We demo components through <repo>/demo-app where import components from <repo>/packages/<componentName>.",
+      benefit: "> Benefit",
+      benefitDetails: "With the new mono-repo structure, you can have multiple smaller components that complement each other in one repo.",
+      others: "> More Info",
+      othersDetails: "https://docs.electrode.io/chapter1/intermediate/component-archetype/"
+    };
+
     return (
-      <div className={styles.someStyle}>
-        <FormattedMessage {...messages.editMe} />
+      <div className={styles.container}>
+        <hr />
+        <h4>New accordion component demo</h4>
+        <Accordion summary={data.definition} details={data.definitionDetails} />
+        <Accordion summary={data.structure} details={data.structureDetails} />
+        <Accordion summary={data.benefit} details={data.benefitDetails} />
+        <Accordion summary={data.others} details={data.othersDetails} />
       </div>
     );
   }

--- a/packages/generator-electrode/component/templates/packages/component/src/styles/_accordion.css
+++ b/packages/generator-electrode/component/templates/packages/component/src/styles/_accordion.css
@@ -1,0 +1,39 @@
+@value blue: #1EAEDB;
+@value black: #000000;
+@value white: #FFFFFF;
+
+section .active {
+  display: inherit;
+}
+
+section .inactive {
+  display: none;
+}
+
+section {
+  background-color: white;
+  border: 1px solid blue;
+  border-radius: 5px;
+  border-top-color: blue;
+  color: black;
+  text-align: left;
+  word-wrap: break-word;
+}
+
+section a {
+  color: blue;
+  display: inline-block;
+  padding: 10px;
+}
+
+section a:hover {
+  color: blue;
+  cursor: pointer;
+}
+
+section p {
+  background-color: blue;
+  color: white;
+  margin-bottom: 0px;
+  padding: 10px;
+}

--- a/packages/generator-electrode/component/templates/packages/component/src/styles/_component.css
+++ b/packages/generator-electrode/component/templates/packages/component/src/styles/_component.css
@@ -1,14 +1,17 @@
-:root {
-  --black: #000;
-  --white: #fff;
+@value grey: #8C8B8B;
+
+.container {
+  font-family: "Raleway", "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  margin: 0 auto;
+  text-align: center;
+  width: 50%;
 }
 
-.baseStyle {
-  background-color: var(--black);
-  color: var(--white);
+.container hr {
+  border-top: 1px solid grey;
+  margin: 50px 0;
 }
 
-.someStyle {
-  composes: baseStyle;
-  font-size: 18px;
+.container h4 {
+  text-align: left;
 }

--- a/packages/generator-electrode/component/templates/packages/component/src/styles/_raleway.css
+++ b/packages/generator-electrode/component/templates/packages/component/src/styles/_raleway.css
@@ -1,0 +1,96 @@
+/* latin-ext */
+@font-face {
+  font-family: 'Raleway';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Raleway Light'),
+    local('Raleway-Light'),
+    url(http://fonts.gstatic.com/s/raleway/v11/ZKwULyCG95tk6mOqHQfRBAsYbbCjybiHxArTLjt7FRU.woff2)
+      format('woff2');
+  unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Raleway';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Raleway Light'),
+    local('Raleway-Light'),
+    url(http://fonts.gstatic.com/s/raleway/v11/-_Ctzj9b56b8RgXW8FAriQzyDMXhdD8sAj6OAJTFsBI.woff2)
+      format('woff2');
+  unicode-range: U+0000-00FF,
+    U+0131,
+    U+0152-0153,
+    U+02C6,
+    U+02DA,
+    U+02DC,
+    U+2000-206F,
+    U+2074,
+    U+20AC,
+    U+2212,
+    U+2215;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Raleway';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Raleway'),
+    local('Raleway-Regular'),
+    url(http://fonts.gstatic.com/s/raleway/v11/YZaO6llzOP57DpTBv2GnyFKPGs1ZzpMvnHX-7fPOuAc.woff2)
+      format('woff2');
+  unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Raleway';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Raleway'),
+    local('Raleway-Regular'),
+    url(http://fonts.gstatic.com/s/raleway/v11/QAUlVt1jXOgQavlW5wEfxQLUuEpTyoUstqEm5AMlJo4.woff2)
+      format('woff2');
+  unicode-range: U+0000-00FF,
+    U+0131,
+    U+0152-0153,
+    U+02C6,
+    U+02DA,
+    U+02DC,
+    U+2000-206F,
+    U+2074,
+    U+20AC,
+    U+2212,
+    U+2215;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Raleway';
+  font-style: normal;
+  font-weight: 600;
+  src: local('Raleway SemiBold'),
+    local('Raleway-SemiBold'),
+    url(http://fonts.gstatic.com/s/raleway/v11/STBOO2waD2LpX45SXYjQBQsYbbCjybiHxArTLjt7FRU.woff2)
+      format('woff2');
+  unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Raleway';
+  font-style: normal;
+  font-weight: 600;
+  src: local('Raleway SemiBold'),
+    local('Raleway-SemiBold'),
+    url(http://fonts.gstatic.com/s/raleway/v11/xkvoNo9fC8O2RDydKj12bwzyDMXhdD8sAj6OAJTFsBI.woff2)
+      format('woff2');
+  unicode-range: U+0000-00FF,
+    U+0131,
+    U+0152-0153,
+    U+02C6,
+    U+02DA,
+    U+02DC,
+    U+2000-206F,
+    U+2074,
+    U+20AC,
+    U+2212,
+    U+2215;
+}

--- a/packages/generator-electrode/generators/app/templates/src/client/styles/custom.css
+++ b/packages/generator-electrode/generators/app/templates/src/client/styles/custom.css
@@ -58,3 +58,8 @@
 img {
   vertical-align: text-bottom;
 }
+
+.demoAppContainer h2 {
+  margin: 50px 0;
+  text-align: center;
+}


### PR DESCRIPTION
Beautify the component generator UI, updated as a expanded accordions. This PR paired with electrode-demo-helper PR: https://github.com/electrode-io/electrode-demo-helper/pull/8

Tested in electrode:component and electrode:component-add generator.

Component Demo:
![screen shot 2017-07-30 at 12 13 43 pm](https://user-images.githubusercontent.com/10135897/28756985-b6643118-752e-11e7-837a-723070794ca9.png)

Component-add Demo:
![screen shot 2017-07-30 at 12 06 11 pm](https://user-images.githubusercontent.com/10135897/28756988-befe547a-752e-11e7-91a6-aa06acc7964f.png)


