### PR TITLE
[patch] webpack 4: concatenateModules false

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/dev.js
@@ -7,7 +7,7 @@ const webpackDevReporter = require("../util/webpack-dev-reporter");
 
 const devProtocol = archetype.webpack.https ? "https://" : "http://";
 
-module.exports = function () {
+module.exports = function() {
   const devServerConfig = {
     reporter: webpackDevReporter,
     https: Boolean(archetype.webpack.https)
@@ -18,7 +18,7 @@ module.exports = function () {
     devServerConfig.headers = {
       "Access-Control-Allow-Origin": `${devProtocol}${archetype.webpack.devHostname}:${
         archetype.webpack.devPort
-        }`
+      }`
     };
   } else {
     devServerConfig.disableHostCheck = true;
@@ -38,7 +38,6 @@ module.exports = function () {
       new ExtractTextPlugin({ filename: "[name].style.css" })
     ],
     optimization: {
-      concatenateModules: true,
       noEmitOnErrors: true
     }
   };


### PR DESCRIPTION
concatenateModules flag is to find segments of the module graph which can be safely concatenated into a single module.

This is not enabled under dev mode with our previous webpack 3 config. It is newly added for improving performance with webpack v4.  However, it causes some issues when testing with home app from `@walmart/feds-wmt-header` module. 

Change back to default: `concatenateModules: false` in dev and `concatenateModules: true` in prod.