### PR TITLE
[bug] set compilerPhase to emit to make sure css split happens after optimization

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract-style.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract-style.js
@@ -99,7 +99,11 @@ module.exports = function() {
     module: { rules },
     plugins: [
       new ExtractTextPlugin({ filename: "[name].style.[hash].css" }),
-      process.env.NODE_ENV === "production" && new OptimizeCssAssetsPlugin(),
+      process.env.NODE_ENV === "production" && new OptimizeCssAssetsPlugin({
+        cssProcessorOptions: {
+          safe: true
+        }
+      }),
 
       /*
        preserve: default: false. Keep the original unsplit file as well.

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract-style.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract-style.js
@@ -99,18 +99,13 @@ module.exports = function() {
     module: { rules },
     plugins: [
       new ExtractTextPlugin({ filename: "[name].style.[hash].css" }),
-      process.env.NODE_ENV === "production" && new OptimizeCssAssetsPlugin({
-        cssProcessorOptions: {
-          safe: true
-        }
-      }),
-
+      process.env.NODE_ENV === "production" && new OptimizeCssAssetsPlugin(),
       /*
        preserve: default: false. Keep the original unsplit file as well.
        Sometimes this is desirable if you want to target a specific browser (IE)
        with the split files and then serve the unsplit ones to everyone else.
        */
-      new CSSSplitPlugin({ size: 4000, imports: true, preserve: true }),
+      new CSSSplitPlugin({ size: 4000, imports: true, preserve: true, compilerPhase: "emit" }),
       new webpack.LoaderOptionsPlugin({
         options: {
           context: Path.resolve(process.cwd(), "src"),

--- a/packages/electrode-archetype-react-app-dev/package.json
+++ b/packages/electrode-archetype-react-app-dev/package.json
@@ -85,7 +85,7 @@
     "mocha": "^4.0.0",
     "nodemon": "^1.8.1",
     "offline-plugin": "^4.6.1",
-    "optimize-css-assets-webpack-plugin": "^1.3.2",
+    "optimize-css-assets-webpack-plugin": "^3.2.0",
     "optional-require": "^1.0.0",
     "penthouse": "^0.11.13",
     "phantomjs-prebuilt": "^2.1.13",


### PR DESCRIPTION
- update css optimization plugin to the latest
- update archetype app based on latest css split webpack plugin
