### PR TITLE
Add useBuiltIns for @babel/preset-env

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/babel/babelrc-client.js
+++ b/packages/electrode-archetype-react-app-dev/config/babel/babelrc-client.js
@@ -109,6 +109,8 @@ const plugins = basePlugins.concat(
 );
 
 const targets = archetype.babel.envTargets[archetype.babel.target];
+const hasOtherTargets = Object.keys(archetype.babel.envTargets).sort().join(",") !== "default,node";
+const useBuiltIns = hasOtherTargets ? "entry" : false;
 
 const presets = [
   //
@@ -117,7 +119,7 @@ const presets = [
   // But keep transforming modules to commonjs when not in production mode so tests
   // can continue to stub ES modules.
   //
-  ["@babel/preset-env", { modules: isProduction ? "auto" : "commonjs", loose: true, targets }],
+  ["@babel/preset-env", { modules: isProduction ? "auto" : "commonjs", loose: true, targets, useBuiltIns }],
   enableTypeScript && "@babel/preset-typescript",
   "@babel/preset-react"
 ];

--- a/packages/electrode-archetype-react-app-dev/config/babel/babelrc-client.js
+++ b/packages/electrode-archetype-react-app-dev/config/babel/babelrc-client.js
@@ -109,7 +109,10 @@ const plugins = basePlugins.concat(
 );
 
 const targets = archetype.babel.envTargets[archetype.babel.target];
-const hasOtherTargets = Object.keys(archetype.babel.envTargets).sort().join(",") !== "default,node";
+const hasOtherTargets =
+  Object.keys(archetype.babel.envTargets)
+    .sort()
+    .join(",") !== "default,node";
 const useBuiltIns = hasOtherTargets ? "entry" : false;
 
 const presets = [
@@ -119,7 +122,10 @@ const presets = [
   // But keep transforming modules to commonjs when not in production mode so tests
   // can continue to stub ES modules.
   //
-  ["@babel/preset-env", { modules: isProduction ? "auto" : "commonjs", loose: true, targets, useBuiltIns }],
+  [
+    "@babel/preset-env",
+    { modules: isProduction ? "auto" : "commonjs", loose: true, targets, useBuiltIns, corejs: "2" }
+  ],
   enableTypeScript && "@babel/preset-typescript",
   "@babel/preset-react"
 ];

--- a/packages/electrode-archetype-react-app-dev/config/babel/babelrc-client.js
+++ b/packages/electrode-archetype-react-app-dev/config/babel/babelrc-client.js
@@ -113,7 +113,9 @@ const hasOtherTargets =
   Object.keys(archetype.babel.envTargets)
     .sort()
     .join(",") !== "default,node";
-const useBuiltIns = hasOtherTargets ? "entry" : false;
+const useBuiltIns = hasOtherTargets
+  ? { useBuiltIns: "entry", corejs: "2" }
+  : { useBuiltIns: false };
 
 const presets = [
   //
@@ -124,7 +126,7 @@ const presets = [
   //
   [
     "@babel/preset-env",
-    { modules: isProduction ? "auto" : "commonjs", loose: true, targets, useBuiltIns, corejs: "2" }
+    { modules: isProduction ? "auto" : "commonjs", loose: true, targets, ...useBuiltIns }
   ],
   enableTypeScript && "@babel/preset-typescript",
   "@babel/preset-react"

--- a/packages/electrode-archetype-react-app-dev/config/babel/babelrc-client.js
+++ b/packages/electrode-archetype-react-app-dev/config/babel/babelrc-client.js
@@ -115,7 +115,7 @@ const hasOtherTargets =
     .join(",") !== "default,node";
 const useBuiltIns = hasOtherTargets
   ? { useBuiltIns: "entry", corejs: "2" }
-  : { useBuiltIns: false };
+  : {};
 
 const presets = [
   //


### PR DESCRIPTION
If multiple targets exists, add `useBuiltIns: "entry"` and `corejs` version in presets to customize core-js size in bundle according to target