### PR TITLE
[patch] optionalRequire archetype/config folder for component archetype

### DIFF
--- a/packages/electrode-archetype-react-component-dev/config/webpack/partial/extract-style.js
+++ b/packages/electrode-archetype-react-component-dev/config/webpack/partial/extract-style.js
@@ -17,12 +17,7 @@ const sassLoader = require.resolve("sass-loader");
 const demoAppPath = Path.resolve(process.cwd(), "..", "..", "demo-app");
 const archetypeAppPath = Path.resolve(demoAppPath, "archetype", "config");
 
-const archetypeApp = optionalRequire(archetypeAppPath) || {
-  webpack: {
-    cssModulesSupport: undefined,
-    cssModuleStylusSupport: undefined
-  }
-};
+const archetypeApp = optionalRequire(archetypeAppPath) || { webpack: {} };
 const archetypeAppWebpack = archetypeApp.webpack;
 let cssModuleSupport = archetypeAppWebpack.cssModuleSupport;
 const cssModuleStylusSupport = archetypeAppWebpack.cssModuleStylusSupport;

--- a/packages/electrode-archetype-react-component-dev/config/webpack/partial/extract-style.js
+++ b/packages/electrode-archetype-react-component-dev/config/webpack/partial/extract-style.js
@@ -2,6 +2,7 @@
 
 const Path = require("path");
 const glob = require("glob");
+const optionalRequire = require("optional-require")(require);
 
 const atImport = require("postcss-import");
 const cssnext = require("postcss-cssnext");
@@ -14,12 +15,15 @@ const stylusLoader = require.resolve("stylus-relative-loader");
 const sassLoader = require.resolve("sass-loader");
 
 const demoAppPath = Path.resolve(process.cwd(), "..", "..", "demo-app");
-const archetypeAppPath = Path.resolve(
-  demoAppPath,
-  "archetype",
-  "config"
-);
-const archetypeAppWebpack = require(archetypeAppPath).webpack;
+const archetypeAppPath = Path.resolve(demoAppPath, "archetype", "config");
+
+const archetypeApp = optionalRequire(archetypeAppPath) || {
+  webpack: {
+    cssModulesSupport: undefined,
+    cssModuleStylusSupport: undefined
+  }
+};
+const archetypeAppWebpack = archetypeApp.webpack;
 let cssModuleSupport = archetypeAppWebpack.cssModuleSupport;
 const cssModuleStylusSupport = archetypeAppWebpack.cssModuleStylusSupport;
 
@@ -72,8 +76,8 @@ module.exports = function() {
       use: cssModuleSupport ? cssModuleQuery : cssQuery
     },
     {
-     test: /\.scss$/,
-     use: cssModuleSupport ? cssScssQuery : scssQuery
+      test: /\.scss$/,
+      use: cssModuleSupport ? cssScssQuery : scssQuery
     },
     {
       test: /\.styl$/,


### PR DESCRIPTION
Use `optionalRequire` for `archetype/config` folder, based on the `electrode-demo-index` instance. 

`electrode-demo-index` has no demo, its a template other components use for demo. the `archetype/config` is not a required folder and should have a default value for it.
Errors:
![screen shot 2018-02-26 at 2 33 49 pm](https://user-images.githubusercontent.com/10135897/36700918-26bd1092-1b06-11e8-813e-3c993511ec1c.png)

 