### PR TITLE
[donotmerge]add i18n to sample app

### DIFF
--- a/samples/universal-react-node/src/client/app.jsx
+++ b/samples/universal-react-node/src/client/app.jsx
@@ -10,6 +10,9 @@ import rootReducer from "./reducers";
 import DevTools from "./devtools";
 import updateStorage from "./middleware";
 
+import { I18nextProvider } from "react-i18next";
+import i18n from "electrode-archetype-react-app/i18next";
+
 require.ensure(["./sw-registration"], (require) => {
   require("./sw-registration")(notify);
 }, "sw-registration");
@@ -25,12 +28,15 @@ window.webappStart = () => {
   const initialState = window.__PRELOADED_STATE__;
   const store = createStore(rootReducer, initialState, enhancer);
   render(
+    <I18nextProvider i18n={ i18n }>
       <Provider store={store}>
         <div>
           <Router history={browserHistory}>{routes}</Router>
           <DevTools />
         </div>
-      </Provider>,
+       
+      </Provider>
+      </I18nextProvider>,
     document.querySelector(".js-content")
   );
 };

--- a/samples/universal-react-node/src/client/components/home.jsx
+++ b/samples/universal-react-node/src/client/components/home.jsx
@@ -4,11 +4,11 @@ import { connect } from "react-redux";
 import electrodeLogo from "../images/electrode.svg";
 import Notifications from "react-notify-toast";
 
+import i18n from "electrode-archetype-react-app/i18next";
+
 class HomeWrapper extends React.Component {
   render() {
-    return (
-      <Home data={this.props.data} />
-    );
+    return <Home data={this.props.data} />;
   }
 }
 
