### PR TITLE
components repo demo-app webconfig alias changes to allow importing module from packages

### DIFF
--- a/packages/generator-electrode/component/templates/demo-app/archetype/config/webpack/component-alias.config.js
+++ b/packages/generator-electrode/component/templates/demo-app/archetype/config/webpack/component-alias.config.js
@@ -17,7 +17,8 @@ const config = {
 
 components.forEach(folderName => {
   const packageName = require(Path.join(repoPackagesDir, folderName, "package.json")).name;
-  config.resolve.alias[packageName] = Path.join(repoPackagesDir, folderName, "src");
+  config.resolve.alias[`${packageName}/lib`] = Path.join(repoPackagesDir, folderName, "src");
+  config.resolve.alias[`${packageName}$`] = Path.join(repoPackagesDir, folderName, "src/index.js");
   config.resolve.modules.push(Path.join(repoPackagesDir, folderName));
   config.resolve.modules.push(Path.join(repoPackagesDir, folderName, "node_modules"));
 });


### PR DESCRIPTION
currently, in demo-app it's only possible to import modules from `src/index.js`, but not anything else.

when the package is published to npm, and later used in the app, it is possible to access all the files using `${package-name}/lib/...` path

this fix mimics real usage in demo-mode (in dev mode)