### PR TITLE
[patch] babel-plugin-transform-react-remove-prop-types

### DIFF
--- a/packages/electrode-archetype-react-component-dev/config/babel/.babelrc
+++ b/packages/electrode-archetype-react-component-dev/config/babel/.babelrc
@@ -1,15 +1,14 @@
 {
-  "presets": [
-    ["env", { "loose": true }],
-    "react",
-    "flow"
-  ],
+  "presets": [["env", { "loose": true }], "react", "flow"],
   "plugins": [
     "babel-plugin-transform-object-rest-spread",
-    ["babel-plugin-react-intl", {
-      "messagesDir": "./tmp/messages/",
-      "enforceDescriptions": true
-    }],
+    [
+      "babel-plugin-react-intl",
+      {
+        "messagesDir": "./tmp/messages/",
+        "enforceDescriptions": true
+      }
+    ],
     "lodash",
     "transform-runtime",
     "transform-flow-strip-types"
@@ -21,10 +20,19 @@
     "production": {
       "plugins": [
         "babel-plugin-transform-react-constant-elements",
-        ["babel-plugin-react-intl", {
-          "messagesDir": "./tmp/messages/",
-          "enforceDescriptions": true
-        }]
+        [
+          "babel-plugin-react-intl",
+          {
+            "messagesDir": "./tmp/messages/",
+            "enforceDescriptions": true
+          }
+        ],
+        [
+          "transform-react-remove-prop-types",
+          {
+            "removeImport": true
+          }
+        ]
       ]
     }
   }

--- a/packages/electrode-archetype-react-component-dev/package.json
+++ b/packages/electrode-archetype-react-component-dev/package.json
@@ -33,6 +33,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
     "babel-plugin-transform-react-constant-elements": "^6.5.0",
     "babel-plugin-transform-react-inline-elements": "^6.6.4",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.20",
     "babel-plugin-transform-runtime": "^6.8.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-flow": "^6.23.0",


### PR DESCRIPTION
JIRA: https://jira.walmart.com/browse/CEECORE-378

Before:
```
var DemoComponent = function (_React$Component) {...}
exports.default = DemoComponent;
DemoComponent.displayName = "DemoComponent";
DemoComponent.propTypes = {};
```

After:
```
var DemoComponent = function (_React$Component) {...}
exports.default = DemoComponent;
DemoComponent.displayName = "DemoComponent";
```

Remove React propTypes from the production build, as they are only used in development. 