### PR TITLE
[minor] allow content to specify use streams for generating output

### DIFF
--- a/packages/electrode-react-webapp/lib/async-template.js
+++ b/packages/electrode-react-webapp/lib/async-template.js
@@ -77,7 +77,9 @@ class AsyncTemplate {
     const context = new RenderContext(options, this);
 
     return Promise.each(this._beforeRenders, r => r.beforeRender(context))
-      .then(() => this._renderer.render(context))
+      .then(() => {
+        return this._renderer.render(context);
+      })
       .then(result => {
         return Promise.each(this._afterRenders, r => r.afterRender(context)).then(() => {
           context.result = context.isVoidStop ? context.voidResult : result;

--- a/packages/electrode-react-webapp/lib/react/content.js
+++ b/packages/electrode-react-webapp/lib/react/content.js
@@ -52,11 +52,10 @@ function transformOutput(result, context) {
 
 const htmlifyScripts = (scripts, scriptNonce) => {
   return scripts
-    .map(
-      x =>
-        typeof x === "string"
-          ? `<script${scriptNonce || ""}>${x}</script>\n`
-          : x.map(n => `<script src="${n.src}"></script>`).join("\n")
+    .map(x =>
+      typeof x === "string"
+        ? `<script${scriptNonce || ""}>${x}</script>\n`
+        : x.map(n => `<script src="${n.src}"></script>`).join("\n")
     )
     .join("\n");
 };

--- a/packages/electrode-react-webapp/lib/react/token-handlers.js
+++ b/packages/electrode-react-webapp/lib/react/token-handlers.js
@@ -12,7 +12,8 @@ const {
   getProdBundles,
   processRenderSsMode,
   getCspNonce,
-  getBundleJsNameByQuery
+  getBundleJsNameByQuery,
+  isReadableStream
 } = require("../utils");
 
 const {
@@ -109,8 +110,6 @@ module.exports = function setup(handlerContext /*, asyncTemplate*/) {
 
       const renderJs = RENDER_JS && mode !== "nojs";
 
-      context.setOutputTransform(transformOutput);
-
       context.user = {
         request: options.request,
         response: {
@@ -130,6 +129,12 @@ module.exports = function setup(handlerContext /*, asyncTemplate*/) {
         jsChunk,
         cssChunk
       };
+
+      if (content.useStream || isReadableStream(content.html)) {
+        context.setMunchyOutput();
+      }
+
+      context.setOutputTransform(transformOutput);
 
       return context;
     });

--- a/packages/electrode-react-webapp/lib/render-context.js
+++ b/packages/electrode-react-webapp/lib/render-context.js
@@ -1,6 +1,8 @@
 "use strict";
 
 const RenderOutput = require("./render-output");
+const Munchy = require("munchy");
+const utils = require("./utils");
 
 class RenderContext {
   constructor(options, asyncTemplate) {
@@ -28,6 +30,10 @@ class RenderContext {
   // Note: cannot be used with setOutputTransform
   setOutputSend(send) {
     this.send = send;
+  }
+
+  setMunchyOutput(munchy) {
+    this.munchy = munchy || new Munchy();
   }
 
   // set a callback to take the output result and transform it
@@ -89,12 +95,12 @@ class RenderContext {
     if (res && res.then) {
       return res.then(r => cb(null, r)).catch(cb);
     } else {
-      // it's a string, add to output
-      if (typeof res === "string") {
+      // if it's a string, buffer, or stream, then add to output
+      if (typeof res === "string" || Buffer.isBuffer(res) || utils.isReadableStream(res)) {
         this.output.add(res);
       }
-
       // ignore other return value types
+
       return cb();
     }
   }

--- a/packages/electrode-react-webapp/lib/utils.js
+++ b/packages/electrode-react-webapp/lib/utils.js
@@ -280,5 +280,6 @@ module.exports = {
   invokeTemplateProcessor,
   getOtherStats,
   getOtherAssets,
-  getBundleJsNameByQuery
+  getBundleJsNameByQuery,
+  isReadableStream: x => Boolean(x && x.pipe && x.on && x._readableState)
 };

--- a/packages/electrode-react-webapp/package.json
+++ b/packages/electrode-react-webapp/package.json
@@ -48,6 +48,7 @@
     "http-status-codes": "^1.3.0",
     "in-publish": "^2.0.0",
     "lodash": "^4.17.10",
+    "munchy": "^1.0.5",
     "require-at": "^1.0.0",
     "string-array": "^1.0.0"
   },

--- a/packages/electrode-react-webapp/test/spec/render-output.spec.js
+++ b/packages/electrode-react-webapp/test/spec/render-output.spec.js
@@ -119,6 +119,11 @@ describe("render-output", function() {
     });
   });
 
+  it("should not munch if no items", done => {
+    const ro = new RenderOutput();
+    ro._output.sendToMunchy(null, done);
+  });
+
   it("should rethrow if no _reject is available in _finish", () => {
     const ro = new RenderOutput();
     ro._reject = undefined;


### PR DESCRIPTION
If app returns SSR content result as a stream or set the flag `useStream` then generate the output for the index.html as a readable stream using https://www.npmjs.com/package/munchy

Prep work for enabling React 16 `renderToNodeStream` API for SSR 