### PR TITLE
added simple progress

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/webpack.config.test.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/webpack.config.test.js
@@ -10,7 +10,8 @@ const Path = require("path");
 function makeConfig() {
   const testProfile = {
     partials: {
-      "_sourcemaps-inline": { order: 10100 }
+      "_sourcemaps-inline": { order: 10100 },
+      "_simple-progress": {order: 10300}
     }
   };
 


### PR DESCRIPTION
This shows webpack build progress in the command line when running `clap test-frontend`.

It is nice because we want to display that webpack is building before our tests execute but we don't want the coverage displayed all the time.