### PR TITLE
update optimize css to not touch zindex by default

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/archetype.js
+++ b/packages/electrode-archetype-react-app-dev/config/archetype.js
@@ -3,6 +3,7 @@
 const Path = require("path");
 const optionalRequire = require("optional-require")(require);
 const userConfig = Object.assign({}, optionalRequire(Path.resolve("archetype/config")));
+const _ = require("lodash");
 
 const devPkg = require("../package.json");
 const devDir = Path.join(__dirname, "..");
@@ -34,7 +35,7 @@ const karmaConfigSpec = {
   browser: { env: "KARMA_BROWSER", default: "chrome" }
 };
 
-module.exports = {
+const config = {
   devDir,
   devPkg,
   devRequire,
@@ -55,3 +56,9 @@ module.exports = {
     userConfig.configPaths
   )
 };
+
+module.exports = config;
+
+// pick any options that are not simple ENV based
+// TODO: update xenv-config to support JSON
+_.defaultsDeep(config, _.pick(userConfig, ["webpack", "karma", "jest"]));

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract-style.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/extract-style.js
@@ -3,6 +3,7 @@
 const archetype = require("electrode-archetype-react-app/config/archetype");
 const Path = require("path");
 const webpack = require("webpack");
+const _ = require("lodash");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const OptimizeCssAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const CSSSplitPlugin = require("css-split-webpack-plugin").default;
@@ -96,11 +97,18 @@ module.exports = function() {
     });
   }
 
+  const optimizeCssOptions = () =>
+    _.defaultsDeep({}, archetype.webpack.optimizeCssOptions, {
+      cssProcessorOptions: {
+        zindex: false
+      }
+    });
+
   return {
     module: { rules },
     plugins: [
       new ExtractTextPlugin({ filename: "[name].style.[hash].css" }),
-      process.env.NODE_ENV === "production" && new OptimizeCssAssetsPlugin(),
+      process.env.NODE_ENV === "production" && new OptimizeCssAssetsPlugin(optimizeCssOptions()),
       /*
        preserve: default: false. Keep the original unsplit file as well.
        Sometimes this is desirable if you want to target a specific browser (IE)


### PR DESCRIPTION
We use optimize-css-assets-webpack-plugin to optimize CSS, which internally uses cssnano, which default to mutate z-index. 

since that's generally a bad idea, we are defaulting this behavior to off.

Further, since optimize-css-assets-webpack-plugin takes an options object, user can now specify the following in `archetype/config/index.js`:

```js
module.exports = {
  webpack: {
    optimizeCssOptions: {
      cssProcessorOptions: {
        zindex: true
      }
    }
  }
};
```

This will turn z-index mutation back on, and any allow any other optimize-css-assets-webpack-plugin options to be specified, see its docs on options it supports.


 - [ ] TBD: update electrode docs