### PR TITLE
[patch] resolve check dependencies warnings

### DIFF
--- a/packages/electrode-archetype-react-component-dev/config/dependencies/check.json
+++ b/packages/electrode-archetype-react-component-dev/config/dependencies/check.json
@@ -10,6 +10,8 @@
     "react": "^15.2.0",
     "react-dom": "^15.2.0",
     "react-hot-loader": "^1.3.0",
-    "react-intl": "^2.1.3"
+    "react-intl": "^2.1.3",
+    "material-ui": "^0.20.0",
+    "electrode-demo-index": "^2.0.0"
   }
 }


### PR DESCRIPTION
Resolve below warnings for component archetype
```
Check dependencies failed.
These dependencies are not expected:
    - material-ui: version: "^0.20.0"
    - electrode-demo-index: version: "^2.0.0"
```