@@ -24,34 +24,62 @@ export class Home extends React.Component {
     return (
       <div>
         <Notifications />
-        <div style={{
-          width: "50%",
-          marginLeft: "auto",
-          marginRight: "auto"
-        }}>
-          <a href="https://github.com/electrode-io"> <img style={{
-            width: "100%"
-          }} alt={data.logo} src={data.electrodeLogo} />
+        <div
+          style={{
+            width: "50%",
+            marginLeft: "auto",
+            marginRight: "auto"
+          }}
+        >
+          <a href="https://github.com/electrode-io">
+            {" "}
+            <img
+              style={{
+                width: "100%"
+              }}
+              alt={data.logo}
+              src={data.electrodeLogo}
+            />
           </a>
         </div>
-        <h2>Demonstration Components</h2>
+        <h2>{i18n.t("title")}</h2>
         <ul>
-          <li><a href="/csrf">CSRF protection using electrode-csrf-jwt</a></li>
+          <li>
+            <a href="/csrf">
+              {i18n.t("CSRF protection using electrode-csrf-jwt")}
+            </a>
+          </li>
           <li>
             <a href="/above-the-fold?skip=true">
-              Above the Fold Render with skip=true - increase your App's performance by using a skip prop
+              {i18n.t("Above the Fold Render with skip=true")}
             </a>
           </li>
           <li>
             <a href="/above-the-fold?skip=false">
-              Above the Fold Render with skip=false - increase your App's performance by using a skip prop
+              {i18n.t("Above the Fold Render with skip=false")}
             </a>
           </li>
-          <li><a href="/ssrcachingsimpletype">SSR Caching Simple Type Example</a></li>
-          <li><a href="/ssrcachingtemplatetype">SSR Caching Template Type Example</a></li>
-          <li><a href="/push-notifications">Push Notifications Example</a></li>
-          <li><a href="/todo-app">Todo List Example</a></li>
-          <li><a href="/record-store">MongoDB Example</a></li>
+          <li>
+            <a href="/ssrcachingsimpletype">
+              {i18n.t("SSR Caching Simple Type Example")}
+            </a>
+          </li>
+          <li>
+            <a href="/ssrcachingtemplatetype">
+              {i18n.t("SSR Caching Template Type Example")}
+            </a>
+          </li>
+          <li>
+            <a href="/push-notifications">
+              {i18n.t("Push Notifications Example")}
+            </a>
+          </li>
+          <li>
+            <a href="/todo-app">{i18n.t("Todo List Example")}</a>
+          </li>
+          <li>
+            <a href="/record-store">{i18n.t("MongoDB Example")}</a>
+          </li>
         </ul>
         <p>{this.props.data}</p>
       </div>
@@ -63,10 +91,8 @@ Home.propTypes = {
   data: PropTypes.string
 };
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = state => ({
   data: state && state.data
 });
 
-export default connect(
-  mapStateToProps
-)(HomeWrapper);
+export default connect(mapStateToProps)(HomeWrapper);

--- a/samples/universal-react-node/src/client/locales/en.json
+++ b/samples/universal-react-node/src/client/locales/en.json
@@ -1,0 +1,12 @@
+{
+    "title": "Demonstration Components",
+    "CSRF protection using electrode-csrf-jwt": "CSRF protection using electrode-csrf-jwt",
+    "Above the Fold Render with skip=true": "Above the Fold Render with skip=true - increase your App's performance by using a skip prop",
+    "Above the Fold Render with skip=false": "Above the Fold Render with skip=false - increase your App's performance by using a skip prop",
+    "SSR Caching Simple Type Example": "SSR Caching Simple Type Example",
+    "SSR Caching Template Type Example": "SSR Caching Template Type Example",
+    "Push Notifications Example": "Push Notifications Example",
+    "Todo List Example": "Todo List Example",
+    "MongoDB Example": "MongoDB Example",
+    "This data is obtained from Redux store": "This data is obtained from Redux store"
+}

--- a/samples/universal-react-node/src/client/locales/en.json
+++ b/samples/universal-react-node/src/client/locales/en.json
@@ -7,6 +7,5 @@
     "SSR Caching Template Type Example": "SSR Caching Template Type Example",
     "Push Notifications Example": "Push Notifications Example",
     "Todo List Example": "Todo List Example",
-    "MongoDB Example": "MongoDB Example",
-    "This data is obtained from Redux store": "This data is obtained from Redux store"
+    "MongoDB Example": "MongoDB Example"
 }

--- a/samples/universal-react-node/src/client/locales/es.json
+++ b/samples/universal-react-node/src/client/locales/es.json
@@ -1,0 +1,11 @@
+{
+    "title": "Componentes de demostración",
+    "CSRF protection using electrode-csrf-jwt": "Protección CSRF usando electrode-csrf-jwt",
+    "Above the Fold Render with skip=true": "Sobre el Render Fold con skip = true - aumenta el rendimiento de tu aplicación usando un skip prop",
+    "Above the Fold Render with skip=false": "Sobre el Render Fold con skip = false - aumenta el rendimiento de tu aplicación usando un skip prop",
+    "SSR Caching Simple Type Example": "Ejemplo de tipo simple de almacenamiento en memoria caché SSR",
+    "SSR Caching Template Type Example": "Ejemplo de tipo de plantilla de almacenamiento en caché SSR",
+    "Push Notifications Example": "Ejemplo de notificaciones push",
+    "Todo List Example": "Ejemplo de lista de tareas",
+    "MongoDB Example": "Ejemplo de MongoDB"
+}

--- a/samples/universal-react-node/src/client/locales/fr.json
+++ b/samples/universal-react-node/src/client/locales/fr.json
@@ -1,0 +1,11 @@
+{
+    "title": "Composants de démonstration",
+    "CSRF protection using electrode-csrf-jwt": "Protection CSRF avec électrode-csrf-jwt",
+    "Above the Fold Render with skip=true": "Au-dessus du Fold Render avec skip = true - augmentez les performances de votre application en utilisant un accessoire de saut",
+    "Above the Fold Render with skip=false": "Au-dessus du Fold Render avec skip = false - augmentez les performances de votre application en utilisant un accessoire de saut",
+    "SSR Caching Simple Type Example": "SSR Caching Exemple de type simple",
+    "SSR Caching Template Type Example": "Exemple de type de modèle de cache SSR",
+    "Push Notifications Example": "Exemple de notifications push",
+    "Todo List Example": "Exemple de liste Todo",
+    "MongoDB Example": "MongoDB Exemple"
+}

--- a/samples/universal-react-node/src/client/locales/it.json
+++ b/samples/universal-react-node/src/client/locales/it.json
@@ -1,0 +1,11 @@
+{
+    "title": "Componenti dimostrativi",
+    "CSRF protection using electrode-csrf-jwt": "Protezione CSRF con elettrodo-csrf-jwt",
+    "Above the Fold Render with skip=true": "Above the Fold Render con skip = true - aumenta le prestazioni della tua app utilizzando un puntello di salto",
+    "Above the Fold Render with skip=false": "Above the Fold Render con skip = false - aumenta le prestazioni della tua app utilizzando un puntello di salto",
+    "SSR Caching Simple Type Example": "Esempio di tipo semplice di caching SSR",
+    "SSR Caching Template Type Example": "Esempio di modello di caching SSR",
+    "Push Notifications Example": "Esempio di notifiche push",
+    "Todo List Example": "Esempio di lista di cose da fare",
+    "MongoDB Example": "Esempio di MongoDB"
+}

--- a/samples/universal-react-node/src/client/locales/zh.json
+++ b/samples/universal-react-node/src/client/locales/zh.json
@@ -7,6 +7,5 @@
     "SSR Caching Template Type Example": "SSR缓存模板类型示例",
     "Push Notifications Example": "推送通知范例",
     "Todo List Example": "待办事项列表范例",
-    "MongoDB Example": "MongoDB范例",
-    "This data is obtained from Redux store": "这些数据来自Redux store"
+    "MongoDB Example": "MongoDB范例"
 }

