### PR TITLE
Remove PWA optional check

### DIFF
--- a/packages/electrode-archetype-opt-pwa/optional-check.js
+++ b/packages/electrode-archetype-opt-pwa/optional-check.js
@@ -35,7 +35,6 @@ try {
     console.log(
       `${name}: skipping install because archetype/config set options.${configName} to false`
     );
-    process.exit(1);
   }
 } catch (e) {}
 


### PR DESCRIPTION
### Problem

The [PWA optional check](https://github.com/electrode-io/electrode/blob/3c54ce0e0742b39f101158d0c5cc2474cc5978ff/packages/electrode-archetype-opt-pwa/optional-check.js#L38) exits with `>0` when the archetype config has `"pwa": false`.

### Solution

npm appears to rollback installs when a package's `preinstall` script fails. Remove the `process.exit(1)` line so the install works.

### Testing

No tests included! Not sure about testing it.