### PR TITLE
[patch][bug] Fix CORS issue when running karma tests in `test-watch` and `test-watch-all`

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/test-base.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/test-base.js
@@ -14,7 +14,17 @@ module.exports = {
     noParse: [new RegExp(Path.normalize("node_modules/sinon/").replace(/\\/g, "\\\\"))]
   },
   devServer: {
-    stats: "errors-only" // only show errors
+    stats: "errors-only", // only show errors
+    /*
+     * Karma browsers and webpack are running on different ports, which introduces
+     * CORS issue.
+     * The following code allows karma launched browsers to access webpack
+     * bundle in `test-watch` and `test-watch-all` modes.
+     */
+    disableHostCheck: true,
+    headers: {
+      "Access-Control-Allow-Origin": "*"
+    }
   },
   // Enzyme depends jsdom and cheerio being global to render their DOM.
   externals: {


### PR DESCRIPTION
This PR fixes the [CORS issue](https://github.com/electrode-io/electrode/issues/102#issuecomment-332284482) when karma is running in `test-watch` and `test-watch-all` modes.

As the result of issue none of the test is running in watch mode. Mocha output:
`Chrome 60.0.3112 (Mac OS X 10.11.4): Executed 0 of 0 ERROR (0.041 secs / 0 secs)`.

