### PR TITLE
Support webpack chunks (css)

### DIFF
--- a/packages/electrode-react-webapp/lib/default-handlers.js
+++ b/packages/electrode-react-webapp/lib/default-handlers.js
@@ -62,11 +62,16 @@ module.exports = function setup(options) {
       const data = context.$.data;
       const manifest = bundleManifest();
       const manifestLink = manifest ? `<link rel="manifest" href="${manifest}" />\n` : "";
-      const css = WEBPACK_DEV
-        ? (!Array.isArray(data.devCSSBundle) && [data.devCSSBundle]) || data.devCSSBundle
-        : data.cssChunk
-          ? (!Array.isArray(data.cssChunk) && [data.cssChunk]) || data.cssChunk
-          : [""];
+      const css = [];
+
+      if (WEBPACK_DEV) {
+        if (Array.isArray(data.devCSSBundle)) css.push(...data.devCSSBundle);
+        else if (data.devCSSBundle) css.push(data.devCSSBundle);
+      }
+      else if (Array.isArray(data.cssChunk)) {
+        css.push(...data.cssChunk);
+      }
+      else if (data.cssChunk) css.push(data.cssChunk);
 
       const cssLink = css.reduce((acc, file) => {
         acc += `<link rel="stylesheet" href="${

--- a/packages/electrode-react-webapp/lib/default-handlers.js
+++ b/packages/electrode-react-webapp/lib/default-handlers.js
@@ -62,14 +62,11 @@ module.exports = function setup(options) {
       const data = context.$.data;
       const manifest = bundleManifest();
       const manifestLink = manifest ? `<link rel="manifest" href="${manifest}" />\n` : "";
-      const css = [];
+      let css = [];
 
-      if (WEBPACK_DEV) {
-        if (Array.isArray(data.devCSSBundle)) css.push(...data.devCSSBundle);
-        else if (data.devCSSBundle) css.push(data.devCSSBundle);
-      } else if (Array.isArray(data.cssChunk)) {
-        css.push(...data.cssChunk);
-      } else if (data.cssChunk) css.push(data.cssChunk);
+      if (data.criticalCSS); // leave css as empty array (reduce will turn it into an empty string)
+      else if (WEBPACK_DEV) css = css.concat(data.devCSSBundle);
+      else css = css.concat(data.cssChunk);
 
       const cssLink = css.reduce((acc, file) => {
         acc += `<link rel="stylesheet" href="${

--- a/packages/electrode-react-webapp/lib/default-handlers.js
+++ b/packages/electrode-react-webapp/lib/default-handlers.js
@@ -67,11 +67,9 @@ module.exports = function setup(options) {
       if (WEBPACK_DEV) {
         if (Array.isArray(data.devCSSBundle)) css.push(...data.devCSSBundle);
         else if (data.devCSSBundle) css.push(data.devCSSBundle);
-      }
-      else if (Array.isArray(data.cssChunk)) {
+      } else if (Array.isArray(data.cssChunk)) {
         css.push(...data.cssChunk);
-      }
-      else if (data.cssChunk) css.push(data.cssChunk);
+      } else if (data.cssChunk) css.push(data.cssChunk);
 
       const cssLink = css.reduce((acc, file) => {
         acc += `<link rel="stylesheet" href="${

--- a/packages/electrode-react-webapp/lib/default-handlers.js
+++ b/packages/electrode-react-webapp/lib/default-handlers.js
@@ -62,11 +62,9 @@ module.exports = function setup(options) {
       const data = context.$.data;
       const manifest = bundleManifest();
       const manifestLink = manifest ? `<link rel="manifest" href="${manifest}" />\n` : "";
-      let css = [];
-
-      if (data.criticalCSS); // leave css as empty array (reduce will turn it into an empty string)
-      else if (WEBPACK_DEV) css = css.concat(data.devCSSBundle);
-      else css = css.concat(data.cssChunk);
+      const css = WEBPACK_DEV
+        ? Array.prototype.concat(data.devCSSBundle)
+        : Array.prototype.concat(data.cssChunk);
 
       const cssLink = css.reduce((acc, file) => {
         acc += `<link rel="stylesheet" href="${

--- a/packages/electrode-react-webapp/lib/default-handlers.js
+++ b/packages/electrode-react-webapp/lib/default-handlers.js
@@ -63,9 +63,19 @@ module.exports = function setup(options) {
       const manifest = bundleManifest();
       const manifestLink = manifest ? `<link rel="manifest" href="${manifest}" />\n` : "";
       const css = WEBPACK_DEV
-        ? data.devCSSBundle
-        : (data.cssChunk && `${prodBundleBase}${data.cssChunk.name}`) || "";
-      const cssLink = css && !data.criticalCSS ? `<link rel="stylesheet" href="${css}" />` : "";
+        ? (!Array.isArray(data.devCSSBundle) && [data.devCSSBundle]) || data.devCSSBundle
+        : data.cssChunk
+          ? (!Array.isArray(data.cssChunk) && [data.cssChunk]) || data.cssChunk
+          : [""];
+
+      const cssLink = css.reduce((acc, file) => {
+        acc += `<link rel="stylesheet" href="${
+          WEBPACK_DEV
+            ? file
+            : prodBundleBase + file.name
+        }" />`;
+        return acc;
+      }, '');
 
       const htmlScripts = htmlifyScripts(
         groupScripts(routeOptions.unbundledJS.enterHead).scripts,

--- a/packages/electrode-react-webapp/lib/default-handlers.js
+++ b/packages/electrode-react-webapp/lib/default-handlers.js
@@ -75,7 +75,7 @@ module.exports = function setup(options) {
             : prodBundleBase + file.name
         }" />`;
         return acc;
-      }, '');
+      }, "");
 
       const htmlScripts = htmlifyScripts(
         groupScripts(routeOptions.unbundledJS.enterHead).scripts,

--- a/packages/electrode-react-webapp/lib/react-webapp.js
+++ b/packages/electrode-react-webapp/lib/react-webapp.js
@@ -116,18 +116,10 @@ function makeRouteHandler(routeOptions, userContent) {
         );
       } else devCSSBundle = [`${devBundleBase}style.css`];
 
-      let devJSBundle;
-      if (chunkNames.js) {
-        const jsChunks = Array.isArray(chunkNames.js)
-          ? chunkNames.js
-          : [ chunkNames.js ];
-        devJSBundle = _.map(
-          jsChunks,
-          (chunkName) => `${devBundleBase}${chunkName}.bundle.dev.js`
-        );
-      } else devJSBundle = [`${devBundleBase}bundle.dev.js`];
-
-      const jsChunk = assets.js;
+      const devJSBundle = chunkNames.js
+        ? `${devBundleBase}${chunkNames.js}.bundle.dev.js`
+        : `${devBundleBase}bundle.dev.js`;
+      const jsChunk = _.find(assets.js, asset => _.includes(asset.chunkNames, chunkNames.js));
       const cssChunk = assets.css;
       const scriptNonce = cspScriptNonce ? ` nonce="${cspScriptNonce}"` : "";
       const styleNonce = cspStyleNonce ? ` nonce="${cspStyleNonce}"` : "";

--- a/packages/electrode-react-webapp/lib/react-webapp.js
+++ b/packages/electrode-react-webapp/lib/react-webapp.js
@@ -120,7 +120,11 @@ function makeRouteHandler(routeOptions, userContent) {
         ? `${devBundleBase}${chunkNames.js}.bundle.dev.js`
         : `${devBundleBase}bundle.dev.js`;
       const jsChunk = _.find(assets.js, asset => _.includes(asset.chunkNames, chunkNames.js));
-      const cssChunk = assets.css;
+      const cssChunk = _.filter(assets.css,
+        asset => _.some(asset.chunkNames,
+          assetChunkName => _.includes(chunkNames.css, assetChunkName)
+        )
+      );
       const scriptNonce = cspScriptNonce ? ` nonce="${cspScriptNonce}"` : "";
       const styleNonce = cspStyleNonce ? ` nonce="${cspStyleNonce}"` : "";
 

--- a/packages/electrode-react-webapp/lib/react-webapp.js
+++ b/packages/electrode-react-webapp/lib/react-webapp.js
@@ -104,14 +104,31 @@ function makeRouteHandler(routeOptions, userContent) {
       }
 
       const chunkNames = chunkSelector(request);
-      const devCSSBundle = chunkNames.css
-        ? `${devBundleBase}${chunkNames.css}.style.css`
-        : `${devBundleBase}style.css`;
-      const devJSBundle = chunkNames.js
-        ? `${devBundleBase}${chunkNames.js}.bundle.dev.js`
-        : `${devBundleBase}bundle.dev.js`;
-      const jsChunk = _.find(assets.js, asset => _.includes(asset.chunkNames, chunkNames.js));
-      const cssChunk = _.find(assets.css, asset => _.includes(asset.chunkNames, chunkNames.css));
+
+      let devCSSBundle;
+      if (chunkNames.css) {
+        const cssChunks = Array.isArray(chunkNames.css)
+          ? chunkNames.css
+          : [ chunkNames.css ];
+        devCSSBundle = _.map(
+          cssChunks,
+          (chunkName) => `${devBundleBase}${chunkName}.style.css`
+        );
+      } else devCSSBundle = [`${devBundleBase}style.css`];
+
+      let devJSBundle;
+      if (chunkNames.js) {
+        const jsChunks = Array.isArray(chunkNames.js)
+          ? chunkNames.js
+          : [ chunkNames.js ];
+        devJSBundle = _.map(
+          jsChunks,
+          (chunkName) => `${devBundleBase}${chunkName}.bundle.dev.js`
+        );
+      } else devJSBundle = [`${devBundleBase}bundle.dev.js`];
+
+      const jsChunk = assets.js;
+      const cssChunk = assets.css;
       const scriptNonce = cspScriptNonce ? ` nonce="${cspScriptNonce}"` : "";
       const styleNonce = cspStyleNonce ? ` nonce="${cspStyleNonce}"` : "";
 

--- a/packages/electrode-react-webapp/test/data/chunk-selector.js
+++ b/packages/electrode-react-webapp/test/data/chunk-selector.js
@@ -12,12 +12,21 @@ const DEFAULT_BUNDLE = {
   css: "home",
   js: "home"
 };
+const MULTI_BUNDLE = {
+  css: [
+    "foo",
+    "bar"
+  ],
+  js: "home"
+};
 
 module.exports = request => {
   if (request.path.endsWith("/foo")) {
     return FOO_BUNDLE;
   } else if (request.path.endsWith("/bar")) {
     return BAR_BUNDLE;
+  } else if (request.path.endsWith("/multi-chunk")) {
+    return MULTI_BUNDLE;
   } else if (request.path.endsWith("/empty")) {
     return {};
   }

--- a/packages/electrode-react-webapp/test/spec/hapi.index.spec.js
+++ b/packages/electrode-react-webapp/test/spec/hapi.index.spec.js
@@ -226,6 +226,55 @@ describe("hapi electrode-react-webapp", () => {
     });
   });
 
+  it("should handle multiple entry points - multi-chunk", () => {
+    configOptions.bundleChunkSelector = "test/data/chunk-selector.js";
+    configOptions.stats = "test/data/stats-test-multibundle.json";
+
+    return electrodeServer(config).then(server => {
+      return server
+        .inject({
+          method: "GET",
+          url: "/multi-chunk"
+        })
+        .then(res => {
+          expect(res.statusCode).to.equal(200);
+          expect(res.result).to.contain("foo.style.f07a873ce87fc904a6a5.css");
+          expect(res.result).to.contain("bar.style.f07a873ce87fc904a6a5.css");
+          expect(res.result).to.contain("home.bundle.f07a873ce87fc904a6a5.js");
+          stopServer(server);
+        })
+        .catch(err => {
+          stopServer(server);
+          throw err;
+        });
+    });
+  });
+
+  it("should handle multiple entry points - @dev multi-chunk", () => {
+    configOptions.bundleChunkSelector = "test/data/chunk-selector.js";
+    configOptions.stats = "test/data/stats-test-multibundle.json";
+
+    process.env.WEBPACK_DEV = "true";
+    return electrodeServer(config).then(server => {
+      return server
+        .inject({
+          method: "GET",
+          url: "/multi-chunk"
+        })
+        .then(res => {
+          expect(res.statusCode).to.equal(200);
+            expect(res.result).to.contain("http://127.0.0.1:2992/js/foo.style.css");
+            expect(res.result).to.contain("http://127.0.0.1:2992/js/bar.style.css");
+            expect(res.result).to.contain("http://127.0.0.1:2992/js/bundle.dev.js");
+          stopServer(server);
+        })
+        .catch(err => {
+          stopServer(server);
+          throw err;
+        });
+    });
+  });
+
   it("should handle multiple entry points - @dev @empty", () => {
     configOptions.bundleChunkSelector = "test/data/chunk-selector.js";
     configOptions.stats = "test/data/stats-test-multibundle.json";

--- a/packages/electrode-react-webapp/test/spec/hapi.index.spec.js
+++ b/packages/electrode-react-webapp/test/spec/hapi.index.spec.js
@@ -265,7 +265,7 @@ describe("hapi electrode-react-webapp", () => {
           expect(res.statusCode).to.equal(200);
             expect(res.result).to.contain("http://127.0.0.1:2992/js/foo.style.css");
             expect(res.result).to.contain("http://127.0.0.1:2992/js/bar.style.css");
-            expect(res.result).to.contain("http://127.0.0.1:2992/js/bundle.dev.js");
+            expect(res.result).to.contain("http://127.0.0.1:2992/js/home.bundle.dev.js");
           stopServer(server);
         })
         .catch(err => {


### PR DESCRIPTION
The app using chunks will need to implement the following to use this.

### Dev
```js
// /config/utils/chunk-selector.js
module.exports = () => ({
    css: [
        'app',
        'third-party-something',
    ],
    js: 'app',
});
```

```js
// /config/default.js

module.exports = {
    // …
    webapp: {
        // …
            options: {
                bundleChunkSelector: path.resolve(__dirname, './utils/chunk-selector'),
```

### Prod

```js
// /archetype/config/webpack/webpack.config.base.js
const appOverrides = {
    // …
    entry: {
        app: [
            'babel-polyfill',
            // ^ electrode-archetype-react-app-dev/config/webpack/partial/entry.js#L37
            path.resolve(appSrc.client, 'app.jsx')
        ],
        'third-party-something': path.resolve(appSrc.client, 'path/to/file'),
    },
};

const customMerger = (a, b) => {
    return (Array.isArray(a) && Array.isArray(b))
        ? [].concat(a).concat(b)
        : undefined;
};

module.exports = function webpackConfigBuilder(envOverrides = {}) {
    return function overrideElectrodeWebapp(composer, options, compose) {
        // this might be overkill (could probably just return the merge?)

        // …

        const config = compose();

        _.mergeWith(
            config,
            appOverrides,
            envOverrides,
            customMerger
        );
    };
};
```

```js
// /archetype/config/webpack/webpack.config.dev.js

const baseWebPack = require('./webpack.config.base');

module.exports = baseWebPack({
    devtool: '#cheap-module-eval-source-map'
});
```

---

I verified this against my own app using semantic-ui-less and react-semantic-ui. The following scenarios worked:
* Dev mode
  * a single value for `css` in chunkSelector
  * an array of 2 values for `css` in chunkSelector
* Prod mode
  * a single key-value pair within `entry` (webpack.config.base)
  * a second key-value pair within `entry` (webpack.config.base

I couldn't hook this up directly to webpack would creating a breaking change with implementers who are relying on the man-in-the-middle. So I think this is the next best and unblocks more functionality already available from webpack.

resolves #708 