### PR TITLE
[patch] lock react 15 in generated app

### DIFF
--- a/packages/generator-electrode/generators/app/templates/_package.json
+++ b/packages/generator-electrode/generators/app/templates/_package.json
@@ -42,7 +42,9 @@
     "koa-static": "^2.0.0", <% } if (isPWA) { %>
     "react-notify-toast": "^0.1.3",<% } if (isAutoSSR) {%>
     "electrode-auto-ssr": "^1.0.0", <% } %>
-    "lodash": "^4.10.1"
+    "lodash": "^4.10.1",
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0"
   },
   "devDependencies": {
     "electrode-archetype-react-app-dev": "^3.0.0"


### PR DESCRIPTION
getting ready to enable React 16, which still has issues, so lock generated app to React 15.

Archetype will be major bump to avoid breaking existing apps that's not locked to React 15.