### PR TITLE
[major] drop PropTypes for production

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/babel/babelrc-client
+++ b/packages/electrode-archetype-react-app-dev/config/babel/babelrc-client
@@ -53,7 +53,10 @@
   "env": {
     "production": {
       "plugins": [
-        "babel-plugin-transform-react-constant-elements"
+        "babel-plugin-transform-react-constant-elements",
+        ["transform-react-remove-prop-types", {
+           "removeImport": true
+        }]
       ]
     }
   }

--- a/packages/electrode-archetype-react-app-dev/package.json
+++ b/packages/electrode-archetype-react-app-dev/package.json
@@ -33,6 +33,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.3.13",
     "babel-plugin-transform-react-constant-elements": "^6.5.0",
     "babel-plugin-transform-react-inline-elements": "^6.6.5",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.8",
     "babel-plugin-transform-runtime": "^6.8.0",
     "babel-polyfill": "^6.5.0",
     "babel-preset-es2015": "^6.3.13",


### PR DESCRIPTION
Same changes for wml archetype app: https://gecgithub01.walmart.com/electrode/electrode-archetype-react-app/pull/243/files

Aim at: Remove unnecessary React propTypes from the production build, as they are only used in development.
