### PR TITLE
unsupported methods returning 500s

### DIFF
--- a/packages/electrode-redux-router-engine/lib/errors/unsupported-method-error.js
+++ b/packages/electrode-redux-router-engine/lib/errors/unsupported-method-error.js
@@ -1,0 +1,8 @@
+class UnsupportedMethodError extends Error {
+    constructor(message) {
+        super(message);
+        this.status = 405;
+    }
+}
+
+module.exports = UnsupportedMethodError;

--- a/packages/electrode-redux-router-engine/lib/redux-router-engine.js
+++ b/packages/electrode-redux-router-engine/lib/redux-router-engine.js
@@ -10,6 +10,7 @@ const ReactDomServer = optionalRequire("react-dom/server");
 const ReactRouter = require("react-router");
 const Provider = require("react-redux").Provider;
 const Path = require("path");
+const UnsupportedMethodError = require("./errors/unsupported-method-error.js");
 
 const BAD_CHARS_REGEXP = /[<\u2028\u2029]/g;
 const REPLACEMENTS_FOR_BAD_CHARS = {
@@ -78,7 +79,7 @@ class ReduxRouterEngine {
         const methods = route.methods || "get";
 
         if (methods.toLowerCase().indexOf(req.method.toLowerCase()) < 0) {
-          throw new Error(
+          throw new UnsupportedMethodError(
             `redux-router-engine: ${location} doesn't allow request method ${req.method}`);
         }
 


### PR DESCRIPTION
unsupported method errors should return 405 codes.

currently returns a 500 error code.