### PR TITLE
[chore] add stylus-sample to CI

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/archetype.js
+++ b/packages/electrode-archetype-react-app-dev/config/archetype.js
@@ -18,7 +18,7 @@ const webpackConfigSpec = {
   reporterSocketPort: { env: "WEBPACK_REPORTER_SOCKET_PORT", default: 5000 },
   https: { env: "WEBPACK_DEV_HTTPS", default: false },
   devMiddleware: { env: "WEBPACK_DEV_MIDDLEWARE", default: false },
-  cssModuleSupport: { env: "CSS_MODULE_SUPPORT", type: "boolean", default: detectCSSModule() },
+  cssModuleSupport: { env: "CSS_MODULE_SUPPORT", type: "truthy", default: detectCSSModule },
   cssModuleStylusSupport: { env: "CSS_MODULE_STYLUS_SUPPORT", default: false },
   enableBabelPolyfill: { env: "ENABLE_BABEL_POLYFILL", default: false },
   enableNodeSourcePlugin: { env: "ENABLE_NODESOURCE_PLUGIN", default: false },

--- a/packages/electrode-archetype-react-app-dev/package.json
+++ b/packages/electrode-archetype-react-app-dev/package.json
@@ -128,7 +128,7 @@
     "webpack-stats-plugin": "^0.1.1",
     "winston": "^2.3.1",
     "xclap": "^0.2.0",
-    "xenv-config": "^1.0.0",
+    "xenv-config": "^1.2.2",
     "xsh": "^0.4.2"
   },
   "optionalDependencies": {

--- a/samples/stylus-sample/src/client/styles/index.styl
+++ b/samples/stylus-sample/src/client/styles/index.styl
@@ -1,3 +1,3 @@
-@import "normalize.styl"
-@import "custom.styl"
-@import "raleway.styl"
+@import "normalize.styl";
+@import "custom.styl";
+@import "raleway.styl";

--- a/xclap.js
+++ b/xclap.js
@@ -56,9 +56,9 @@ const runAppTest = (dir, forceLocal) => {
   };
 
   const localClap = Path.join("node_modules", ".bin", "clap");
-  return exec({ cwd: dir }, `fyn --pg simple -q v i && ${localClap} ?fix-generator-eslint`).then(
-    () => exec({ cwd: dir }, `npm test`)
-  );
+  return exec({ cwd: dir }, `fyn --pg simple -q v i && ${localClap} ?fix-generator-eslint`)
+    .then(() => exec({ cwd: dir }, `npm test`))
+    .then(() => exec({ cwd: dir }, `${localClap} build`));
 };
 
 const testGenerator = (testDir, name, clean, runTest, prompts) => {
@@ -138,6 +138,7 @@ xclap.load({
     `~$cd samples/demo-component && fyn --pg none install && npm test`
   ],
   "test-boilerplate": [".fyn-setup", ".test-boilerplate"],
+  "test-stylus-sample": [".fyn-setup", ".test-stylus-sample"],
   "update-changelog": [".fyn-setup", "~$node tools/update-changelog.js"],
   "gitbook-serve": [".fyn-setup", "~$gitbook serve --no-watch --no-live"],
   "build-test": {
@@ -145,7 +146,7 @@ xclap.load({
     task: () => {
       process.env.BUILD_TEST = "true";
       process.env.NODE_PRESERVE_SYMLINKS = "1";
-      const tasks = ["test-boilerplate"];
+      const tasks = ["test-boilerplate", "test-stylus-sample"];
       let updated;
       return exec("lerna updated")
         .then(output => {
@@ -179,10 +180,22 @@ xclap.load({
     }
   },
 
+  ".test-stylus-sample": {
+    desc: "Run tests for the boilerplage app stylus-sample",
+    task: () => {
+      return runAppTest(Path.join(__dirname, "samples/stylus-sample"));
+    }
+  },
+
   "samples-local": {
     desc: "modify all samples to pull electrode packages from local",
     task: () => {
-      ["electrode-demo-index", "universal-material-ui", "universal-react-node"].forEach(a => {
+      [
+        "electrode-demo-index",
+        "stylus-sample",
+        "universal-material-ui",
+        "universal-react-node"
+      ].forEach(a => {
         pullLocalPackages(Path.join(__dirname, "samples", a));
       });
     }


### PR DESCRIPTION
This is meant to repro and trigger the stylus issue with the recently released App archetype 5.4.0.

CI should fail (and OK for merge since this is meant to trigger failure).

- but make sure to verify failure is from samples/stylus-sample with `Unnecessary semicolon` error during the build step.

A PR should submit after to verify the issue's fixed.
