### PR TITLE
Update webpack config composer to make it easier to customize

### DIFF
--- a/docs/chapter1/intermediate/app-archetype/webpack-config.md
+++ b/docs/chapter1/intermediate/app-archetype/webpack-config.md
@@ -1,6 +1,6 @@
 # Webpack Configurations
 
-Webpack configurations are a significant part of the app archetype.  They help with compiling and bundling your React app code.  Webpack is a very sophisticated and complex software and while we provided sensible defaults, we make it possible for you to customize your own.
+Webpack configurations are a significant part of the app archetype. They help with compiling and bundling your React app code. Webpack is a very sophisticated and complex software and while we provided sensible defaults, we make it possible for you to customize your own.
 
 The webpack configurations in the app archetype are separated into partials and compose into a single configuration using [webpack-config-composer] that's passed to webpack.
 
@@ -11,32 +11,23 @@ There are two ways to override the app archetype's webpack configuration.
 
 Either way, the archetype has the following configuration to use with webpack:
 
--   `webpack.config.js` - When building your app for production
--   `webpack.config.dev.js` - When running your app in development mode
--   `webpack.config.hot.js` - When running your app in hot mode
--   `webpack.config.test.js` - When running tests
--   `webpack.config.coverage.js` - When running coverage test
--   `webpack.config.browsercoverage.js` - When running coverage test in the browser
+- `webpack.config.js` - When building your app for production
+- `webpack.config.dev.js` - When running your app in development mode
+- `webpack.config.hot.js` - When running your app in hot mode
+- `webpack.config.test.js` - When running tests
+- `webpack.config.coverage.js` - When running coverage test
+- `webpack.config.browsercoverage.js` - When running coverage test in the browser
 
 ## Overriding
 
 To override the webpack configuration, you can create a webpack configuration with the same filename as above, either in your app's root directory, or under the directory `archetype/config/webpack`.
 
-For example, you can extended or overriding webpack configuration by:
+Your file can customize the final webpack config with two approaches:
 
-```
-const BellOnBundlerErrorPlugin = require('bell-on-bundler-error-plugin');
+1. Simply export the JSON object to be merged into the final config
+2. Export a function that takes the [webpack-config-composer] instance to manipulate the composition programatically.
 
-const config = {
-  plugins: [
-    new BellOnBundlerErrorPlugin()
-  ]
-};
-
-module.exports = config;
-```
-
-### Provide A Configuration
+### Simple JSON Object
 
 Your file can export a plain JSON format file that can be merged into the archetype's configuration.
 
@@ -49,31 +40,57 @@ module.exports = {
       "my-alias": "my-module"
     }
   }
-}
+};
 ```
 
-> Note that this will only affect `webpack.config.js`.  To override other webpack configuration in the archetype, you need to add another file with the corresponding name.
+> Note that this will only affect `webpack.config.js`. To override other webpack configuration in the archetype, you need to add another file with the corresponding name.
 
-### Control The Composer
+Another example to add a plugin:
 
-If you want to have more control of how the final webpack configuration is composed, your file should export a function that will receive the composer from the app archetype.
+```js
+const BellOnBundlerErrorPlugin = require("bell-on-bundler-error-plugin");
 
-The function should take three parameters: `composer`, `options`, `compose_func`.
+const config = {
+  plugins: [new BellOnBundlerErrorPlugin()]
+};
 
