### PR TITLE
fix entry chunk name in multi-bundle selection

### DIFF
--- a/packages/electrode-react-webapp/lib/utils.js
+++ b/packages/electrode-react-webapp/lib/utils.js
@@ -256,7 +256,8 @@ function getBundleJsNameByQuery(data, otherAssets) {
   let { name } = data.jsChunk;
   const { __dist } = data.query;
   if (__dist && otherAssets[__dist]) {
-    name = `${__dist}.main.bundle.js`;
+    const entryChunkName = name.split(".")[1];
+    name = `${__dist}.${entryChunkName}.bundle.js`;
   }
   return name;
 }

--- a/packages/electrode-react-webapp/lib/utils.js
+++ b/packages/electrode-react-webapp/lib/utils.js
@@ -256,8 +256,7 @@ function getBundleJsNameByQuery(data, otherAssets) {
   let { name } = data.jsChunk;
   const { __dist } = data.query;
   if (__dist && otherAssets[__dist]) {
-    const entryChunkName = name.split(".")[1];
-    name = `${__dist}.${entryChunkName}.bundle.js`;
+    name = `${__dist}${name.substr(name.indexOf("."))}`;
   }
   return name;
 }

--- a/packages/electrode-react-webapp/test/spec/utils.spec.js
+++ b/packages/electrode-react-webapp/test/spec/utils.spec.js
@@ -257,7 +257,7 @@ describe("utils", function() {
   describe("getBundleJsNameByQuery", () => {
     it("should get file name ends with main.bundle.js", () => {
       const data = {
-        jsChunk: { name: "bundle" }
+        jsChunk: { name: "default.main.bundle.js" }
       };
       const otherAssets = {
         es6: { js: [{ name: "es6.main.bundle.js" }] }


### PR DESCRIPTION
As for user defined entry point other than `main`, the bundle name after bundle selection should include the chunk name defined by user. 

For example `default.foo.bundle.js` as default bundle, and the corresponding es6 bundle shall be `es6.foo.bundle.js`