### PR TITLE
[major] webpack4: update ProgressPlugin to webpack4

### DIFF
--- a/packages/electrode-archetype-react-app-dev/lib/webpack-dev-hapi.js
+++ b/packages/electrode-archetype-react-app-dev/lib/webpack-dev-hapi.js
@@ -57,10 +57,10 @@ function register(server, options, next) {
     new Webpack.NoEmitOnErrorsPlugin()
   ].concat(config.plugins);
 
-  const compiler = new Webpack(config);
+  const compiler = Webpack(config);
 
   if (options.progress !== false) {
-    compiler.apply(new Webpack.ProgressPlugin({ profile: options.progressProfile }));
+    new Webpack.ProgressPlugin({ profile: options.progressProfile }).apply(compiler); 
   }
 
   const webpackDevOptions = _.merge(


### PR DESCRIPTION
Resolve warnings:
```
TypeError: Webpack is not a constructor
    at Object.register (/Users/s0d00px/Electrode/electrode/samples/universal-react-node/node_modules/electrode-archetype-react-app-dev/lib/webpack-dev-hapi.js:60:20)
    at Object.target [as register] (/Users/s0d00px/Electrode/electrode/samples/universal-react-node/node_modules/__fv_/11.4.0/joi/lib/types/object/index.js:76:34)
    at each (/Users/s0d00px/Electrode/electrode/samples/universal-react-node/node_modules/hapi/lib/plugin.js:310:14)
```