### PR TITLE
[minor][feat] implement dynamic code splitting

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/babel/babelrc-client
+++ b/packages/electrode-archetype-react-app-dev/config/babel/babelrc-client
@@ -48,7 +48,8 @@
     ],
     "transform-node-env-inline",
     "lodash",
-    "transform-runtime"
+    "transform-runtime",
+    "syntax-dynamic-import"
   ],
   "env": {
     "production": {

--- a/packages/electrode-archetype-react-app-dev/package.json
+++ b/packages/electrode-archetype-react-app-dev/package.json
@@ -25,6 +25,7 @@
     "babel-core": "^6.4.0",
     "babel-eslint": "^7.0.0",
     "babel-loader": "^7.0.0",
+    "babel-plugin-dynamic-import-node": "^1.1.0",
     "babel-plugin-i18n-id-hashing": "^2.1.0",
     "babel-plugin-lodash": "^3.1.3",
     "babel-plugin-minify-dead-code-elimination": "^0.1.7",

--- a/packages/electrode-archetype-react-app/arch-clap.js
+++ b/packages/electrode-archetype-react-app/arch-clap.js
@@ -410,7 +410,7 @@ Individual .babelrc files were generated for you in src/client and src/server
       desc: false,
       dep: [".clean.lib:client", ".mk.lib.client.dir", ".build.client.babelrc"],
       task: mkCmd(
-        `babel`,
+        `babel --plugins dynamic-import-node`,
         `--source-maps=inline --copy-files --out-dir ${AppMode.lib.client}`,
         `${AppMode.src.client}`
       )
@@ -572,7 +572,7 @@ Individual .babelrc files were generated for you in src/client and src/server
           .map(n => `--watch ${n}`)
           .join(" ");
         AppMode.setEnv(AppMode.src.dir);
-        const node = AppMode.isSrc ? `babel-node` : "node";
+        const node = AppMode.isSrc ? `babel-node --plugins dynamic-import-node` : "node";
         const serverIndex = Path.join(AppMode.src.server, "index.js");
         return exec(
           `nodemon`,

--- a/packages/electrode-archetype-react-app/config/babel/.babelrc
+++ b/packages/electrode-archetype-react-app/config/babel/.babelrc
@@ -48,7 +48,8 @@
     ],
     "transform-node-env-inline",
     "lodash",
-    "transform-runtime"
+    "transform-runtime",
+    "syntax-dynamic-import"
   ],
   "env": {
     "production": {


### PR DESCRIPTION
Incorporated babel plugin [babel-plugin-dynamic-import-node](https://github.com/airbnb/babel-plugin-dynamic-import-node) to support [dynamic code splitting](https://webpack.js.org/guides/code-splitting/#dynamic-imports).

Added a sample code of lazy loading practice, the example was taken from [Lazy loading Guide](https://webpack.js.org/guides/lazy-loading/).