### PR TITLE
[patch] add getHeader() to middleware

### DIFF
--- a/packages/electrode-archetype-react-app-dev/lib/fake-res.js
+++ b/packages/electrode-archetype-react-app-dev/lib/fake-res.js
@@ -33,6 +33,10 @@ class FakeRes extends EventEmitter {
   get responded() {
     return this._end > 0;
   }
+  
+  getHeader(h) {
+    return this._headers[h.toLowerCase()];
+  }
 
   setHeader(h, v) {
     this._headers[h.toLowerCase()] = v;


### PR DESCRIPTION
webpack-dev-middleware is calling this function as of 3.6.1 so Electrode breaks when trying to load webpack assets