### PR TITLE
add devbrk and hotbrk tasks

### DIFF
--- a/packages/electrode-archetype-react-app/arch-clap.js
+++ b/packages/electrode-archetype-react-app/arch-clap.js
@@ -108,11 +108,11 @@ function createElectrodeTmpDir() {
 function removeLogFiles() {
   try {
     Fs.unlinkSync(Path.resolve("archetype-exceptions.log"));
-  } catch (e) { } // eslint-disable-line
+  } catch (e) {} // eslint-disable-line
 
   try {
     Fs.unlinkSync(Path.resolve("archetype-debug.log"));
-  } catch (e) { } // eslint-disable-line
+  } catch (e) {} // eslint-disable-line
 }
 
 /*
@@ -154,7 +154,7 @@ function lint(options) {
   const commands = [
     grouped.custom.length > 0 && `~$eslint${ext} ${grouped.custom.join(" ")}`,
     grouped.archetype.length > 0 &&
-    `~$eslint${ext} --no-eslintrc -c ${options.config} ${grouped.archetype.join(" ")}`
+      `~$eslint${ext} --no-eslintrc -c ${options.config} ${grouped.archetype.join(" ")}`
   ];
 
   return Promise.resolve(commands.filter(x => x));
@@ -326,7 +326,8 @@ function makeTasks() {
       setProductionEnv();
       return exec(
         `webpack`,
-        `--config`, quote(webpackConfig("webpack.config.browsercoverage.js")),
+        `--config`,
+        quote(webpackConfig("webpack.config.browsercoverage.js")),
         `--colors`
       );
     },
@@ -357,7 +358,11 @@ function makeTasks() {
 
     "build-dist-dev-static": {
       desc: false,
-      task: mkCmd(`webpack --config`, quote(webpackConfig("webpack.config.dev.static.js")), `--colors`)
+      task: mkCmd(
+        `webpack --config`,
+        quote(webpackConfig("webpack.config.dev.static.js")),
+        `--colors`
+      )
     },
 
     ".ss-prod-react": () => optimizeModuleForProd("react"),
@@ -370,7 +375,9 @@ function makeTasks() {
       );
     },
     "ss-prod-react": {
-      desc: `Make optimized copy of react&react-dom for server side in dir ${archetype.prodModulesDir}`,
+      desc: `Make optimized copy of react&react-dom for server side in dir ${
+        archetype.prodModulesDir
+      }`,
       dep: [".ss-clean.prod-react", ".mk-prod-dir"],
       task: [[".ss-prod-react", ".ss-prod-react-dom"]]
     },
@@ -604,7 +611,8 @@ Individual .babelrc files were generated for you in src/client and src/server
       task: mkCmd(
         "webpack-dev-server",
         `--watch --watch-aggregate-timeout 2000`,
-        `--config`, quote(webpackConfig("webpack.config.dev.js")),
+        `--config`,
+        quote(webpackConfig("webpack.config.dev.js")),
         `--progress --colors`,
         `--port ${archetype.webpack.devPort}`,
         `--host ${archetype.webpack.devHostname}`
@@ -615,7 +623,8 @@ Individual .babelrc files were generated for you in src/client and src/server
       desc: "Start webpack-dev-server with Hot Module Reload",
       task: mkCmd(
         "webpack-dev-server",
-        `--config`, quote(webpackConfig("webpack.config.hot.js")),
+        `--config`,
+        quote(webpackConfig("webpack.config.hot.js")),
         `--hot --progress --colors --inline`,
         `--port ${archetype.webpack.devPort}`,
         `--host ${archetype.webpack.devHostname}`
@@ -626,7 +635,8 @@ Individual .babelrc files were generated for you in src/client and src/server
       desc: "Start webpack-dev-server in test mode",
       task: mkCmd(
         "webpack-dev-server",
-        `--config`, quote(webpackConfig("webpack.config.test.js")),
+        `--config`,
+        quote(webpackConfig("webpack.config.test.js")),
         `--progress --colors`,
         `--port ${archetype.webpack.testPort}`,
         `--host ${archetype.webpack.devHostname}`
@@ -652,9 +662,17 @@ Individual .babelrc files were generated for you in src/client and src/server
 
     "test-frontend": mkCmd(`karma start`, quote(karmaConfig("karma.conf.js")), `--colors`),
 
-    "test-frontend-ci": mkCmd(`karma start`, quote(karmaConfig("karma.conf.coverage.js")), `--colors`),
+    "test-frontend-ci": mkCmd(
+      `karma start`,
+      quote(karmaConfig("karma.conf.coverage.js")),
+      `--colors`
+    ),
 
-    "test-frontend-cov": mkCmd(`karma start`, quote(karmaConfig("karma.conf.coverage.js")), `--colors`),
+    "test-frontend-cov": mkCmd(
+      `karma start`,
+      quote(karmaConfig("karma.conf.coverage.js")),
+      `--colors`
+    ),
 
     "test-frontend-dev": () =>
       exec(`pgrep -fl "webpack-dev-server.*${archetype.webpack.testPort}"`)
@@ -673,7 +691,9 @@ Individual .babelrc files were generated for you in src/client and src/server
         return mkCmd(
           `~$istanbul cover --include-all-sources --root src/server`,
           `--report text --report lcov node_modules/mocha/bin/_mocha`,
-          `-- -c --opts`, quote(mochaConfig("mocha.opts")), `test/server`
+          `-- -c --opts`,
+          quote(mochaConfig("mocha.opts")),
+          `test/server`
         );
       }
       return undefined;
@@ -705,7 +725,11 @@ Individual .babelrc files were generated for you in src/client and src/server
     "build-fp-stats": {
       desc:
         "Build static bundle with stats.json containing fullPaths to inspect the bundle on electrode-electrify",
-      task: mkCmd(`webpack --config`, quote(webpackConfig("webpack.config.stats.electrify.js")), `--colors`)
+      task: mkCmd(
+        `webpack --config`,
+        quote(webpackConfig("webpack.config.stats.electrify.js")),
+        `--colors`
+      )
     },
     "critical-css": {
       desc: "Start server and run penthouse to output critical CSS",
@@ -745,7 +769,8 @@ Individual .babelrc files were generated for you in src/client and src/server
     tasks = Object.assign(tasks, {
       "build-dist-dll": {
         dep: [".mk-dll-dir", ".mk-dist-dir", ".production-env"],
-        task: () => exec(`webpack --config`, quote(webpackConfig("webpack.config.dll.js")), `--colors`)
+        task: () =>
+          exec(`webpack --config`, quote(webpackConfig("webpack.config.dll.js")), `--colors`)
       },
       "copy-dll": () => shell.cp("-r", "dll/*", "dist")
     });
@@ -754,7 +779,7 @@ Individual .babelrc files were generated for you in src/client and src/server
   return tasks;
 }
 
-module.exports = function (xclap) {
+module.exports = function(xclap) {
   setupPath();
   createElectrodeTmpDir();
   xclap = xclap || requireAt(process.cwd())("xclap") || devRequire("xclap");

--- a/packages/electrode-archetype-react-app/support/babel-run.js
+++ b/packages/electrode-archetype-react-app/support/babel-run.js
@@ -16,18 +16,27 @@ const Path = require("path");
 
 const serverDir = process.argv[2] || "src/server";
 
+let start;
+
 try {
   // Try to load user's dev.js under src/server
-  require(Path.resolve(serverDir, "dev.js"));
+  start = require(Path.resolve(serverDir, "dev.js"));
 } catch (e) {
   const cwdNM = Path.resolve("node_modules");
   const cwd = process.cwd();
 
   // fallback to default action that loads babel-register and then requires
   // src/server, under which there should be an index.js file.
-  require("babel-register")({ only: x => {
-    x = Path.normalize(x);
-    return x.startsWith(cwd) && !x.startsWith(cwdNM);
-  }});
-  require(Path.resolve(serverDir));
+  require("babel-register")({
+    only: x => {
+      x = Path.normalize(x);
+      return x.startsWith(cwd) && !x.startsWith(cwdNM);
+    }
+  });
+  const fullServerDir = Path.resolve(serverDir);
+  start = require(fullServerDir);
+}
+
+if (typeof start === "function") {
+  start();
 }

--- a/packages/generator-electrode/generators/app/templates/src/server/index.js
+++ b/packages/generator-electrode/generators/app/templates/src/server/index.js
@@ -11,14 +11,40 @@ const support = require("electrode-archetype-react-app/support");
 
 //<% if (isHapi) { %>
 const staticPathsDecor = require("electrode-static-paths");
-const startServer = config => require("electrode-server")(config, [staticPathsDecor()]);
+const electrodeServer = require("electrode-server");
+
+//
+// sample to show electrode server startup events
+// https://github.com/electrode-io/electrode-server#listener-function
+//
+function setupElectrodeServerEvents(emitter) {
+  emitter.on("config-composed", (data, next) => next());
+  emitter.on("server-created", (data, next) => next());
+  emitter.on("connection-set", (data, next) => next());
+  emitter.on("plugins-sorted", (data, next) => next());
+  emitter.on("plugins-registered", (data, next) => next());
+  emitter.on("server-started", (data, next) => next());
+  emitter.on("complete", (data, next) => next());
+}
+
+const startServer = config => {
+  const decor = staticPathsDecor();
+  if (!config.listener) config.listener = setupElectrodeServerEvents;
+  return electrodeServer(config, [decor]);
+};
+
 //<% } else if (isExpress) { %>
 const startServer = config => require("./express-server")(config);
 //<% } else { %>
 const startServer = config => require("./koa-server")(config);
 //<% } %>
 
-support.load().then(() => {
-  const config = electrodeConfippet.config;
-  return startServer(config);
-});
+module.exports = () =>
+  support.load().then(() => {
+    const config = electrodeConfippet.config;
+    return startServer(config);
+  });
+
+if (require.main === module) {
+  module.exports();
+}


### PR DESCRIPTION
- allow `dev`, `hot`, and `server-watch` tasks to take arguments to be passed to nodemon.
- add devbrk and hotbrk that automatically set `--inspect-brk` node flag