### PR TITLE
Use phantomjs as test browser for now till looper support headlesschrome

### DIFF
--- a/packages/generator-electrode/component/templates/packages/component/_xclap.js
+++ b/packages/generator-electrode/component/templates/packages/component/_xclap.js
@@ -1,5 +1,11 @@
 "use strict";
 
+/*
+ * Use PhantomJS to run your Karma Unit tests.  Default is "chrome" (Chrome Headless)
+ */
+
+process.env.KARMA_BROWSER = "phantomjs";
+
 /**
  * There is a full range of clap tasks defined in the above archetype
  * but below is a concise list of most often used clap tasks at the

--- a/packages/generator-electrode/generators/app/templates/xclap.js
+++ b/packages/generator-electrode/generators/app/templates/xclap.js
@@ -14,7 +14,7 @@ process.env.SERVER_ES6 = true;
  * Use PhantomJS to run your Karma Unit tests.  Default is "chrome" (Chrome Headless)
  */
 
-// process.env.KARMA_BROWSER = "phantomjs";
+process.env.KARMA_BROWSER = "phantomjs";
 
 /*
  * Turn off using electrode-webpack-reporter to show visual report of your webpack


### PR DESCRIPTION
Since looper will support headless chrome soon, for now, just use phantomjs as karma browser inside generator.
Temporarily resolve the `Chrome_bin` cannot be found issue from looper.