### PR TITLE
[MINOR]make the babel config configurable 

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/archetype.js
+++ b/packages/electrode-archetype-react-app-dev/config/archetype.js
@@ -51,6 +51,10 @@ const webpackConfigSpec = {
     env: "ELECTRODE_LOAD_DLLS",
     type: "json",
     default: {}
+  },
+  extendBabelLoader: {
+    type: "json",
+    default: {}
   }
 };
 
@@ -80,6 +84,9 @@ const babelConfigSpec = {
     env: "ENV_TARGET",
     type: "string",
     default: "default"
+  },
+  noBabelRc: {
+    default: false
   }
 };
 

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/babel.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/babel.js
@@ -18,7 +18,7 @@ module.exports = function(options) {
 
   const test = archetype.babel.enableTypeScript ? /\.[tj]sx?$/ : /\.jsx?$/;
 
-  let customBabelConfig = {};
+  const customBabelConfig = {};
   if (archetype.babel.noBabelRc) {
     customBabelConfig.babelrc = false;
     customBabelConfig.plugins = babelConfig.plugins;

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/babel.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/babel.js
@@ -6,6 +6,7 @@ const Path = require("path");
 const identity = require("lodash/identity");
 const assign = require("lodash/assign");
 const babelLoader = require.resolve("babel-loader");
+const babelConfig = require("../../babel/babelrc-client");
 
 module.exports = function(options) {
   const clientVendor = Path.join(AppMode.src.client, "vendor/");
@@ -17,6 +18,13 @@ module.exports = function(options) {
 
   const test = archetype.babel.enableTypeScript ? /\.[tj]sx?$/ : /\.jsx?$/;
 
+  let customBabelConfig = {};
+  if (archetype.babel.noBabelRc) {
+    customBabelConfig.babelrc = false;
+    customBabelConfig.plugins = babelConfig.plugins;
+    customBabelConfig.presets = babelConfig.presets;
+  }
+
   const babelLoaderConfig = {
     _name: "babel",
     test,
@@ -26,11 +34,13 @@ module.exports = function(options) {
         loader: babelLoader,
         options: Object.assign(
           { cacheDirectory: Path.resolve(".etmp/babel-loader") },
-          options.babel
+          options.babel,
+          customBabelConfig
         )
       }
     ].filter(identity)
   };
+
 
   return {
     module: {


### PR DESCRIPTION
This allows apps to override the babel exclude and babelrc option which enables apps to transpile dependencies in node_modules
