### PR TITLE
separate SSR render steps

### DIFF
--- a/packages/electrode-redux-router-engine/test/spec/redux-router-engine.spec.js
+++ b/packages/electrode-redux-router-engine/test/spec/redux-router-engine.spec.js
@@ -212,7 +212,7 @@ describe("redux-router-engine", function() {
 
     return engine.render(testReq).then(result => {
       expect(result.status).to.equal(200);
-      expect(result.html).to.equal("<div>Page<a href=\"/to-target\">Test</a></div>");
+      expect(result.html).to.equal(`<div>Page<a href="/to-target">Test</a></div>`);
     });
   });
 
@@ -222,7 +222,7 @@ describe("redux-router-engine", function() {
 
     return engine.render(testReq).then(result => {
       expect(result.status).to.equal(200);
-      expect(result.html).to.equal("<div>Page<a href=\"/my-base/to-target\">Test</a></div>");
+      expect(result.html).to.equal(`<div>Page<a href="/my-base/to-target">Test</a></div>`);
     });
   });
 


### PR DESCRIPTION
Instead of a single render entry `engine.render(request)`, allow caller to do these in multiple stages:

```js
const data = engine.startMatch(request);
const errorResult = engine.checkMatch(data);
if (errorResult) {
  // can't continue, do something with errorResult
} else {
  await this.prepReduxStore(data);
  return await this._handleRender(data);
}
```

`data` acquires relevant info through the stages:

- `request`
- `match` - result of react router match
- `location`
- `store` - redux store