### PR TITLE
support insert token ids to output for debugging

### DIFF
--- a/packages/electrode-react-webapp/README.md
+++ b/packages/electrode-react-webapp/README.md
@@ -6,7 +6,7 @@ This module helps render and serve your Electrode React application's `index.htm
 
 All the defaults are configured out of the box, but your index page is extensible. You can specify your own index template file with the `htmlFile` option.
 
-See [design](./DESIGN.md) for details on how the template can be extended.
+See [design](/packages/electrode-react-webapp/DESIGN.md) for details on how the template can be extended.
 
 ## Installing
 

--- a/packages/electrode-react-webapp/lib/async-template.js
+++ b/packages/electrode-react-webapp/lib/async-template.js
@@ -49,6 +49,7 @@ class AsyncTemplate {
       this._initializeTokenHandlers(this._tokenHandlers);
       this._applyTokenLoad();
       this._renderer = new Renderer({
+        insertTokenIds: this._options.insertTokenIds,
         htmlTokens: this._tokens,
         tokenHandlers: this._tokenHandlers
       });

--- a/packages/electrode-react-webapp/lib/react-webapp.js
+++ b/packages/electrode-react-webapp/lib/react-webapp.js
@@ -27,6 +27,7 @@ function makeRouteHandler(routeOptions) {
   const asyncTemplate = new AsyncTemplate({
     htmlFile: routeOptions.htmlFile,
     tokenHandlers: tokenHandlers.filter(x => x),
+    insertTokenIds: routeOptions.insertTokenIds,
     routeOptions
   });
 

--- a/packages/electrode-react-webapp/test/fixtures/custom-call.js
+++ b/packages/electrode-react-webapp/test/fixtures/custom-call.js
@@ -4,7 +4,7 @@ function setup() {
   return {
     name: "custom-call",
     process: function() {
-      return `_call`;
+      return `_call process from custom-call token fixture`;
     }
   };
 }

--- a/packages/electrode-react-webapp/test/spec/token.spec.js
+++ b/packages/electrode-react-webapp/test/spec/token.spec.js
@@ -20,7 +20,7 @@ describe("token", function() {
     expect(tk.id).to.equal("#./test/fixtures/custom-call");
     expect(tk.isModule).to.equal(true);
     tk.load();
-    expect(tk[TOKEN_HANDLER]()).to.equal("_call");
+    expect(tk[TOKEN_HANDLER]()).to.equal("_call process from custom-call token fixture");
   });
 
   it("should create token as custom and call setup only once for each token", () => {


### PR DESCRIPTION
- allow setting a flag `insertTokenIds` in route options so the renderer will insert token IDs as HTML comment in the final output

Helps with debugging.
