### PR TITLE
[patch] resolve warnings

### DIFF
--- a/packages/electrode-archetype-react-component-dev/package.json
+++ b/packages/electrode-archetype-react-component-dev/package.json
@@ -59,7 +59,7 @@
     "karma-ie-launcher": "^1.0.0",
     "karma-intl-shim": "^1.0.0",
     "karma-mocha": "^0.2.0",
-    "karma-mocha-reporter": "^1.1.1",
+    "karma-mocha-reporter": "^2.0.0",
     "karma-phantomjs-launcher": "^1.0.2",
     "karma-phantomjs-shim": "^1.0.0",
     "karma-safari-launcher": "^0.1.1",


### PR DESCRIPTION
before:
> WARN deprecated node-uuid@1.4.8 Use uuid module instead
> WARN deprecated nodemailer@2.7.2 All versions below 4.0.1 of Nodemailer are deprecated. See https://nodemailer.com/status/

after:
![screen shot 2018-02-13 at 12 14 51 pm](https://user-images.githubusercontent.com/10135897/36171540-e7676cf6-10b7-11e8-9bc0-8bfe4b80c110.png)
