### PR TITLE
[patch] add demo-component as dependency

### DIFF
--- a/samples/electrode-demo-index/package.json
+++ b/samples/electrode-demo-index/package.json
@@ -36,13 +36,11 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
+    "component-playground": "^3.0.0",
     "object-assign": "^4.1.0"
   },
   "devDependencies": {
     "electrode-archetype-react-component": "^5",
     "electrode-archetype-react-component-dev": "^5"
-  },
-  "peerDependencies": {
-    "component-playground": "*"
   }
 }


### PR DESCRIPTION
Inside index.js, we import `component-playground` as a direct usage here: https://github.com/didi0613/electrode/blob/9762bdc8c34fa7ac1e532ae77219d66aa8fdb55c/samples/electrode-demo-index/src/index.js#L4

We need `component-playground` as a dependency here.

Needs this one get merged first:
https://github.com/electrode-io/electrode/pull/733