### PR TITLE
[minor][feat] implement code splitting support with webpack 3.

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/babel/babelrc-client
+++ b/packages/electrode-archetype-react-app-dev/config/babel/babelrc-client
@@ -48,7 +48,8 @@
     ],
     "transform-node-env-inline",
     "lodash",
-    "transform-runtime"
+    "transform-runtime",
+    "syntax-dynamic-import"
   ],
   "env": {
     "production": {

--- a/packages/electrode-archetype-react-app-dev/package.json
+++ b/packages/electrode-archetype-react-app-dev/package.json
@@ -25,6 +25,8 @@
     "babel-core": "^6.4.0",
     "babel-eslint": "^7.0.0",
     "babel-loader": "^7.0.0",
+    "babel-plugin-dynamic-import-node": "^1.0.2",
+    "babel-plugin-dynamic-import-webpack": "^1.0.1",
     "babel-plugin-i18n-id-hashing": "^2.1.0",
     "babel-plugin-lodash": "^3.1.3",
     "babel-plugin-minify-dead-code-elimination": "^0.1.7",

--- a/packages/electrode-archetype-react-app/arch-clap.js
+++ b/packages/electrode-archetype-react-app/arch-clap.js
@@ -410,7 +410,7 @@ Individual .babelrc files were generated for you in src/client and src/server
       desc: false,
       dep: [".clean.lib:client", ".mk.lib.client.dir", ".build.client.babelrc"],
       task: mkCmd(
-        `babel`,
+        `babel --plugins dynamic-import-node`,
         `--source-maps=inline --copy-files --out-dir ${AppMode.lib.client}`,
         `${AppMode.src.client}`
       )
@@ -572,7 +572,7 @@ Individual .babelrc files were generated for you in src/client and src/server
           .map(n => `--watch ${n}`)
           .join(" ");
         AppMode.setEnv(AppMode.src.dir);
-        const node = AppMode.isSrc ? `babel-node` : "node";
+        const node = AppMode.isSrc ? `babel-node --plugins dynamic-import-node` : "node";
         const serverIndex = Path.join(AppMode.src.server, "index.js");
         return exec(
           `nodemon`,

--- a/packages/electrode-archetype-react-app/config/babel/.babelrc
+++ b/packages/electrode-archetype-react-app/config/babel/.babelrc
@@ -48,7 +48,8 @@
     ],
     "transform-node-env-inline",
     "lodash",
-    "transform-runtime"
+    "transform-runtime",
+    "syntax-dynamic-import"
   ],
   "env": {
     "production": {

--- a/packages/generator-electrode/generators/app/templates/src/client/components/demo-code-splitting.jsx
+++ b/packages/generator-electrode/generators/app/templates/src/client/components/demo-code-splitting.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+import custom from "../styles/custom.css";
+
+export default () =>
+  <div className={custom["docs-example"]}>
+    Dynamic Content Loaded!!
+  </div>;

--- a/packages/generator-electrode/generators/app/templates/src/client/components/home.jsx
+++ b/packages/generator-electrode/generators/app/templates/src/client/components/home.jsx
@@ -6,6 +6,7 @@
  * To start your own app, please replace or remove these files:
  *
  * - this file (home.jsx)
+ * - demo-code-splitting.jsx
  * - demo-buttons.jsx
  * - demo-pure-states.jsx
  * - demo-states.jsx
@@ -15,6 +16,8 @@
  */
 
 import React from "react";
+import PropTypes from "prop-types";
+import { Link } from "react-router";
 import "../styles/normalize.css";
 import "../styles/raleway.css";
 import skeleton from "../styles/skeleton.css";
@@ -27,28 +30,48 @@ import { DemoButtons } from "./demo-buttons";
 import Notifications from "react-notify-toast";
 /*<% } %>*/
 
-export default () =>
-  <div className={custom.container}>
-    {/*<% if (pwa) { %>*/}
-    <Notifications />
-    {/*<% } %>*/}
+const Home = props => {
+  const {children} = props;
 
-    <section className={custom.header}>
-      <h2 className={skeleton.title}>
-        Hello from {" "}
-        <a href="https://github.com/electrode-io">{"Electrode"} <img src={electrodePng} /></a>
-      </h2>
-    </section>
+  return (
+    <div className={custom.container}>
+      {/*<% if (pwa) { %>*/}
+        <Notifications />
+      {/*<% } %>*/}
 
-    <div className={custom["docs-section"]}>
-      <DemoStates />
+      <section className={custom.header}>
+        <h2 className={skeleton.title}>
+          Hello from {" "}
+          <a href="https://github.com/electrode-io">{"Electrode"} <img
+            src={electrodePng}/></a>
+        </h2>
+      </section>
+
+      <div className={custom["docs-section"]}>
+        <DemoStates/>
+      </div>
+
+      <div className={custom["docs-section"]}>
+        <DemoPureStates/>
+      </div>
+
+      <div className={custom["docs-section"]}>
+        <DemoButtons/>
+      </div>
+
+      <div className={custom["docs-section"]}>
+        <h6 className={custom["docs-header"]}>
+          Demo Code Splitting <Link to="/splitting">Load Here</Link>
+        </h6>
+
+        {children}
+      </div>
     </div>
+  );
+};
 
-    <div className={custom["docs-section"]}>
-      <DemoPureStates />
-    </div>
+Home.propTypes = {
+  children: PropTypes.node
+};
 
-    <div className={custom["docs-section"]}>
-      <DemoButtons />
-    </div>
-  </div>;
+export default Home;

--- a/packages/generator-electrode/generators/app/templates/src/client/routes.jsx
+++ b/packages/generator-electrode/generators/app/templates/src/client/routes.jsx
@@ -1,5 +1,14 @@
-import React from "react";
-import { Route } from "react-router";
 import Home from "./components/home";
 
-export const routes = <Route path="/" component={Home} />;
+export const routes = {
+  path: "/",
+  component: Home,
+  childRoutes: [{
+    path: "splitting",
+    getComponent(nextState, callback) {
+      import(/* webpackChunkName: "splitting" */ "./components/demo-code-splitting").then(module => {
+        callback(null, module.default);
+      });
+    }
+  }]
+};


### PR DESCRIPTION
Thanks for upgrading to webpack 3. With webpack 3, we could specify chunk name for each dynamically loaded JS file now.

```
import(/* webpackChunkName: "splitting" */ "./components/demo-code-splitting").then(module => {
  callback(null, module.default);
});
```
Beside that, it use another set of babel plugins (`babel-plugin-dynamic-import-webpack`, `babel-plugin-dynamic-import-node`) to implement.

