### PR TITLE
Fixed registerRoutes never resolving promise from express-server.js

### DIFF
--- a/packages/electrode-react-webapp/lib/express/index.js
+++ b/packages/electrode-react-webapp/lib/express/index.js
@@ -25,7 +25,7 @@ const handleRoute = (request, response, handler) => {
     .catch(err => response.status(err.status).send(err.message));
 };
 
-const registerRoutes = (app, options, next) => {
+const registerRoutes = (app, options, next = () => {}) => {
   const registerOptions = ReactWebapp.setupOptions(options);
 
   _.each(registerOptions.paths, (v, path) => {

--- a/packages/electrode-react-webapp/lib/express/index.js
+++ b/packages/electrode-react-webapp/lib/express/index.js
@@ -25,7 +25,7 @@ const handleRoute = (request, response, handler) => {
     .catch(err => response.status(err.status).send(err.message));
 };
 
-const registerRoutes = (app, options) => {
+const registerRoutes = (app, options, next) => {
   const registerOptions = ReactWebapp.setupOptions(options);
 
   _.each(registerOptions.paths, (v, path) => {
@@ -58,6 +58,9 @@ const registerRoutes = (app, options) => {
       app[method.toLowerCase()](path, (req, res) => handleRoute(req, res, routeHandler));
     });
   });
+
+  // resolve promise
+  next();
 };
 
 module.exports = registerRoutes;


### PR DESCRIPTION
# Bugfix for version 2.0.0 of electrode-react-webapp

When trying out the newest version of electrode-react-webapp with an express server, I noticed the promise chain in the electrodeServer configuration in express-server.js was never resolved, since you didn't call the supplied callback function. 