### PR TITLE
replace uglify with terser

### DIFF
--- a/packages/electrode-archetype-react-component-dev/config/webpack/partial/uglify.js
+++ b/packages/electrode-archetype-react-component-dev/config/webpack/partial/uglify.js
@@ -1,18 +1,25 @@
 "use strict";
 
-const optimize = require("webpack").optimize;
 const LodashModuleReplacementPlugin = require("lodash-webpack-plugin");
+const TerserPlugin = require("terser-webpack-plugin-legacy");
+
+const isProduction = process.env.NODE_ENV === "production";
 
 module.exports = function() {
-  return {
-    plugins: [
-      new LodashModuleReplacementPlugin(),
-      new optimize.UglifyJsPlugin({
-        sourceMap: true,
-        compress: {
-          warnings: false
-        }
-      })
-    ]
-  };
+  const plugins = [new LodashModuleReplacementPlugin()];
+
+  if (process.env.NODE_ENV === "production") {
+    return {
+      plugins: [
+        ...plugins,
+        new TerserPlugin({
+          test: /\.js(\?.*)?$/i
+        })
+      ]
+    };
+  } else {
+    return {
+      plugins: [...plugins]
+    };
+  }
 };

--- a/packages/electrode-archetype-react-component-dev/package.json
+++ b/packages/electrode-archetype-react-component-dev/package.json
@@ -92,6 +92,7 @@
     "stylint": "^1.3.6",
     "stylus": "^0.54.5",
     "stylus-relative-loader": "^3.4.0",
+    "terser-webpack-plugin-legacy": "^1.2.3",
     "url-loader": "^0.6.2",
     "webpack": "^3.0.0",
     "webpack-config-composer": "^1.1.0",


### PR DESCRIPTION
this replaces uglify with terser as uglify plugin does not handle es6 code correctly.

it looks like uglify-es is no longer maintained and terser is replacement being used for Webpack 4, this version is for legacy which supports Webpack 3 

also we only want uglification of code on prod builds, a check has been added for this.


