### PR TITLE
[patch] component archetype style loader fixes

### DIFF
--- a/packages/electrode-archetype-react-component-dev/config/webpack/partial/extract-style.js
+++ b/packages/electrode-archetype-react-component-dev/config/webpack/partial/extract-style.js
@@ -38,11 +38,11 @@ const cssModuleStylusSupport = archetypeAppWebpack.cssModuleStylusSupport;
 const cssLoaderOptions =
   "?modules&localIdentName=[name]__[local]___[hash:base64:5]&-autoprefixer";
 const cssQuery = `${styleLoader}!${cssLoader}!${postcssLoader}`;
-const stylusQuery = `${cssLoader}?-autoprefixer!${stylusLoader}`;
+const stylusQuery = `${styleLoader}!${cssLoader}?-autoprefixer!${stylusLoader}`;
 const scssQuery = `${cssQuery}!${sassLoader}`;
-const cssModuleQuery = `${cssLoader}${cssLoaderOptions}!${postcssLoader}`;
-const cssStylusQuery = `${cssLoader}${cssLoaderOptions}!${postcssLoader}!${stylusLoader}`;
-const cssScssQuery = `${cssLoader}${cssLoaderOptions}!${postcssLoader}!${sassLoader}`;
+const cssModuleQuery = `${styleLoader}!${cssLoader}${cssLoaderOptions}!${postcssLoader}`;
+const cssStylusQuery = `${cssModuleQuery}!${stylusLoader}`;
+const cssScssQuery = `${cssModuleQuery}!${sassLoader}`;
 
 const cssExists =
   glob.sync(Path.resolve(process.cwd(), "src/styles", "*.css")).length > 0;


### PR DESCRIPTION
Add style loader for component archetype to inject css into the <style> tag.

`Bug`:
When we run `npm run test` inside `packages/[component]`, if we import css-modules, for example, to test if the mounted component contains the styles as:
```
const component = mount(<Component />);
expect(component.hasClass(styles.someStyle)).to.equal(true);
```
We got false because `console.log("xxxxxx", styles.baseStyle);` is undefined.

`Fixes`:
After adding style-loader to the archetype component, we got `console.log("xxxxxx", styles.baseStyle);`:
`HeadlessChrome 66.0.3359 (Mac OS X 10.11.6) LOG LOG: 'xxxxxx', 'demo-component__baseStyle___1c6lQ'`

Verified on `css-modules`, `stylus+css-modules`, `sass+css-modules`