### PR TITLE
[patch][bug] fix babelrc being overriden

### DIFF
--- a/packages/electrode-archetype-react-component/archetype-clap.js
+++ b/packages/electrode-archetype-react-component/archetype-clap.js
@@ -99,7 +99,7 @@ const makeBabelRc = () => {
   let rc = {};
 
   if (Fs.existsSync(fn)) {
-    const rc = JSON.parse(Fs.readFileSync(fn));
+    rc = JSON.parse(Fs.readFileSync(fn));
   }
 
   if (rc.extends !== archRc) {


### PR DESCRIPTION
The .babelrc was being regenerated every time because the `rc` variable was only set within the `if` block's scope