### PR TITLE
[patch][bug] should always return promise object.

### DIFF
--- a/packages/electrode-react-webapp/lib/react-webapp.js
+++ b/packages/electrode-react-webapp/lib/react-webapp.js
@@ -99,7 +99,7 @@ function makeRouteHandler(routeOptions, userContent) {
     const callUserContent = content => {
       const x = content(options.request);
       return !x.catch
-        ? x
+        ? Promise.resolve(x)
         : x.catch(err => {
             return Promise.reject({
               status: err.status || HTTP_ERROR_500,


### PR DESCRIPTION
The caller of the function callUserContent expects a Promise result, so the function should create a promise that is resolved with the output, if the output is not a promise object. 