### PR TITLE
allow disabling responseForBadStatus

### DIFF
--- a/packages/electrode-react-webapp/lib/hapi/index.js
+++ b/packages/electrode-react-webapp/lib/hapi/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-/* eslint-disable no-magic-numbers, max-params, max-statements */
+/* eslint-disable no-magic-numbers, max-params, max-statements, complexity */
 
 const _ = require("lodash");
 const assert = require("assert");
@@ -33,10 +33,15 @@ const DefaultHandleRoute = (request, reply, handler, content, routeOptions) => {
         return respond;
       } else if (HttpStatus.displayHtml[status] || (status >= 200 && status < 300)) {
         respond = reply(data.html !== undefined ? data.html : data);
-      } else {
+      } else if (routeOptions.responseForBadStatus) {
         const output = routeOptions.responseForBadStatus(request, routeOptions, data);
         status = output.status;
         respond = reply(output.html);
+      } else {
+        // should not reach here w/o html because user returned content
+        // would have to return a literal string that has no `.status`
+        // and html being undefined to be able to skip all the cases above
+        respond = reply(data.html);
       }
 
       const response = context.user && context.user.response;

--- a/packages/electrode-react-webapp/lib/react-webapp.js
+++ b/packages/electrode-react-webapp/lib/react-webapp.js
@@ -83,12 +83,14 @@ const setupOptions = options => {
   return pluginOptions;
 };
 
+const pathSpecificOptions = ["htmlFile", "responseForBadStatus", "responseForError"];
+
 const setupPathOptions = (routeOptions, path) => {
   const pathData = _.get(routeOptions, ["paths", path], {});
   const pathOptions = pathData.options;
   return _.defaultsDeep(
+    _.pick(pathData, pathSpecificOptions),
     {
-      htmlFile: pathData.htmlFile,
       tokenHandler: [].concat(routeOptions.tokenHandler, pathData.tokenHandler),
       tokenHandlers: [].concat(routeOptions.tokenHandlers, pathData.tokenHandlers)
     },

--- a/packages/electrode-react-webapp/test/spec/hapi.index.spec.js
+++ b/packages/electrode-react-webapp/test/spec/hapi.index.spec.js
@@ -252,7 +252,7 @@ describe("hapi electrode-react-webapp", () => {
     });
   });
 
-  it("should return error", () => {
+  it("should return 500 if content rejects with error", () => {
     assign(mainRoutePathOptions, {
       content: () =>
         Promise.reject({
@@ -1352,7 +1352,36 @@ describe("hapi electrode-react-webapp", () => {
     assign(mainRoutePathOptions, {
       content: {
         status: 501,
+        html: "custom 501 HTML message",
         message: "not implemented"
+      }
+    });
+
+    return electrodeServer(config).then(server => {
+      return server
+        .inject({
+          method: "GET",
+          url: "/?__mode=noss"
+        })
+        .then(res => {
+          expect(res.statusCode).to.equal(501);
+          stopServer(server);
+        })
+        .catch(err => {
+          stopServer(server);
+          throw err;
+        });
+    });
+  });
+
+  it("should render if content has html despite non 200 status", () => {
+    assign(mainRoutePathOptions, {
+      options: {
+        responseForBadStatus: null
+      },
+      content: {
+        status: 501,
+        html: null
       }
     });
 


### PR DESCRIPTION
electrode-react-webapp: Allow user to set `responseForBadStatus` option to null, so even if content return bad status, still return the rendered result verbatim.
