### PR TITLE
[patch] Few fixes for new electrode component

### DIFF
--- a/packages/electrode-archetype-react-component-dev/package.json
+++ b/packages/electrode-archetype-react-component-dev/package.json
@@ -40,7 +40,7 @@
     "electrode-docgen": "^1.0.0",
     "enzyme": "^2.3.0",
     "eslint": "^4.4.1",
-    "eslint-config-walmart": "^1.1.0",
+    "eslint-config-walmart": "^2.0.0",
     "eslint-plugin-filenames": "^1.1.0",
     "eslint-plugin-react": "^7.4.0",
     "file-loader": "^0.8.4",

--- a/packages/generator-electrode/component/templates/demo-app/archetype/config/webpack/component-alias.config.js
+++ b/packages/generator-electrode/component/templates/demo-app/archetype/config/webpack/component-alias.config.js
@@ -15,10 +15,11 @@ const config = {
   }
 };
 
-components.forEach(name => {
-  config.resolve.alias[name] = Path.join(repoPackagesDir, name, "src");
-  config.resolve.modules.push(Path.join(repoPackagesDir, name));
-  config.resolve.modules.push(Path.join(repoPackagesDir, name, "node_modules"));
+components.forEach(folderName => {
+  const packageName = require(Path.join(repoPackagesDir, folderName, "package.json")).name;
+  config.resolve.alias[packageName] = Path.join(repoPackagesDir, folderName, "src");
+  config.resolve.modules.push(Path.join(repoPackagesDir, folderName));
+  config.resolve.modules.push(Path.join(repoPackagesDir, folderName, "node_modules"));
 });
 
 module.exports = config;

--- a/packages/generator-electrode/component/templates/packages/component/src/styles/_component.css
+++ b/packages/generator-electrode/component/templates/packages/component/src/styles/_component.css
@@ -4,6 +4,7 @@
   font-family: "Raleway", "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
   margin: 0 auto;
   text-align: center;
+  width: 70%;
 }
 
 .container hr {

--- a/packages/generator-electrode/component/templates/packages/component/test/client/components/helpers/_intlEnzymeTestHelper.js
+++ b/packages/generator-electrode/component/templates/packages/component/test/client/components/helpers/_intlEnzymeTestHelper.js
@@ -19,11 +19,11 @@ const { intl } = intlProvider.getChildContext();
 /*
   When using React-Intl `injectIntl` on components, props.intl is required.
 */
-const nodeWithIntlProp = (node) => {
+const nodeWithIntlProp = node => {
   return React.cloneElement(node, { intl });
 };
 
-const shallowWithIntl = (node) => {
+const shallowWithIntl = node => {
   return shallow(
     nodeWithIntlProp(node),
     {
@@ -32,7 +32,7 @@ const shallowWithIntl = (node) => {
   );
 };
 
-const mountWithIntl = (node) => {
+const mountWithIntl = node => {
   return mount(
     nodeWithIntlProp(node),
     {


### PR DESCRIPTION
Fixes for new electrode component:
- Fix the issue when updating the package name in `package/[componentName]/package.json`, webpack hot reload will not work.
- update `eslint-config-walmart` to 2.0.0 for `jsx-wrap-multilines` rule (Need a new patch release for https://github.com/walmartlabs/eslint-config-walmart)
- minor fixes for UI (currently the accordion is too wide)
- fixes for component `clap test` eslint errors