### PR TITLE
[patch] component archetype webpack 4: remove extra postcss-cssnext

### DIFF
--- a/packages/electrode-archetype-react-component-dev/package.json
+++ b/packages/electrode-archetype-react-component-dev/package.json
@@ -75,7 +75,6 @@
     "mocha": "^4.0.0",
     "nodemon": "^1.8.1",
     "optional-require": "^1.0.0",
-    "postcss-cssnext": "^2.7.0",
     "postcss-import": "^9.1.0",
     "postcss-loader": "^3.0.0",
     "postcss-preset-env": "^5.3.0",


### PR DESCRIPTION
```
npm WARN deprecated postcss-cssnext@2.11.0: 'postcss-cssnext' has been deprecated in favor of 'postcss-preset-env'. Read more at https://moox.io/blog/deprecating-cssnext/
```

Remove deprecated & extra postcss-cssnext