### PR TITLE
[major] webpack 4: Decrease bundle size, load lodash methods needed only

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/babel.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/babel.js
@@ -3,7 +3,8 @@
 const archetype = require("electrode-archetype-react-app/config/archetype");
 const AppMode = archetype.AppMode;
 const Path = require("path");
-const _ = require("lodash");
+const identity = require("lodash/identity");
+const assign = require("lodash/assign");
 
 module.exports = function(options) {
   const clientVendor = Path.join(AppMode.src.client, "vendor/");
@@ -25,12 +26,12 @@ module.exports = function(options) {
           options.babel
         )
       }
-    ].filter(_.identity)
+    ].filter(identity)
   };
 
   return {
     module: {
-      rules: [_.assign({}, babelLoader, archetype.webpack.extendBabelLoader)]
+      rules: [assign({}, babelLoader, archetype.webpack.extendBabelLoader)]
     }
   };
 };

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/dll-load.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/dll-load.js
@@ -19,7 +19,7 @@
 
 const Fs = require("fs");
 const Path = require("path");
-const _ = require("lodash");
+const isEmpty = require("lodash/isEmpty");
 const webpack = require("webpack");
 const DonePlugin = require("../plugins/done-plugin");
 const logger = require("electrode-archetype-react-app/lib/logger");
@@ -141,13 +141,13 @@ module.exports = function(options) {
 
   const dllMods = Object.keys(loadDlls).filter(x => loadDlls[x] && loadDlls[x].enable !== false);
 
-  if (_.isEmpty(dllMods)) return {};
+  if (isEmpty(dllMods)) return {};
 
   logger.info("Electrode DLL modules to be loaded", dllMods.join(" "));
 
   const dllInfo = dllMods.reduce((mani, modName) => mani.concat(findDllManifests(modName)), []);
 
-  if (_.isEmpty(dllInfo)) {
+  if (isEmpty(dllInfo)) {
     logger.warn("Electrode DLL found no manifests to load");
     return {};
   }

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/resolve-loader.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/resolve-loader.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const _ = require("lodash");
+const identity= require("lodash/identity");
 const Path = require("path");
 const ModuleResolver = require("electrode-node-resolver/lib/webpack-plugin");
 const archetype = require("electrode-archetype-react-app/config/archetype");
@@ -10,7 +10,7 @@ module.exports = {
     symlinks: !archetype.webpack.preserveSymlinks,
     modules: [Path.resolve("lib"), process.cwd()]
       .concat(archetype.webpack.loaderDirectories)
-      .filter(_.identity),
+      .filter(identity),
     plugins: [new ModuleResolver("module", "resolve", archetype.devDir, undefined)]
   }
 };

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/resolve.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/resolve.js
@@ -4,7 +4,7 @@ const archetype = require("electrode-archetype-react-app/config/archetype");
 const AppMode = archetype.AppMode;
 const Path = require("path");
 const ModuleResolver = require("electrode-node-resolver/lib/webpack-plugin");
-const _ = require("lodash");
+const identity= require("lodash/identity");
 
 function infernoReactAlias() {
   return AppMode.reactLib === "inferno"
@@ -31,7 +31,7 @@ module.exports = {
       "node_modules"
     ]
       .concat(archetype.webpack.modulesDirectories)
-      .filter(_.identity),
+      .filter(identity),
     extensions: [".js", ".jsx", ".json"]
   }
 };


### PR DESCRIPTION
 Lodash (as of v4.17.4) adds 72 KB of minified code to the bundle. But if you use only, like, 20 of its methods, then approximately 65 KB of minified code does just nothing.