### PR TITLE
Improve `build-analyze` command

### DIFF
--- a/packages/electrode-archetype-react-app/arch-clap.js
+++ b/packages/electrode-archetype-react-app/arch-clap.js
@@ -799,7 +799,8 @@ Individual .babelrc files were generated for you in src/client and src/server
       desc: "Generate a list of all files that went into production bundle JS (results in .etmp)",
       task: () => {
         const stats = JSON.parse(Fs.readFileSync("dist/server/stats.json"));
-        const bundle = stats.assetsByChunkName.main.find(x => x.endsWith(".js"));
+        const entry = Object.keys(tats.assetsByChunkName).pop()
+        const bundle = stats.assetsByChunkName[entry].find(x => x.endsWith(".js"));
         return `~$analyze-bundle -b dist/js/${bundle} -s dist/server/stats.json`;
       }
     },


### PR DESCRIPTION
Currently `build-analyze` command analyzes the entry with hardcoded name `main` only.
If you happen to change your entry name in the `entry.config.js` this command will fail.
This PR fixes this by just picking up the first entry from the `stats.json`.