### PR TITLE
[minor][bug] unable to launch sample program.

### DIFF
--- a/samples/stylus-sample/package.json
+++ b/samples/stylus-sample/package.json
@@ -41,7 +41,9 @@
     "electrode-redux-router-engine": "../../packages/electrode-redux-router-engine",
     "electrode-server": "^1.0.0",
     "electrode-static-paths": "^1.0.0",
-    "lodash": "^4.10.1"
+    "lodash": "^4.10.1",
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0"
   },
   "devDependencies": {
     "electrode-archetype-react-app-dev": "../../packages/electrode-archetype-react-app-dev"

--- a/samples/universal-material-ui/package.json
+++ b/samples/universal-material-ui/package.json
@@ -43,6 +43,8 @@
     "electrode-static-paths": "^1.0.0",
     "lodash": "^4.10.1",
     "material-ui": "^0.16.4",
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0",
     "react-tap-event-plugin": "^2.0.0"
   },
   "devDependencies": {

--- a/samples/universal-react-node/package.json
+++ b/samples/universal-react-node/package.json
@@ -42,6 +42,8 @@
     "es6-promise": "^4.0.5",
     "isomorphic-fetch": "^2.2.1",
     "mongojs": "^2.4.0",
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0",
     "react-notify-toast": "^0.1.3",
     "uuid": "^3.0.1"
   },


### PR DESCRIPTION
stylus-sample, universal-material-ui and universal-react-node are not able to launch without having explicit dependencies of react/react-dom.