--   `composer` - The [webpack-config-composer] instance that the app archetype has setup.  It contains all the webpack partials and composer profiles from the app archetype.
--   `options` - The options for the app archetype's webpack configuration composition.
--   `compose_func` - The function that the app archetype would've used to compose the final config.  If you like, you can call this after you've made some updates to the `composer`.
+module.exports = config;
+```
 
-This approach hands you the most direct control of composing the final webpack configuration using [webpack-config-composer].  The `composer` instance your function received has all the webpack partials from the archetype, and the profiles that would've contributed to the final config.
+### Customize Function
+
+You can provide a function that takes the [webpack-config-composer] instance to manipulate the composition programatically.
+
+For example:
+
+```js
+const BellOnBundlerErrorPlugin = require("bell-on-bundler-error-plugin");
+
+module.exports = composer => {
+  composer.addPartialToProfile("my-partial", "user", {
+    plugins: [new BellOnBundlerErrorPlugin()]
+  });
+};
+```
+
+> By returning nothing, you still leave the final composition step to the archetype, but you can actually do all that in your function also. See below for further details.
+
+The function can take up to three parameters: `composer`, `options`, `compose_func`.
+
+- `composer` - The [webpack-config-composer] instance that the app archetype has setup. It contains all the webpack partials and composer profiles from the app archetype.
+- `options` - The options for the app archetype's webpack configuration composition.
+- `compose_func` - The function that the app archetype would've used to compose the final config. If you like, you can call this after you've made some updates to the `composer`.
+
+This approach hands you the most direct control of composing the final webpack configuration using [webpack-config-composer]. The `composer` instance your function received has all the webpack partials from the archetype, and the profiles that would've contributed to the final config.
 
 #### `options`
 
-The options object contains all the information that the archetype used to create the composer instance.  It contains the following:
+The options object contains all the information that the archetype used to create the composer instance. It contains the following:
 
--   `profiles` - The profiles that's added to the composer
--   `profileNames` - Names of the profiles to use to compose the final configuration
--   `configFilename` - Name of the webpack configuration file.  ie: `webpack.config.js`
--   `keepCustomProps` - Flag to indicate whether to keep the custom props in the final configuration.
+- `profiles` - The profiles that's added to the composer
+- `profileNames` - Names of the profiles to use to compose the final configuration
+- `configFilename` - Name of the webpack configuration file. ie: `webpack.config.js`
+- `keepCustomProps` - Flag to indicate whether to keep the custom props in the final configuration.
 
 #### Examples
 
@@ -81,22 +98,24 @@ Below are two examples showing `webpack.config.js`, that is placed in `archetype
 
 ##### Merging
 
-Lodash's merge method doesn't concatenate arrays, but you can provide a customizer to make the change.  
+Lodash's merge method doesn't concatenate arrays, but you can provide a customizer to make the change.
 
-This example shows a function that merges a configuration into the archetype configuration.
+This example shows a function that merges a configuration into the final configuration with a custom function for handling array concatenation.
 
 ```js
 const _ = require("lodash");
 
-module.exports = function (composer, options, compose) {
+module.exports = function(composer, options, compose) {
   const config = compose();
-  _.merge(config, {
-    // your custom webpack config
-  }, (a, b) => {
-    return (Array.isArray(a) && Array.isArray(b))
-      ? [].concat(a).concat(b)
-      : undefined;
-  });
+  _.merge(
+    config,
+    {
+      // your custom webpack config
+    },
+    (a, b) => {
+      return Array.isArray(a) && Array.isArray(b) ? [].concat(a).concat(b) : undefined;
+    }
+  );
   return config;
 };
 ```
