### PR TITLE
[patch] fix autoprefixer for ie10

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract-style.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract-style.js
@@ -125,15 +125,12 @@ module.exports = function() {
               : [];
           },
           stylus: {
-            use: () => {
-              return !cssModuleSupport
-                ? [
-                    autoprefixer({
-                      browsers: ["last 2 versions", "ie >= 9", "> 5%"]
-                    })
-                  ]
-                : [];
-            }
+            use: !cssModuleSupport ? [
+                autoprefixer({
+                  browsers: ["last 2 versions", "ie >= 9", "> 5%"]
+                })
+              ]
+            : []
           }
         }
       })


### PR DESCRIPTION
Request from newyork project home app.
For IE 10, we need auto-prefixer for transforming `display: flexbox` into `display: -ms-flexbox`
![screen shot 2018-03-05 at 9 38 56 pm](https://user-images.githubusercontent.com/10135897/37015754-da74a336-20bd-11e8-9b04-2265a83adb15.png)
