### PR TITLE
webpack-dev-hapi plugin depends on WEBPACK_DEV also

### DIFF
--- a/packages/generator-electrode/generators/config/templates/default.js
+++ b/packages/generator-electrode/generators/config/templates/default.js
@@ -22,7 +22,7 @@ module.exports = {
   plugins: {
     "webpack-dev": {
       module: "electrode-archetype-react-app-dev/lib/webpack-dev-hapi",
-      enable: process.env.WEBPACK_DEV_MIDDLEWARE === "true"
+      enable: process.env.WEBPACK_DEV_MIDDLEWARE === "true" && process.env.WEBPACK_DEV === "true"
     },
     inert: {
       enable: true


### PR DESCRIPTION
- Otherwise running prod with clap would enable the webpack-dev-hapi plugin because xclap.js could always be setting WEBPACK_DEV_MIDDLEWARE to true