### PR TITLE
[minor] add flow-typed for flow library definitions

### DIFF
--- a/packages/electrode-archetype-react-app-dev/package.json
+++ b/packages/electrode-archetype-react-app-dev/package.json
@@ -70,6 +70,7 @@
     "file-loader": "^0.11.1",
     "finalhandler": "^1.1.1",
     "flow-bin": "^0.74.0",
+    "flow-typed": "^2.4.0",
     "fs-extra": "^0.26.5",
     "glob": "^7.0.6",
     "identity-obj-proxy": "^3.0.0",

--- a/packages/electrode-archetype-react-app/arch-clap.js
+++ b/packages/electrode-archetype-react-app/arch-clap.js
@@ -796,6 +796,10 @@ Individual .babelrc files were generated for you in src/client and src/server
     initflow: {
       desc: "Initiate Flow for type checker",
       task: mkCmd(`flow init`)
+    },
+    "flow-typed-install": {
+      desc: "A central repository for Flow library definitions",
+      task: mkCmd(`flow-typed install --packageDir ${archetype.devDir}`)
     }
   };
 

--- a/packages/electrode-archetype-react-app/arch-clap.js
+++ b/packages/electrode-archetype-react-app/arch-clap.js
@@ -798,7 +798,7 @@ Individual .babelrc files were generated for you in src/client and src/server
       task: mkCmd(`flow init`)
     },
     "flow-typed-install": {
-      desc: "A central repository for Flow library definitions",
+      desc: "Install flow 3rd-party interface library definitions from flow-typed repo.",
       task: mkCmd(`flow-typed install --packageDir ${archetype.devDir}`)
     }
   };


### PR DESCRIPTION
By default, Flow will ignore the 3rd-party libraries which were not written with Flow and leave them untyped. 

The `flow-typed` repo is a collection of high-quality library definitions which allow you to describe the interface of a module or library separate from the implementation of that module/library.