### PR TITLE
[minor][feat] add basename support for SSR Links

### DIFF
--- a/packages/electrode-redux-router-engine/lib/redux-router-engine.js
+++ b/packages/electrode-redux-router-engine/lib/redux-router-engine.js
@@ -36,6 +36,8 @@ class ReduxRouterEngine {
 
     this.options.withIds = !!options.withIds;
 
+    this.options.basename = options.basename || "";
+
     if (!options.stringifyPreloadedState) {
       this.options.stringifyPreloadedState = state =>
         `window.__PRELOADED_STATE__ = ${escapeBadChars(JSON.stringify(state))};`;
@@ -198,7 +200,7 @@ class ReduxRouterEngine {
           { store },
           React.createElement(
             StaticRouter,
-            { location, context: routeContext },
+            { location, context: routeContext, basename: this.options.basename },
             this._routesComponent
           )
         )

--- a/packages/electrode-redux-router-engine/test/routes.jsx
+++ b/packages/electrode-redux-router-engine/test/routes.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import { withRouter, Redirect } from "react-router-dom";
+import { withRouter, Redirect, Link } from "react-router-dom";
 import { renderRoutes } from "react-router-config";
 import { renderFlatRoutes } from "./render-flat-routes";
 
@@ -28,6 +28,12 @@ class Page extends React.Component {
 class Test extends React.Component {
   render() {
     return <div>Test</div>;
+  }
+}
+
+class TestBasename extends React.Component {
+  render() {
+    return <Link to="/to-target">Test</Link>;
   }
 }
 
@@ -131,6 +137,12 @@ const routes = [
         path: "/test",
         exact: true,
         component: Home
+      },
+      {
+        // Default, equivalent of RR3's IndexRoute
+        path: "/test/basename",
+        exact: true,
+        component: TestBasename
       },
       {
         path: "/test/init",

--- a/packages/electrode-redux-router-engine/test/spec/redux-router-engine.spec.js
+++ b/packages/electrode-redux-router-engine/test/spec/redux-router-engine.spec.js
@@ -206,6 +206,26 @@ describe("redux-router-engine", function() {
     });
   });
 
+  it("should render Link with no basename", () => {
+    const engine = new ReduxRouterEngine({ routes });
+    testReq.url = Url.parse("/test/basename");
+
+    return engine.render(testReq).then(result => {
+      expect(result.status).to.equal(200);
+      expect(result.html).to.equal("<div>Page<a href=\"/to-target\">Test</a></div>");
+    });
+  });
+
+  it("should render Link with basename", () => {
+    const engine = new ReduxRouterEngine({ routes, basename: "/my-base" });
+    testReq.url = Url.parse("/test/basename");
+
+    return engine.render(testReq).then(result => {
+      expect(result.status).to.equal(200);
+      expect(result.html).to.equal("<div>Page<a href=\"/my-base/to-target\">Test</a></div>");
+    });
+  });
+
   it("should not populate react-id by default", () => {
     const engine = new ReduxRouterEngine({ routes });
     testReq.url = Url.parse("/test");


### PR DESCRIPTION
If you use Link from react-router-dom with a basename, for example,
basename: '/my-base' and a `<Link to="/to-target">Test</Link>`

CSR will render it as `<a href="/my-base/to-target">Test</a>`
But SSR will render it as `<a href="/to-target">Test</a>` because the render engine doesn't support basename. 

This PR is to add basename support to the render engine, so we can get same render result CSR vs. SSR.