### PR TITLE
fix isomorphic loading after webpack compile

### DIFF
--- a/packages/electrode-archetype-react-app/arch-clap.js
+++ b/packages/electrode-archetype-react-app/arch-clap.js
@@ -510,7 +510,7 @@ Individual .babelrc files were generated for you in src/client and src/server
     devbrk: ["dev --inspect-brk"],
     dev: {
       desc: "Start your app with watch in development mode with webpack-dev-server",
-      dep: [".remove-log-files", ".development-env"],
+      dep: [".remove-log-files", ".development-env", ".mk-dist-dir"],
       task: function() {
         if (!Fs.existsSync(".isomorphic-loader-config.json")) {
           Fs.writeFileSync(".isomorphic-loader-config.json", JSON.stringify({}));

--- a/packages/generator-electrode/generators/config/templates/default.js
+++ b/packages/generator-electrode/generators/config/templates/default.js
@@ -22,7 +22,19 @@ module.exports = {
   plugins: {
     "webpack-dev": {
       module: "electrode-archetype-react-app-dev/lib/webpack-dev-hapi",
-      enable: process.env.WEBPACK_DEV_MIDDLEWARE === "true" && process.env.WEBPACK_DEV === "true"
+      enable: process.env.WEBPACK_DEV_MIDDLEWARE === "true" && process.env.WEBPACK_DEV === "true",
+      options: {
+        // webpack dev middleware options
+        dev: {
+          // user reporter that's called by the archetype's reporter
+          reporter: reporterOptions => {
+            // For example, you can start app server with `clap devbrk` and attach
+            // to it with chrome://inspect, and then enable this debugger statement
+            // so chrome stop here every time webpack middleware finish compiling
+            // debugger
+          }
+        }
+      }
     },
     inert: {
       enable: true


### PR DESCRIPTION
After webpack compile, should wait for isomorphic to load before showing done message, opening the url, and hot module reload.
