### PR TITLE
migrate uglify to terser

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/uglify.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/uglify.js
@@ -1,40 +1,25 @@
-"use strict";
+const TerserPlugin = require("terser-webpack-plugin-legacy");
 
-const Uglify = require("uglifyjs-webpack-plugin");
-const optimize = require("webpack").optimize;
-const archetype = require("electrode-archetype-react-app/config/archetype");
+const isProduction = process.env.NODE_ENV === "production";
+
+const plugins = [];
 
 module.exports = function() {
-  // Allow env var to disable minifcation for inspectpack usage.
-  if (process.env.INSPECTPACK_DEBUG === "true" || !archetype.webpack.minify) {
-    return {};
+
+  if (isProduction) {
+    return {
+      plugins: [
+        ...plugins,
+        new TerserPlugin({
+          test: /\.js(\?.*)?$/i,
+          extractComments: /^\**!|^ [0-9]+ $|@preserve|@license/
+        })
+      ]
+    };
+  } else {
+    
+    return {
+      plugins: [...plugins]
+    };
   }
-
-  const uglifyOpts = archetype.babel.hasMultiTargets
-    ? {
-        sourceMap: true,
-        uglifyOptions: {
-          compress: {
-            warnings: false
-          }
-        }
-      }
-    : {
-        sourceMap: true,
-        compress: {
-          warnings: false
-        }
-      };
-
-  // preserve module ID comment in bundle output for optimizeStats
-  if (process.env.OPTIMIZE_STATS === "true") {
-    const comments = archetype.babel.hasMultiTargets ? "extractComments" : "comments";
-    uglifyOpts[comments] = /^\**!|^ [0-9]+ $|@preserve|@license/;
-  }
-
-  const uglifyPlugin = archetype.babel.hasMultiTargets
-    ? new Uglify(uglifyOpts)
-    : new optimize.UglifyJsPlugin(uglifyOpts);
-
-  return { plugins: [uglifyPlugin] };
 };

--- a/packages/electrode-archetype-react-app-dev/package.json
+++ b/packages/electrode-archetype-react-app-dev/package.json
@@ -115,6 +115,7 @@
     "sugarss": "^1.0.1",
     "sw-precache": "^5.0.0",
     "sw-toolbox": "^3.4.0",
+    "terser-webpack-plugin-legacy": "^1.2.3",
     "uglify-js": "^3.0.26",
     "uglifyjs-webpack-plugin": "^1.2.2",
     "url-loader": "^0.6.2",

--- a/packages/electrode-archetype-react-app-dev/package.json
+++ b/packages/electrode-archetype-react-app-dev/package.json
@@ -117,7 +117,6 @@
     "sw-toolbox": "^3.4.0",
     "terser-webpack-plugin-legacy": "^1.2.3",
     "uglify-js": "^3.0.26",
-    "uglifyjs-webpack-plugin": "^1.2.2",
     "url-loader": "^0.6.2",
     "web-app-manifest-loader": "^0.1.1",
     "webpack": "^3.6.0",


### PR DESCRIPTION
this replaces uglify with terser as uglify-es is no longer maintained and uglify-js does not support ES6+.

let me know if I'm missing anything, anything being cleaned out needs putting back ?

is hasMultiTargets, INSPECTPACK_DEBUG , archetype.webpack.minify being used or can we nuke it ?

- if prod use terser to uglify 
- if dev don't run any sort of uglification on code (this speeds stuff up considerably)
- I added the flag to preserve comments for license etc ..

extension of https://github.com/electrode-io/electrode/pull/1238