### PR TITLE
lock react versions to avoid issue

### DIFF
--- a/packages/electrode-webpack-reporter/package.json
+++ b/packages/electrode-webpack-reporter/package.json
@@ -40,6 +40,8 @@
     "ansi-to-html": "^0.6.0",
     "chalk": "^2.3.0",
     "optional-require": "^1.0.0",
+    "react": "16.3.2",
+    "react-dom": "16.3.3",
     "socket.io": "^1.7.3"
   }
 }


### PR DESCRIPTION
https://github.com/zilverline/react-tap-event-plugin/issues/121

breaks webpack-reporter webapp

lock react versions to fix