### PR TITLE
fix test and spec file in `src/server` cannot be removed after build

### DIFF
--- a/packages/electrode-archetype-react-app/arch-clap.js
+++ b/packages/electrode-archetype-react-app/arch-clap.js
@@ -574,7 +574,7 @@ Individual .babelrc files were generated for you in src/client and src/server
     ".build-lib:delete-babel-ignored-files": {
       desc: false,
       task: () => {
-        const libDir = Path.resolve(AppMode.lib.client);
+        const libDir = Path.resolve(AppMode.lib.dir);
         const ignoredFiles = scanDir.sync({
           dir: libDir,
           includeRoot: true,


### PR DESCRIPTION
According to issue https://github.com/electrode-io/electrode/issues/1151, the `*.spec.js` and `*.test.js` within `src/client` and `src/server` shall be removed in `lib` after build. 
But currently, task `.build-lib:delete-babel-ignored-files` only work for `src/client`. 
Correct `libDir` will fix this issue