### PR TITLE
[patch] Add CSS_MODULE_STYLUS_SUPPORT option

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/archetype.js
+++ b/packages/electrode-archetype-react-app-dev/config/archetype.js
@@ -15,6 +15,7 @@ const webpackConfigSpec = {
   devPort: { env: "WEBPACK_DEV_PORT", default: 2992 },
   testPort: { env: "WEBPACK_TEST_PORT", default: 3001 },
   https: { env: "WEBPACK_DEV_HTTPS", default: false },
+  cssModuleStylusSupport: { env: "CSS_MODULE_STYLUS_SUPPORT", default: false },
   enableBabelPolyfill: { env: "ENABLE_BABEL_POLYFILL", default: false },
   enableNodeSourcePlugin: { env: "ENABLE_NODESOURCE_PLUGIN", default: false },
   woffFontInlineLimit: { env: "WOFF_FONT_INLINE_LIMIT", default: 1000 }


### PR DESCRIPTION
Enabling css modules for stylus from user config has no effect.
```js
// "/archetype/config/index.js"
module.exports = {
  webpack: {
    cssModuleStylusSupport: true // has no effect
  }
};
```

This PR adds cssModulesStylusSupport to webpack config spec and allows to control this options from user config or env variables.