### PR TITLE
[patch] autoprefixer + pure css component tests fix

### DIFF
--- a/packages/electrode-archetype-react-component-dev/config/webpack/partial/extract-style.js
+++ b/packages/electrode-archetype-react-component-dev/config/webpack/partial/extract-style.js
@@ -7,6 +7,7 @@ const optionalRequire = require("optional-require")(require);
 const atImport = require("postcss-import");
 const cssnext = require("postcss-cssnext");
 const webpack = require("webpack");
+const autoprefixer = require("autoprefixer-stylus");
 
 const styleLoader = require.resolve("style-loader");
 const cssLoader = require.resolve("css-loader");
@@ -36,7 +37,7 @@ const cssModuleStylusSupport = archetypeAppWebpack.cssModuleStylusSupport;
 
 const cssLoaderOptions =
   "?modules&localIdentName=[name]__[local]___[hash:base64:5]&-autoprefixer";
-const cssQuery = `${cssLoader}!${postcssLoader}`;
+const cssQuery = `${styleLoader}!${cssLoader}!${postcssLoader}`;
 const stylusQuery = `${cssLoader}?-autoprefixer!${stylusLoader}`;
 const scssQuery = `${cssQuery}!${sassLoader}`;
 const cssModuleQuery = `${cssLoader}${cssLoaderOptions}!${postcssLoader}`;
@@ -68,15 +69,15 @@ module.exports = function() {
   rules.push(
     {
       test: /\.css$/,
-      use: cssModuleSupport ? cssModuleQuery : cssQuery
+      loader: cssModuleSupport ? cssModuleQuery : cssQuery
     },
     {
       test: /\.scss$/,
-      use: cssModuleSupport ? cssScssQuery : scssQuery
+      loader: cssModuleSupport ? cssScssQuery : scssQuery
     },
     {
       test: /\.styl$/,
-      use: cssModuleSupport ? cssStylusQuery : stylusQuery
+      loader: cssModuleSupport ? cssStylusQuery : stylusQuery
     }
   );
 
@@ -88,7 +89,7 @@ module.exports = function() {
   if (cssModuleStylusSupport) {
     rules.push({
       test: /\.styl$/,
-      use: cssStylusQuery
+      loader: cssStylusQuery
     });
   }
 


### PR DESCRIPTION
When component uses css only:
09 04 2018 10:33:58.410:ERROR [config]: Invalid config file!
ReferenceError: `autoprefixer` is not defined

Verified on newly generated ignite component: packages/[component]
![screen shot 2018-04-10 at 12 27 08 pm](https://user-images.githubusercontent.com/10135897/38579001-8323ca44-3cba-11e8-91f7-bf7c2abfbbde.png)
