### PR TITLE
[patch][bug] put @babel/runtime in electrode-archetype-react-app

### DIFF
--- a/packages/electrode-archetype-react-app-dev/package.json
+++ b/packages/electrode-archetype-react-app-dev/package.json
@@ -39,7 +39,6 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.1.0",
     "@babel/register": "^7.0.0",
-    "@babel/runtime": "^7.1.5",
     "ansi-to-html": "^0.6.8",
     "autoprefixer": "^9.3.1",
     "babel-core": "7.0.0-bridge.0",

--- a/packages/electrode-archetype-react-app/package.json
+++ b/packages/electrode-archetype-react-app/package.json
@@ -25,6 +25,7 @@
     "supports.js"
   ],
   "dependencies": {
+    "@babel/runtime": "^7.1.5",
     "css-modules-require-hook": "^4.0.2",
     "isomorphic-loader": "^2.0.0",
     "optional-require": "^1.0.0"


### PR DESCRIPTION
fix https://github.com/electrode-io/electrode/issues/1107