### PR TITLE
[PATCH]define extendBabelLoader in default config

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/archetype.js
+++ b/packages/electrode-archetype-react-app-dev/config/archetype.js
@@ -46,7 +46,10 @@ const webpackConfigSpec = {
     type: "json",
     default: {}
   },
-  extendBabelLoader: {}
+  extendBabelLoader: {
+    type: "json",
+    default: {}
+  }
 };
 
 const karmaConfigSpec = {

--- a/packages/electrode-archetype-react-app-dev/config/archetype.js
+++ b/packages/electrode-archetype-react-app-dev/config/archetype.js
@@ -45,7 +45,8 @@ const webpackConfigSpec = {
     env: "ELECTRODE_LOAD_DLLS",
     type: "json",
     default: {}
-  }
+  },
+  extendBabelLoader: {}
 };
 
 const karmaConfigSpec = {


### PR DESCRIPTION
 define extendBabelLoader in default config to enable the babel config to be overridden from app

extendBabelLoader is used here
https://github.com/electrode-io/electrode/blob/v5.x.x/packages/electrode-archetype-react-app-dev/config/webpack/partial/babel.js#L43