### PR TITLE
custom-404: allow for custom 404 responses

### DIFF
--- a/packages/electrode-react-webapp/lib/express/index.js
+++ b/packages/electrode-react-webapp/lib/express/index.js
@@ -19,7 +19,7 @@ const handleRoute = (request, response, handler) => {
       } else if (status >= 200 && status < 300) {
         response.send(data.html !== undefined ? data.html : data);
       } else {
-        response.status(status).send(data);
+        response.status(status).send(data.html !== undefined ? data.html : data);
       }
     })
     .catch(err => response.status(err.status).send(err.message));

--- a/packages/electrode-react-webapp/lib/hapi/index.js
+++ b/packages/electrode-react-webapp/lib/hapi/index.js
@@ -19,7 +19,7 @@ const handleRoute = (request, reply, handler) => {
       } else if (status >= 200 && status < 300) {
         reply(data.html !== undefined ? data.html : data);
       } else {
-        reply(data).code(status);
+        reply(data.html !== undefined ? data.html : data).code(status);
       }
     })
     .catch(err => {

--- a/packages/electrode-react-webapp/lib/koa/index.js
+++ b/packages/electrode-react-webapp/lib/koa/index.js
@@ -26,7 +26,7 @@ function handleRoute(handler) {
       } else if (status >= 200 && status < 300) {
         respond(status, data.html !== undefined ? data.html : data);
       } else {
-        respond(status, data);
+        respond(status, data.html !== undefined ? data.html : data);
       }
     })
     .catch(err => {

--- a/packages/electrode-react-webapp/lib/react-webapp.js
+++ b/packages/electrode-react-webapp/lib/react-webapp.js
@@ -137,7 +137,12 @@ function makeRouteHandler(routeOptions, userContent) {
         user: {}
       });
 
-      return renderer.render(context);
+      // return promise with status/html object if "status" was supplied
+      // from electrode-redux-router-engine
+      return renderer.render(context)
+        .then(renderedHtml => content.status !== undefined
+          ? { status: content.status, html: renderedHtml }
+          : renderedHtml);
     };
 
     if (typeof userContent === "function") {


### PR DESCRIPTION
**DO NOT MERGE**

This is code to start the conversation around custom 404 handling in https://github.com/electrode-io/electrode/issues/560.  It still needs additional work and tests.  See the issue for details.

##  Context
For SEO reasons, we need to be returning a custom 404 response from the server on routes that do not exist.  Currently, if you set a catch-all route in `routes.jsx` you will always get a 200 response from the server on routes that don't exist.  If you do not have a catch-all route set up for React Router, the server will return a 404 response in the form of a JSON object.

## Solution
This PR would allow for a `notFoundRoute` property to be passed to the options object in `ReduxRouterEngine` render method in the `index-view.jsx`.  Passing this property allows the server side 404's to use the 404 not found route in `routes.jsx`.  The code for enabling this works similar to this [stack overflow post](https://stackoverflow.com/questions/35524117/express-status-404-with-react-router).  This allows the server to respond to the browser with the 404 route specified in the `routes.jsx` file.

![screen shot 2017-09-21 at 8 05 46 am](https://user-images.githubusercontent.com/2547722/30700073-bea6926e-9ea3-11e7-9f23-20f810fbefc2.png)
![screen shot 2017-09-21 at 8 05 25 am](https://user-images.githubusercontent.com/2547722/30700071-bca9143c-9ea3-11e7-9ec1-b0ce8183f9ab.png)