@@ -106,25 +125,19 @@ module.exports = function (composer, options, compose) {
 This example completely removes the `_extract-style` partial from the composer and adds a custom partial for handling styles.
 
 ```js
-module.exports = function( composer, options, compose ) {
+module.exports = function(composer, options, compose) {
   // add custom-style partial to the composer
-  composer.addPartials({
-    "custom-style": {
-      config: {
-        // contains the actual webpack configs for this partial
-      }
-    }
+  composer.addPartial("custom-style", {
+    // contains the actual webpack configs for this partial
   });
+
   // disable the _extract-style partial from _base profile
   // and add custom-style partial to it with the same order
-  const base = composer.profiles._base;
-  const tmp = base.partials["_extract-style"];
-  tmp.enable = false;
-  base.partials["custom-style"] = { order: tmp.order };
-
-  // Now that the composer has been updated, compose the final config
-  return compose();
-}
+  const baseProf = composer.getProfile("_base");
+  const stylePartProf = baseProf.getPartial("_extract-style");
+  stylePartProf.enable = false; // disable it
+  baseProf.setPartial("custom-style", { order: stylePartProf.order });
+};
 ```
 
 #### App Archetype's partials and profiles

--- a/packages/electrode-archetype-react-app-dev/config/webpack/util/generate-config.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/util/generate-config.js
@@ -12,6 +12,7 @@ const logger = require("electrode-archetype-react-app/lib/logger");
 function generateConfig(options) {
   const composer = new WebpackConfigComposer();
   composer.addProfiles(options.profiles);
+  composer.addProfile("user", {});
   composer.addPartials(partialConfigs.partials);
 
   let customConfig;
@@ -30,11 +31,12 @@ function generateConfig(options) {
   }
 
   const keepCustomProps = options.keepCustomProps;
-  const compose = () =>
-    composer.compose(
+  const compose = () => {
+    return composer.compose(
       { keepCustomProps },
-      options.profileNames
+      options.profileNames.concat("user")
     );
+  };
 
   let config;
 
@@ -42,11 +44,11 @@ function generateConfig(options) {
     if (_.isFunction(customConfig)) {
       config = customConfig(composer, options, compose);
     } else {
-      config = _.merge(compose(), customConfig);
+      composer.addPartialToProfile("custom", "user", customConfig);
     }
-  } else {
-    config = compose();
   }
+
+  if (!config) config = compose();
 
   logger.verbose("Final Webpack config", JSON.stringify(config, null, 2));
 

--- a/packages/webpack-config-composer/lib/concat-method.js
+++ b/packages/webpack-config-composer/lib/concat-method.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const headConcatArrayMerge = require("./head-concat-array-merge");
+const tailConcatArrayMerge = require("./tail-concat-array-merge");
+
+const concatArrayMerge = {
+  head: headConcatArrayMerge,
+  tail: tailConcatArrayMerge,
+  no: undefined
+};
+
+const getConcatMethod = (method, fallback) => {
+  return concatArrayMerge.hasOwnProperty(method)
+    ? concatArrayMerge[method]
+    : fallback || concatArrayMerge.tail;
+};
+
+module.exports = { getConcatMethod };

--- a/packages/webpack-config-composer/lib/index.js
+++ b/packages/webpack-config-composer/lib/index.js
@@ -7,19 +7,18 @@ const _ = require("lodash");
 const assert = require("assert");
 
 const concatArrayMerge = {
-  "head": headConcatArrayMerge,
-  "tail": tailConcatArrayMerge,
-  "no": undefined
+  head: headConcatArrayMerge,
+  tail: tailConcatArrayMerge,
+  no: undefined
 };
 
 const getConcatMethod = (method, fallback) => {
   return concatArrayMerge.hasOwnProperty(method)
     ? concatArrayMerge[method]
-    : (fallback || concatArrayMerge.tail);
+    : fallback || concatArrayMerge.tail;
 };
 
 class WebpackConfigComposer {
-
   constructor(options) {
     options = options || {};
     this.profiles = {};
@@ -35,8 +34,8 @@ class WebpackConfigComposer {
 
   addProfiles(profiles) {
     profiles = Array.isArray(profiles) ? profiles : Array.prototype.slice.call(arguments);
-    profiles.forEach((a) => {
-      Object.keys(a).forEach((k) => {
+    profiles.forEach(a => {
+      Object.keys(a).forEach(k => {
         assert(!this.profiles.hasOwnProperty(k), `Profile ${k} already exist.`);
         this.profiles[k] = a[k];
       });
@@ -45,15 +44,19 @@ class WebpackConfigComposer {
 
   addPartials(partials) {
     partials = Array.isArray(partials) ? partials : Array.prototype.slice.call(arguments);
-    partials.forEach((a) => {
-      Object.keys(a).forEach((k) => {
+    partials.forEach(a => {
+      Object.keys(a).forEach(k => {
         const x = a[k];
         const opt = x.addOptions || {};
         const p = _.omit(x, "addOptions");
         if (opt.method === "replace") {
           this.partials[k] = p;
         } else {
-          _.mergeWith(this.partials, { [k]: _.omit(x, "addOptions") }, getConcatMethod(opt.concatArray));
+          _.mergeWith(
+            this.partials,
+            { [k]: _.omit(x, "addOptions") },
+            getConcatMethod(opt.concatArray)
+          );
         }
       });
     });
@@ -65,7 +68,7 @@ class WebpackConfigComposer {
     }
 
     const name = profile.join("-");
-    profile = profile.map((p) => {
+    profile = profile.map(p => {
       if (_.isString(p)) {
         assert(this.profiles.hasOwnProperty(p), `Profile ${p} doesn't exist in the composer`);
         return this.profiles[p];
@@ -76,24 +79,30 @@ class WebpackConfigComposer {
     profile = _.merge.apply(null, profile);
     profile.name = name;
 
-    const num = (x) => {
+    const num = x => {
       return _.isString(x) ? parseInt(x, 10) : x;
     };
-    const checkNaN = (x) => {
+    const checkNaN = x => {
       return isNaN(x) ? Infinity : x;
     };
-    const isEnable = (p) => profile.partials[p].enable !== false;
+    const isEnable = p => profile.partials[p].enable !== false;
 
-    const partialOrder = (p) => checkNaN(num(profile.partials[p].order));
-    const sortedKeys = _(Object.keys(profile.partials)).filter(isEnable).sortBy(partialOrder).value();
+    const partialOrder = p => checkNaN(num(profile.partials[p].order));
+    const sortedKeys = _(Object.keys(profile.partials))
+      .filter(isEnable)
+      .sortBy(partialOrder)
+      .value();
 
     const currentConfig = options.currentConfig || {};
 
     const concat = getConcatMethod(options.concatArray);
 
-    sortedKeys.forEach((partialName) => {
+    sortedKeys.forEach(partialName => {
       let ret;
-      assert(this.partials.hasOwnProperty(partialName), `Partial ${partialName} doesn't exist or has not been added`);
+      assert(
+        this.partials.hasOwnProperty(partialName),
+        `Partial ${partialName} doesn't exist or has not been added`
+      );
       const partial = this.partials[partialName];
       if (typeof partial.config === "object") {
         ret = partial.config;
@@ -114,7 +123,7 @@ class WebpackConfigComposer {
     });
 
     if (!options.skipNamePlugins && currentConfig.plugins) {
-      currentConfig.plugins = currentConfig.plugins.map((x) => {
+      currentConfig.plugins = currentConfig.plugins.map(x => {
         x.__name = x.constructor.name;
         return x;
       });

--- a/packages/webpack-config-composer/lib/partial.js
+++ b/packages/webpack-config-composer/lib/partial.js
@@ -1,0 +1,54 @@
+"use strict";
+
+const _ = require("lodash");
+const { getConcatMethod } = require("./concat-method");
+
+class Partial {
+  constructor(name, data) {
+    this._name = name;
+    this._data = Object.assign({ config: {}, options: {} }, data);
+  }
+
+  set config(config) {
+    this._data.config = config;
+  }
+
+  get config() {
+    return this._data.config;
+  }
+
+  set options(options) {
+    this._data.options = Object.assign({}, options);
+  }
+
+  get options() {
+    return this._data.options;
+  }
+
+  merge(data, concatArray) {
+    _.mergeWith(this._data, data, getConcatMethod(concatArray));
+  }
+
+  compose(options) {
+    const config = this.config;
+    const configType = typeof config;
+
+    let ret;
+
+    if (configType === "object") {
+      ret = config;
+    } else if (configType === "function") {
+      options = Object.assign({}, this.options, options);
+      ret = config(options);
+      if (typeof ret === "function") {
+        ret = ret(options);
+      }
+    } else {
+      throw new Error(`can't process config from Partial ${this._name}`);
+    }
+
+    return ret;
+  }
+}
+
+module.exports = Partial;

--- a/packages/webpack-config-composer/lib/profile.js
+++ b/packages/webpack-config-composer/lib/profile.js
@@ -1,0 +1,30 @@
+"use strict";
+
+class Profile {
+  constructor(name, partials) {
+    this._name = name;
+    this._partials = partials || {};
+  }
+
+  get name() {
+    return this._name;
+  }
+
+  get partials() {
+    return this._partials;
+  }
+
+  setPartial(name, options) {
+    this._partials[name] = options || {};
+  }
+
+  getPartial(name) {
+    return this._partials[name];
+  }
+
+  delPartial(name) {
+    delete this._partials[name];
+  }
+}
+
+module.exports = Profile;

--- a/packages/webpack-config-composer/test/spec/index.spec.js
+++ b/packages/webpack-config-composer/test/spec/index.spec.js
@@ -67,7 +67,8 @@ describe("composer", function() {
       { keepCustomProps: true },
       {
         partials: { test: {} }
-      }
+      },
+      {} // test empty profile
     );
     expect(config._test).to.equal("hello");
   });
@@ -205,6 +206,64 @@ describe("composer", function() {
       const composer = new WebpackConfigComposer();
       composer.addProfiles([{ a: { partials: {} }, b: { partials: {} } }]);
       expect(composer.profiles).to.have.keys("a", "b");
+    });
+  });
+
+  describe("addProfile", function() {
+    it("should take list of partial names for new profile", () => {
+      const composer = new WebpackConfigComposer();
+      composer.addProfile("test", "a", "b", "c");
+      const prof = composer.getProfile("test");
+      expect(prof.partials).to.deep.equal({
+        a: {},
+        b: {},
+        c: {}
+      });
+    });
+
+    it("should add profile with an object of partials", () => {
+      const composer = new WebpackConfigComposer();
+      composer.addProfile("test", {
+        a: {},
+        b: {},
+        c: {}
+      });
+      const prof = composer.getProfile("test");
+      expect(prof.partials).to.deep.equal({
+        a: {},
+        b: {},
+        c: {}
+      });
+    });
+  });
+
+  describe("addPartialToProfile", function() {
+    it("should create profile if it doesn't exist", () => {
+      const composer = new WebpackConfigComposer();
+      composer.addPartialToProfile("user", "test", { plugins: [] });
+      const user = composer.getPartial("user");
+      expect(user).to.exist;
+      expect(user.config).to.deep.equal({ plugins: [] });
+      expect(user.options).to.deep.equal({});
+      expect(composer.getProfile("test")).to.exist;
+    });
+
+    it("should add the partial", () => {
+      const composer = new WebpackConfigComposer();
+      composer.addPartialToProfile("user", "test", { plugins: [] });
+      const user = composer.getPartial("user");
+      expect(user).to.exist;
+      expect(user.config).to.deep.equal({ plugins: [] });
+      expect(user.options).to.deep.equal({});
+    });
+
+    it("should use existing profile", () => {
+      const composer = new WebpackConfigComposer();
+      composer.addProfile("test", "foo");
+      composer.addPartialToProfile("user", "test", { plugins: [] });
+      const prof = composer.getProfile("test");
+      expect(prof).to.exist;
+      expect(prof.getPartial("foo")).to.deep.equal({});
     });
   });
 

--- a/packages/webpack-config-composer/test/spec/index.spec.js
+++ b/packages/webpack-config-composer/test/spec/index.spec.js
@@ -8,7 +8,7 @@ const loaderPartial = require("../fixtures/partial/loader");
 const _ = require("lodash");
 const FooPlugin = require("../fixtures/plugins/foo-plugin");
 
-describe("composer", function () {
+describe("composer", function() {
   it("should accept partials and generate config", () => {
     const composer = new WebpackConfigComposer({
       partials: {
@@ -21,17 +21,17 @@ describe("composer", function () {
       profiles: {
         b: {
           partials: {
-            "bar": {
+            bar: {
               order: 200
             },
-            "test": {
+            test: {
               order: 300
             }
           }
         },
         a: {
           partials: {
-            "foo": {
+            foo: {
               order: "100"
             }
           }
@@ -40,7 +40,11 @@ describe("composer", function () {
     });
     composer.addPartials(fooPartial, barPartial);
     expect(composer.profiles).to.have.keys("a", "b");
-    const config = composer.compose({}, "a", "b");
+    const config = composer.compose(
+      {},
+      "a",
+      "b"
+    );
     expect(config.testFoo).to.equal("test");
   });
 
@@ -55,9 +59,12 @@ describe("composer", function () {
         }
       }
     });
-    const config = composer.compose({ keepCustomProps: true }, {
-      partials: { test: {} }
-    });
+    const config = composer.compose(
+      { keepCustomProps: true },
+      {
+        partials: { test: {} }
+      }
+    );
     expect(config._test).to.equal("hello");
   });
 
@@ -72,59 +79,68 @@ describe("composer", function () {
         }
       }
     });
-    const config = composer.compose({ currentConfig: { hello: "world" } }, {
-      partials: { test: {} }
-    });
+    const config = composer.compose(
+      { currentConfig: { hello: "world" } },
+      {
+        partials: { test: {} }
+      }
+    );
     expect(config.hello).to.equal("world");
   });
 
   it("instance should have deleteCustomProps", () => {
     const composer = new WebpackConfigComposer();
-    expect(composer.deleteCustomProps({
-      _name: "test",
-      hello: "world"
-    })).to.deep.equal({ hello: "world" });
-  })
+    expect(
+      composer.deleteCustomProps({
+        _name: "test",
+        hello: "world"
+      })
+    ).to.deep.equal({ hello: "world" });
+  });
 
   it("should skip adding __name to plugins", () => {
     const composer = new WebpackConfigComposer();
     composer.addPartials({
-      "foo": {
+      foo: {
         config: {
-          plugins: [
-            new FooPlugin()
-          ]
+          plugins: [new FooPlugin()]
         }
       }
     });
-    const config = composer.compose({ skipNamePlugins: true }, {
-      partials: {
-        "foo": {}
+    const config = composer.compose(
+      { skipNamePlugins: true },
+      {
+        partials: {
+          foo: {}
+        }
       }
-    });
+    );
     expect(config.plugins[0].__name).to.equal(undefined);
   });
 
   it("should call a partial config if it's a function", () => {
     const composer = new WebpackConfigComposer();
     composer.addPartials(fooPartial, loaderPartial);
-    const config = composer.compose({}, [
-      {
-        partials: {
-          "foo": {
-            order: "100"
+    const config = composer.compose(
+      {},
+      [
+        {
+          partials: {
+            foo: {
+              order: "100"
+            }
+          }
+        },
+        {
+          partials: {
+            loader: {},
+            badButDisabled: {
+              enable: false
+            }
           }
         }
-      },
-      {
-        partials: {
-          "loader": {},
-          "badButDisabled": {
-            enable: false
-          }
-        }
-      }
-    ]);
+      ]
+    );
     expect(config.module.rules[0]).to.equal("loader-rule1");
   });
 
@@ -135,7 +151,10 @@ describe("composer", function () {
         config: () => require("../fixtures/partial/loader").loader.config
       }
     });
-    const config = composer.compose({}, { partials: { "loader": {} } });
+    const config = composer.compose(
+      {},
+      { partials: { loader: {} } }
+    );
     expect(config.module.rules[0]).to.equal("loader-rule1");
   });
 
@@ -146,24 +165,32 @@ describe("composer", function () {
         config: true
       }
     });
-    expect(() => composer.compose({}, { partials: { "test": {} } })).to.throw();
+    expect(() =>
+      composer.compose(
+        {},
+        { partials: { test: {} } }
+      )
+    ).to.throw();
   });
 
   it("should allow a config function to apply the config by returning nothing", () => {
     const composer = new WebpackConfigComposer();
     composer.addPartials(fooPartial, {
       loader: {
-        config: (options) => {
+        config: options => {
           const config = require("../fixtures/partial/loader").loader.config(options);
           _.merge(options.currentConfig, config);
         }
       }
     });
-    const config = composer.compose({}, { partials: { "loader": {} } });
+    const config = composer.compose(
+      {},
+      { partials: { loader: {} } }
+    );
     expect(config.module.rules[0]).to.equal("loader-rule1");
   });
 
-  describe("addProfiles", function () {
+  describe("addProfiles", function() {
     it("should accept multiple profiles", () => {
       const composer = new WebpackConfigComposer();
       composer.addProfiles({ a: { partials: {} }, b: { partials: {} } });
@@ -177,7 +204,7 @@ describe("composer", function () {
     });
   });
 
-  describe("addPartials", function () {
+  describe("addPartials", function() {
     it("should add new partial", () => {
       const composer = new WebpackConfigComposer();
       composer.addPartials(fooPartial);
@@ -198,9 +225,7 @@ describe("composer", function () {
       composer.addPartials({
         foo: {
           config: {
-            plugins: [
-              "fooTest"
-            ]
+            plugins: ["fooTest"]
           },
           addOptions: {
             concatArray: "tail"
@@ -208,9 +233,7 @@ describe("composer", function () {
         },
         bar: {
           config: {
-            plugins: [
-              "barTest"
-            ]
+            plugins: ["barTest"]
           },
           addOptions: {
             concatArray: "head"
@@ -221,7 +244,6 @@ describe("composer", function () {
       expect(composer.partials.bar.config.plugins[0]).to.equal("barTest");
     });
 
-
     it("should repalce existing partial", () => {
       const composer = new WebpackConfigComposer({
         partials: [fooPartial, barPartial]
@@ -229,9 +251,7 @@ describe("composer", function () {
       composer.addPartials({
         foo: {
           config: {
-            plugins: [
-              "fooTest"
-            ]
+            plugins: ["fooTest"]
           },
           addOptions: {
             method: "replace",
@@ -240,9 +260,7 @@ describe("composer", function () {
         },
         bar: {
           config: {
-            plugins: [
-              "barTest"
-            ]
+            plugins: ["barTest"]
           },
           addOptions: {
             concatArray: "head"

--- a/packages/webpack-config-composer/test/spec/profile.spec.js
+++ b/packages/webpack-config-composer/test/spec/profile.spec.js
@@ -1,0 +1,27 @@
+"use strict";
+
+const Profile = require("../../lib/profile");
+const expect = require("chai").expect;
+
+describe("profile", function() {
+  it("should default partials to {}", () => {
+    const prof = new Profile("test");
+    expect(prof.partials).to.deep.equal({});
+  });
+
+  it("should have name", () => {
+    const prof = new Profile("test");
+    expect(prof.name).to.equal("test");
+  });
+
+  it("should handle set/get/del partial", () => {
+    const prof = new Profile("test", { foo: {} });
+    prof.setPartial("bar");
+    prof.setPartial("blah", { order: 10 });
+    expect(prof.getPartial("foo")).to.deep.equal({});
+    expect(prof.getPartial("bar")).to.deep.equal({});
+    expect(prof.getPartial("blah")).to.deep.equal({ order: 10 });
+    prof.delPartial("blah");
+    expect(prof.getPartial("blah")).to.not.exist;
+  });
+});


### PR DESCRIPTION
- add three new APIs to webpack-config-composer `addPartial`, `addProfile`, and `addPartialToProfile`
- update archetype generate-config:

    - add a `user` profile to allow custom code to easily add config partials
    - use webpack config composer to compose user's config object

- update webpack config customization doc to show the easier way
