### PR TITLE
enable cors to debug unit tests

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/karma/karma.conf.watch.js
+++ b/packages/electrode-archetype-react-app-dev/config/karma/karma.conf.watch.js
@@ -13,6 +13,7 @@ const Path = require("path");
 module.exports = function(config) {
   dev(config);
   const settings = {
+    crossOriginAttribute: false,
     files: [
       // Test bundle (must be created via `npm run dev|hot|server-test`)
       "http://127.0.0.1:3001/assets/bundle.js"


### PR DESCRIPTION
When running `clap test-watch-all`, Chrome has no access to webpack due to a CORS failure.