### PR TITLE
update isomorphic-loader to v2

### DIFF
--- a/packages/electrode-archetype-react-app-dev/package.json
+++ b/packages/electrode-archetype-react-app-dev/package.json
@@ -60,7 +60,7 @@
     "file-loader": "^0.11.1",
     "fs-extra": "^0.26.5",
     "glob": "^7.0.6",
-    "isomorphic-loader": "^1.0.0",
+    "isomorphic-loader": "^2.0.0",
     "isparta": "^4.0.0",
     "istanbul": "^0.4.5",
     "json-loader": "^0.5.7",

--- a/packages/electrode-archetype-react-app/package.json
+++ b/packages/electrode-archetype-react-app/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "css-modules-require-hook": "^4.0.2",
-    "isomorphic-loader": "^1.6.1",
+    "isomorphic-loader": "^2.0.0",
     "optional-require": "^1.0.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Preparing to work with webpack 4.

No need to major bump since isomorphic-loader v2 was to drop support for Node 4 and archetypes v5 already dropped that.