--- a/samples/universal-react-node/src/client/locales/zh.json
+++ b/samples/universal-react-node/src/client/locales/zh.json
@@ -1,0 +1,12 @@
+{
+    "title": "演示组件",
+    "CSRF protection using electrode-csrf-jwt": "使用electrode-csrf-jwt进行CSRF保护",
+    "Above the Fold Render with skip=true": "Above the Fold Render 使用skip = true进行渲染 - 通过使用跳过道具来提高应用程序的性能",
+    "Above the Fold Render with skip=false": "Above the Fold Render 使用skip = false进行渲染 - 通过使用跳过道具来提高应用程序的性能",
+    "SSR Caching Simple Type Example": "SSR缓存简单类型示例",
+    "SSR Caching Template Type Example": "SSR缓存模板类型示例",
+    "Push Notifications Example": "推送通知范例",
+    "Todo List Example": "待办事项列表范例",
+    "MongoDB Example": "MongoDB范例",
+    "This data is obtained from Redux store": "这些数据来自Redux store"
+}


### PR DESCRIPTION
Must based on this PR: https://github.com/electrode-io/electrode/pull/747 release

add chinese, spanish, french & italian to sample app. 
languages change based on browser language. Default en. You can test by setting cookie `i18next`. (zh, en, fr, it, es)

zh, french, italian & spanish samples:
![screen shot 2018-03-14 at 5 29 46 pm](https://user-images.githubusercontent.com/10135897/37438052-9a13e558-27ad-11e8-8025-861ffdad881d.png)
![screen shot 2018-03-14 at 5 30 20 pm](https://user-images.githubusercontent.com/10135897/37438054-9a2cfe3a-27ad-11e8-8158-0c6c600e990f.png)
![screen shot 2018-03-14 at 11 06 39 am](https://user-images.githubusercontent.com/10135897/37438056-9a421536-27ad-11e8-8528-576491d55f19.png)
