### PR TITLE
Keep Status code from content and set status codes for Status 404

### DIFF
--- a/packages/electrode-react-webapp/lib/express/index.js
+++ b/packages/electrode-react-webapp/lib/express/index.js
@@ -4,6 +4,8 @@ const _ = require("lodash");
 const assert = require("assert");
 const ReactWebapp = require("../react-webapp");
 
+const HTTP_OK = 200;
+const HTTP_NOT_FOUND = 404;
 const HTTP_ERROR_500 = 500;
 const HTTP_REDIRECT = 302;
 
@@ -30,10 +32,17 @@ const registerRoutes = (app, options, next) => {
           app[method.toLowerCase()](path, (request, response) => {
             const handleStatus = data => {
               const status = data.status;
-              if (status === HTTP_REDIRECT) {
-                response.redirect(data.path);
-              } else {
-                response.send({ message: "error" }).code(status);
+
+              // Handle Different Status Codes differently
+              switch (status) {
+                case HTTP_OK:
+                  return response.send(data.content);
+                case HTTP_NOT_FOUND:
+                  return response.status(HTTP_NOT_FOUND).send(data.content);
+                case HTTP_REDIRECT:
+                  return response.redirect(data.path);
+                default:
+                  return response.send({ message: "error" }).code(status);
               }
             };
 

--- a/packages/electrode-react-webapp/lib/hapi/index.js
+++ b/packages/electrode-react-webapp/lib/hapi/index.js
@@ -4,6 +4,8 @@ const _ = require("lodash");
 const assert = require("assert");
 const ReactWebapp = require("../react-webapp");
 
+const HTTP_OK = 200;
+const HTTP_NOT_FOUND = 404;
 const HTTP_ERROR_500 = 500;
 const HTTP_REDIRECT = 302;
 
@@ -33,10 +35,17 @@ const registerRoutes = (server, options, next) => {
           handler: (request, reply) => {
             const handleStatus = data => {
               const status = data.status;
-              if (status === HTTP_REDIRECT) {
-                reply.redirect(data.path);
-              } else {
-                reply({ message: "error" }).code(status);
+
+              // Handle Different Status Codes differently
+              switch (status) {
+                case HTTP_OK:
+                  return reply(data.content);
+                case HTTP_NOT_FOUND:
+                  return reply(data.content).code(HTTP_NOT_FOUND);
+                case HTTP_REDIRECT:
+                  return reply.redirect(data.path);
+                default:
+                  return reply({ message: "error" }).code(status);
               }
             };
 

--- a/packages/electrode-react-webapp/lib/koa/index.js
+++ b/packages/electrode-react-webapp/lib/koa/index.js
@@ -6,6 +6,8 @@ const assert = require("assert");
 const ReactWebapp = require("../react-webapp");
 const koaRouter = require("koa-router")();
 
+const HTTP_OK = 200;
+const HTTP_NOT_FOUND = 404;
 const HTTP_REDIRECT = 302;
 
 const registerRoutes = (app, options, next) => {
@@ -34,12 +36,29 @@ const registerRoutes = (app, options, next) => {
               this.body = data; //eslint-disable-line
             };
 
+            // Respond with explicitly set status
+            const respondWithStatus = (data) => {
+              this.status = data.status; //eslint-disable-line
+              this.body = data.content; //eslint-disable-line
+            };
+
             const handleStatus = data => {
               const status = data.status;
-              if (status === HTTP_REDIRECT) {
-                this.redirect(data.path); //eslint-disable-line
-              } else {
-                respond({ message: "error" });
+
+              // Handle Different Status Codes differently
+              switch (status) {
+                case HTTP_OK:
+                  respond(data.content);
+                  break;
+                case HTTP_NOT_FOUND:
+                  respondWithStatus(data);
+                  break;
+                case HTTP_REDIRECT:
+                  this.redirect(data.path); //eslint-disable-line
+                  break;
+                default:
+                  respond({ message: "error" });
+                  break;
               }
             };
 

--- a/packages/electrode-react-webapp/lib/react-webapp.js
+++ b/packages/electrode-react-webapp/lib/react-webapp.js
@@ -155,8 +155,7 @@ function makeRouteHandler(routeOptions, userContent) {
 
     const renderPage = content => {
       const helmet = Helmet.renderStatic();
-
-      return html.replace(/{{[A-Z_]*}}/g, m => {
+      const contentReplaced = html.replace(/{{[A-Z_]*}}/g, m => {
         switch (m) {
           case CONTENT_MARKER:
             return content.html || "";
@@ -176,6 +175,17 @@ function makeRouteHandler(routeOptions, userContent) {
             return `Unknown marker ${m}`;
         }
       });
+
+      /**
+       * If the response sent from the ssr redux render,
+       * changes the status code (e.g.: from 200 to 404),
+       * this information, should still be preserved for
+       * the node server to set status headers correctly
+       */
+      return {
+        status: content.status,
+        content: contentReplaced
+      };
     };
 
     const renderSSRContent = content => {

--- a/packages/electrode-react-webapp/package.json
+++ b/packages/electrode-react-webapp/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "bluebird": "^3",
     "hoek": "^3.0.1",
+    "http-status-codes": "^1.3.0",
     "in-publish": "^2.0.0",
     "koa-router": "^5.4.0",
     "lodash": "^4.0.0",


### PR DESCRIPTION
# Logic for keeping Status Codes

## Introduction
The current ssr logic, provides no clear hook, how to set status codes headers. 

Let's say for example I have an application, that manages a book collection, with a single books route `/books/:name`. Let's say this route handles the display of the book with the given name, by fetching the book via redux. If the book is found, it displays Details and the http status 200, that is sent from the node server is ok. However if the book isn't found, currently we would still have an http status of 200 even though in the app we might display a 404 error message.

## Proposal
In the index-view.js of the application, we currently can prefetch data. Even now it wouldn't be too difficult to hook into the promise chain of the `app.routesEngine.render(req)` command at the end, and update the status code by checking the prefetched redux state. 

Consider this code example: 
```
const prefetchedStatePrefix = 'window.__PRELOADED_STATE__ = ';

const getPrefetchedState = state => JSON.parse(state.replace(prefetchedStatePrefix, '').replace(/;([^;]*)$/, '$1'));

const get404Response = res => ({
  ...res,
  status: 404,
});

module.exports = (req) => {
  const app = req.server && req.server.app || req.app;
  if (!app.routesEngine) {
    app.routesEngine = new ReduxRouterEngine({routes, createReduxStore});
  }

  // After the content was prefetched, check if book could be fetched, otherwise set 404 status
  return app.routesEngine.render(req)
    .then((res) => {
      const prefetchedState = getPrefetchedState(res.prefetch);
      if (!prefetchedState.books.wasNotFound) {
        return get404Response(res);
      }

      return res;
    });
};
```

Maybe in the future you could even provide a cleaner documented hook, to check for the content of the prefetch, but for now this would suffice. 

## Content of PR
I updated the content of the electrode-react-webapp package, to correctly use the status code of the prefetched ssr content, when sending the server response. 

## Tested

- hapi: tests are still running through without problems
- express: was tested manually in our application and behaves as expected

## Untested

- koa: I implemented this by looking at online documentation for koa and the current implementation. However I have no way of really testing this right now.  