### PR TITLE
[major] Webpack4: decrease compilation time

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/uglify.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/uglify.js
@@ -10,6 +10,7 @@ module.exports = function() {
 
   const uglifyOpts = {
     sourceMap: true,
+    parallel: true,
     uglifyOptions: {
       compress: {
         warnings: false


### PR DESCRIPTION
Use multi-process parallel running to improve the build speed.

Time: 34879ms -> Time: 28470ms