### PR TITLE
[patch] enable defer based on latest css-split-webpack-plugin

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract-style.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract-style.js
@@ -105,7 +105,12 @@ module.exports = function() {
        Sometimes this is desirable if you want to target a specific browser (IE)
        with the split files and then serve the unsplit ones to everyone else.
        */
-      new CSSSplitPlugin({ size: 4000, imports: true, preserve: true, compilerPhase: "emit" }),
+      new CSSSplitPlugin({
+        size: 4000,
+        imports: true,
+        preserve: true,
+        defer: true
+      }),
       new webpack.LoaderOptionsPlugin({
         options: {
           context: Path.resolve(process.cwd(), "src"),


### PR DESCRIPTION
enable defer for deferring css split after optimization.