### PR TITLE
[patch][bug] webpack reporter should not render when no errors

### DIFF
--- a/packages/electrode-archetype-react-app-dev/lib/webpack-middleware.js
+++ b/packages/electrode-archetype-react-app-dev/lib/webpack-middleware.js
@@ -217,6 +217,7 @@ class Middleware {
         const warning = stats.hasWarnings() ? chalk.yellow(" WARNINGS") : "";
         const notOk = Boolean(error || warning);
         const but = (notOk && chalk.yellow(" but has")) || "";
+        const showError = Boolean(error);
         console.log(`webpack bundle is now ${chalk.green("VALID")}${but}${error}${warning}`);
 
         this.webpackDev.valid = true;
@@ -232,11 +233,11 @@ class Middleware {
           }
 
           if (this.webpackDev.lastReporterOptions === undefined) {
-            this.returnReporter = notOk;
+            this.returnReporter = showError;
             openUrl(baseUrl());
           } else {
             // keep returning reporter until a first success compile
-            this.returnReporter = this.returnReporter ? notOk : false;
+            this.returnReporter = this.returnReporter ? showError : false;
           }
 
           if (!this.webpackDev.hasErrors) {


### PR DESCRIPTION
This fixes https://github.com/electrode-io/electrode/issues/1087

The webpack reporter was rendering when no errors were present. This should not be the expected behaviour since the build still passes