### PR TITLE
[bug] upgrade babel-eslint

### DIFF
--- a/packages/electrode-archetype-react-app-dev/package.json
+++ b/packages/electrode-archetype-react-app-dev/package.json
@@ -23,7 +23,7 @@
     "autoprefixer-stylus": "^0.9.1",
     "babel-cli": "^6.4.5",
     "babel-core": "^6.4.0",
-    "babel-eslint": "^7.0.0",
+    "babel-eslint": "^8.1.2",
     "babel-loader": "^7.0.0",
     "babel-plugin-i18n-id-hashing": "^2.1.0",
     "babel-plugin-lodash": "^3.1.3",


### PR DESCRIPTION
Seeing an issue on Home app running with archetype app in current master.

```
TypeError: Cannot read property 'type' of undefined
```

To resolve the issue, we need to upgrade to the latest `babel-eslint`.
Related link: https://github.com/eslint/eslint/issues/9767
