### PR TITLE
[minor] enable react 16

### DIFF
--- a/packages/electrode-react-webapp/package.json
+++ b/packages/electrode-react-webapp/package.json
@@ -42,9 +42,6 @@
     "lodash": "^4.0.0",
     "require-at": "^1.0.0"
   },
-  "peerDependencies": {
-    "react": "^15.3.1 || ^0.14.8"
-  },
   "devDependencies": {
     "benchmark": "^2.1.4",
     "electrode-archetype-njs-module-dev": "^2.1.0",
@@ -54,7 +51,7 @@
     "koa-router": "^5.4.0",
     "object-assign": "^4.1.0",
     "prettier": "^1.5.2",
-    "react": "^15.3.1 || ^0.14.8",
+    "react": "^15.3.1",
     "react-dom": "^15.6.1",
     "react-helmet": "^5.1.3",
     "superagent": "^1.8.5",


### PR DESCRIPTION
electrode-react-webapp doesn't really have dependence on react, so removing it from peerDependencies, and enabling react 16