### PR TITLE
make node-sass optional

### DIFF
--- a/packages/electrode-archetype-opt-sass/README.md
+++ b/packages/electrode-archetype-opt-sass/README.md
@@ -1,0 +1,39 @@
+# Electrode Archetype Option SASS
+
+Allow [Electrode](https://github.com/electrode-io/electrode) apps to optionally choose to skip installing dependencies for SASS.
+
+The app can skip installing sass dependencies by adding a file `archetype/config/index.js` or `archetype/config.js` and set:
+
+```js
+module.exports = {
+  options: {
+    sass: false
+  }
+};
+```
+
+If nothing is set, then default is to install.
+
+# Usage
+
+This module generally is included by other Electrode modules. An Electrode app should not need to install this directly.
+
+## Install
+
+In `package.json`:
+
+```js
+{
+  "optionalDependencies": {
+    "electrode-archetype-opt-sass": "^1.0.0"
+  }
+}
+```
+
+And setup archetype config accordingly.
+
+## License
+
+Copyright (c) 2016-present, WalmartLabs
+
+Licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/packages/electrode-archetype-opt-sass/optional-check.js
+++ b/packages/electrode-archetype-opt-sass/optional-check.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const Path = require("path");
+
+const cwd = process.env.PWD || process.cwd();
+
+function findAppDir() {
+  if (cwd.indexOf("node_modules") > 0) {
+    const splits = cwd.split("node_modules");
+    return Path.dirname(Path.join(splits[0], "x")); // remove trailing slash
+  }
+  return cwd;
+}
+
+const appDir = findAppDir();
+const myPkg = require("./package.json");
+
+if (cwd === appDir) {
+  try {
+    const appPkg = require(Path.join(appDir, "package.json"));
+    if (myPkg.name === appPkg.name) {
+      process.exit(0);
+    }
+  } catch (e) {}
+}
+
+const name = myPkg.name;
+
+try {
+  const config = require(Path.join(appDir, "archetype/config"));
+  const lib = config && config.options && config.options.sass;
+  if (lib === false) {
+    console.log(
+      `${name}: archetype config set sass to false - skipping install because it's not being used.`
+    );
+    process.exit(1);
+  }
+} catch (e) {}
+
+process.exit(0);

--- a/packages/electrode-archetype-opt-sass/optional-check.js
+++ b/packages/electrode-archetype-opt-sass/optional-check.js
@@ -31,7 +31,7 @@ try {
   const lib = config && config.options && config.options.sass;
   if (lib === false) {
     console.log(
-      `${name}: archetype config set sass to false - skipping install because it's not being used.`
+      `${name}: archetype config set sass to false - skipping install because it's not true.`
     );
     process.exit(1);
   }

--- a/packages/electrode-archetype-opt-sass/package.json
+++ b/packages/electrode-archetype-opt-sass/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "electrode-archetype-opt-node-sass",
+  "name": "electrode-archetype-opt-sass",
   "version": "1.0.0",
-  "description": "Electrode NodeJS/React Optional Archetype - node-sass",
+  "description": "Electrode NodeJS/React Optional Archetype SASS",
   "main": "index.js",
   "homepage": "http://www.electrode.io",
   "repository": {

--- a/packages/electrode-archetype-opt-sass/package.json
+++ b/packages/electrode-archetype-opt-sass/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "electrode-archetype-opt-node-sass",
+  "version": "1.0.0",
+  "description": "Electrode NodeJS/React Optional Archetype - node-sass",
+  "main": "index.js",
+  "homepage": "http://www.electrode.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/electrode-io/electrode.git"
+  },
+  "bugs": {
+    "url": "https://github.com/electrode-io/electrode/issues"
+  },
+  "files": [
+    "optional-check.js"
+  ],
+  "license": "Apache-2.0",
+  "scripts": {
+    "preinstall": "node optional-check.js"
+  },
+  "dependencies": {
+    "node-sass": "^4.9.3",
+    "sass-loader": "^6.0.6"
+  }
+}

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract-style.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract-style.js
@@ -15,7 +15,9 @@ const cssLoader = require.resolve("css-loader");
 const styleLoader = require.resolve("style-loader");
 const stylusLoader = require.resolve("stylus-relative-loader");
 const postcssLoader = require.resolve("postcss-loader");
-const sassLoader = require.resolve("sass-loader");
+
+const sassSupport = archetype.options && archetype.options.sass;
+const sassLoader = sassSupport === false ? "" : require.resolve("sass-loader");
 
 /*
  * cssModuleSupport: false

--- a/packages/electrode-archetype-react-app-dev/package.json
+++ b/packages/electrode-archetype-react-app-dev/package.json
@@ -88,7 +88,6 @@
     "mime": "^1.0.0",
     "mkdirp": "^0.5.1",
     "mocha": "^4.0.0",
-    "node-sass": "^4.7.2",
     "nodemon": "^1.8.1",
     "offline-plugin": "^4.6.1",
     "opn": "^5.3.0",
@@ -107,7 +106,6 @@
     "react-test-renderer": "^16.1.1",
     "require-at": "^1.0.0",
     "rimraf": "^2.4.0",
-    "sass-loader": "^6.0.6",
     "sinon": "^4.0.0",
     "sinon-chai": "^2.14.0",
     "style-loader": "^0.20.1",
@@ -134,7 +132,8 @@
   "optionalDependencies": {
     "electrode-archetype-opt-inferno": "^0.2.3",
     "electrode-archetype-opt-karma": "^1.0.1",
-    "electrode-archetype-opt-react": "^1.0.1"
+    "electrode-archetype-opt-react": "^1.0.1",
+    "electrode-archetype-opt-sass": "^1.0.0"
   },
   "devDependencies": {
     "electrode-archetype-react-app": "../electrode-archetype-react-app",
@@ -155,7 +154,8 @@
     "optionalDependencies": {
       "electrode-archetype-opt-inferno": "../electrode-archetype-opt-inferno",
       "electrode-archetype-opt-karma": "../electrode-archetype-opt-karma",
-      "electrode-archetype-opt-react": "../electrode-archetype-opt-react"
+      "electrode-archetype-opt-react": "../electrode-archetype-opt-react",
+      "electrode-archetype-opt-sass": "../electrode-archetype-opt-sass"
     }
   }
 }

--- a/packages/electrode-archetype-react-app/config/archetype.js
+++ b/packages/electrode-archetype-react-app/config/archetype.js
@@ -8,7 +8,7 @@ const utils = require("../lib/utils");
 const makeAppMode = require("../lib/app-mode");
 const userConfig = Object.assign(
   {
-    options: { reactLib: "react", karma: true }
+    options: { reactLib: "react", karma: true, sass: true }
   },
   optionalRequire(Path.resolve("archetype/config"))
 );

--- a/packages/electrode-archetype-react-component-dev/config/webpack/partial/extract-style.js
+++ b/packages/electrode-archetype-react-component-dev/config/webpack/partial/extract-style.js
@@ -13,15 +13,17 @@ const styleLoader = require.resolve("style-loader");
 const cssLoader = require.resolve("css-loader");
 const postcssLoader = require.resolve("postcss-loader");
 const stylusLoader = require.resolve("stylus-relative-loader");
-const sassLoader = require.resolve("sass-loader");
 
 const demoAppPath = Path.resolve(process.cwd(), "..", "..", "demo-app");
 const archetypeAppPath = Path.resolve(demoAppPath, "archetype", "config");
 
-const archetypeApp = optionalRequire(archetypeAppPath) || { webpack: {} };
+const archetypeApp = optionalRequire(archetypeAppPath) || { webpack: {}, options: {} };
 const archetypeAppWebpack = archetypeApp.webpack;
 let cssModuleSupport = archetypeAppWebpack.cssModuleSupport;
 const cssModuleStylusSupport = archetypeAppWebpack.cssModuleStylusSupport;
+
+const sassSupport = archetypeApp.options && archetypeApp.options.sass;
+const sassLoader = sassSupport === false ? "" : require.resolve("sass-loader");
 
 /*
  * cssModuleSupport: false
@@ -35,8 +37,7 @@ const cssModuleStylusSupport = archetypeAppWebpack.cssModuleStylusSupport;
  * case 3: *only* *.scss => normal CSS => CSS-Modules + CSS-Next
  */
 
-const cssLoaderOptions =
-  "?modules&localIdentName=[name]__[local]___[hash:base64:5]&-autoprefixer";
+const cssLoaderOptions = "?modules&localIdentName=[name]__[local]___[hash:base64:5]&-autoprefixer";
 const cssQuery = `${styleLoader}!${cssLoader}!${postcssLoader}`;
 const stylusQuery = `${styleLoader}!${cssLoader}?-autoprefixer!${stylusLoader}`;
 const scssQuery = `${cssQuery}!${sassLoader}`;
@@ -44,12 +45,9 @@ const cssModuleQuery = `${styleLoader}!${cssLoader}${cssLoaderOptions}!${postcss
 const cssStylusQuery = `${cssModuleQuery}!${stylusLoader}`;
 const cssScssQuery = `${cssModuleQuery}!${sassLoader}`;
 
-const cssExists =
-  glob.sync(Path.resolve(process.cwd(), "src/styles", "*.css")).length > 0;
-const stylusExists =
-  glob.sync(Path.resolve(process.cwd(), "src/styles", "*.styl")).length > 0;
-const scssExists =
-  glob.sync(Path.resolve(process.cwd(), "src/styles", "*.scss")).length > 0;
+const cssExists = glob.sync(Path.resolve(process.cwd(), "src/styles", "*.css")).length > 0;
+const stylusExists = glob.sync(Path.resolve(process.cwd(), "src/styles", "*.styl")).length > 0;
+const scssExists = glob.sync(Path.resolve(process.cwd(), "src/styles", "*.scss")).length > 0;
 
 const rules = [];
 
@@ -109,12 +107,13 @@ module.exports = function() {
               : [];
           },
           stylus: {
-            use: !cssModuleSupport ? [
-                autoprefixer({
-                  browsers: ["last 2 versions", "ie >= 9", "> 5%"]
-                })
-              ]
-            : [],
+            use: !cssModuleSupport
+              ? [
+                  autoprefixer({
+                    browsers: ["last 2 versions", "ie >= 9", "> 5%"]
+                  })
+                ]
+              : [],
             define: {
               $tenant: process.env.ELECTRODE_TENANT || "walmart"
             }

--- a/packages/electrode-archetype-react-component-dev/package.json
+++ b/packages/electrode-archetype-react-component-dev/package.json
@@ -72,7 +72,6 @@
     "lodash": "^4.5.0",
     "lodash-webpack-plugin": "^0.11.2",
     "mocha": "^4.0.0",
-    "node-sass": "^4.7.2",
     "nodemon": "^1.8.1",
     "optional-require": "^1.0.0",
     "postcss-cssnext": "^2.7.0",
@@ -87,7 +86,6 @@
     "react-test-renderer": "^16.0.0",
     "require-at": "^1.0.0",
     "rimraf": "^2.5.2",
-    "sass-loader": "^6.0.6",
     "sinon": "^4.0.0",
     "sinon-chai": "^2.14.0",
     "style-loader": "^0.20.1",
@@ -105,7 +103,8 @@
   "optionalDependencies": {
     "electrode-archetype-opt-inferno": "^0.2.3",
     "electrode-archetype-opt-karma": "^1.0.1",
-    "electrode-archetype-opt-react": "^1.0.1"
+    "electrode-archetype-opt-react": "^1.0.1",
+    "electrode-archetype-opt-sass": "^1.0.0"
   },
   "devDependencies": {
     "electrode-archetype-react-component": "../electrode-archetype-react-component",
@@ -126,7 +125,8 @@
     "optionalDependencies": {
       "electrode-archetype-opt-inferno": "../electrode-archetype-opt-inferno",
       "electrode-archetype-opt-karma": "../electrode-archetype-opt-karma",
-      "electrode-archetype-opt-react": "../electrode-archetype-opt-react"
+      "electrode-archetype-opt-react": "../electrode-archetype-opt-react",
+      "electrode-archetype-opt-sass": "../electrode-archetype-opt-sass"
     }
   }
 }

--- a/packages/electrode-archetype-react-component/config/archetype.js
+++ b/packages/electrode-archetype-react-component/config/archetype.js
@@ -33,7 +33,7 @@ if (process.cwd() !== hostDir) {
 
 const userConfig = Object.assign(
   {
-    options: { karma: true }
+    options: { karma: true, sass: true }
   },
   optionalRequire(Path.join(hostDir, "archetype/config"))
 );


### PR DESCRIPTION
* When specifying nodeSass:true
> optional dep check passed electrode-archetype-opt-node-sass@1.0.0-fynlocal_h- preinstall script exit with code 0

```
fyn stat node-sass
> node-sass matched these installed versions node-sass@4.9.3
> node-sass@4.9.3 has these dependents sass-loader@6.0.7

fyn stat sass-loader
> sass-loader matched these installed versions sass-loader@6.0.7
> sass-loader@6.0.7 has these dependents
```

* Without specifying nodeSass or nodeSass: false
> executed electrode-archetype-opt-node-sass@1.0.0-fynlocal_h- preinstall failed shell cmd 'node optional-check.js' exit code 1

```
fyn stat node-sass
> node-sass is not installed

fyn stat sass-loader
> sass-loader is not installed
```

Tested on `universal-react-node` sample.
electrode issue link: https://github.com/electrode-io/electrode/issues/913