### PR TITLE
[patch] Roll back electrode-node-resolver version for component for webpack 3

### DIFF
--- a/packages/electrode-archetype-react-component-dev/package.json
+++ b/packages/electrode-archetype-react-component-dev/package.json
@@ -47,7 +47,7 @@
     "css-loader": "^0.28.9",
     "electrode-check-dependencies": "^1.0.2",
     "electrode-docgen": "^1.0.0",
-    "electrode-node-resolver": "^2.0.0",
+    "electrode-node-resolver": "^1.0.0",
     "enzyme": "^3.0.0",
     "enzyme-adapter-react-16": "^1.1.0",
     "eslint": "^4.8.0",


### PR DESCRIPTION
electrode-node-resolver v2 is for webpack 4. Rollback to v1 instead.