### PR TITLE
Default reporter socket port from env

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/archetype.js
+++ b/packages/electrode-archetype-react-app-dev/config/archetype.js
@@ -14,6 +14,7 @@ const webpackConfigSpec = {
   devHostname: { env: ["WEBPACK_HOST", "WEBPACK_DEV_HOST"], default: "localhost" },
   devPort: { env: "WEBPACK_DEV_PORT", default: 2992 },
   testPort: { env: "WEBPACK_TEST_PORT", default: 3001 },
+  reporterSocketPort: { env: "WEBPACK_REPORTER_SOCKET_PORT", default: 5000 },
   https: { env: "WEBPACK_DEV_HTTPS", default: false },
   cssModuleStylusSupport: { env: "CSS_MODULE_STYLUS_SUPPORT", default: false },
   enableBabelPolyfill: { env: "ENABLE_BABEL_POLYFILL", default: false },

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/html-reporter.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/html-reporter.js
@@ -1,11 +1,12 @@
 "use strict";
 
+const archetype = require("electrode-archetype-react-app/config/archetype");
 const notifyBundleValid = require("../util/notify-bundle-valid");
 const WebpackReporter = require("electrode-webpack-reporter");
 
 module.exports = function(options) {
   if (!process.env.HTML_WEBPACK_REPORTER_OFF) {
-    const reporter = new WebpackReporter();
+    const reporter = new WebpackReporter({socketPort: archetype.webpack.reporterSocketPort});
 
     reporter.apply(options.currentConfig);
     reporter.on("report", reporterOptions => {

--- a/packages/electrode-webpack-reporter/lib/webpack-reporter.js
+++ b/packages/electrode-webpack-reporter/lib/webpack-reporter.js
@@ -22,12 +22,13 @@ function removeCwd(s) {
 
 const optionalRequire = require("optional-require")(require);
 const reporterStats = optionalRequire("../dist/server/stats.json");
+const defaultSocketPort = process.env.WEBPACK_REPORTER_SOCKET_PORT || 5000;
 
 class WebpackReporter extends EventEmitter {
   constructor(options) {
     super();
 
-    this.options = _.defaults({}, options, { socketPort: 5000 });
+    this.options = _.defaults({}, options, { socketPort: defaultSocketPort });
 
     if (reporterStats) {
       //

--- a/packages/electrode-webpack-reporter/lib/webpack-reporter.js
+++ b/packages/electrode-webpack-reporter/lib/webpack-reporter.js
@@ -22,13 +22,12 @@ function removeCwd(s) {
 
 const optionalRequire = require("optional-require")(require);
 const reporterStats = optionalRequire("../dist/server/stats.json");
-const defaultSocketPort = process.env.WEBPACK_REPORTER_SOCKET_PORT || 5000;
 
 class WebpackReporter extends EventEmitter {
   constructor(options) {
     super();
 
-    this.options = _.defaults({}, options, { socketPort: defaultSocketPort });
+    this.options = _.defaults({}, options, { socketPort: 5000 });
 
     if (reporterStats) {
       //


### PR DESCRIPTION
# Override standard reporter socket port

Since we are currently running multiple electrode apps in our dev environment, we run into a conflict, since the Webpack Reporter always uses the same standard port. This PR introduces a new environment variable called WEBPACK_REPORTER_SOCKET_PORT, that can be used to override the standard port 5000. 