### PR TITLE
[minor][feat] support template written in JSX

### DIFF
--- a/packages/electrode-react-webapp/.gitignore
+++ b/packages/electrode-react-webapp/.gitignore
@@ -1,0 +1,1 @@
+template

--- a/packages/electrode-react-webapp/index.js
+++ b/packages/electrode-react-webapp/index.js
@@ -11,5 +11,6 @@ module.exports = {
   middleware, // for express
   hapiRegisterRoutes: hapiPlugin.registerRoutes,
   ReactWebapp,
-  AsyncTemplate
+  AsyncTemplate,
+  jsx: require("./lib/jsx")
 };

--- a/packages/electrode-react-webapp/lib/jsx/Component.js
+++ b/packages/electrode-react-webapp/lib/jsx/Component.js
@@ -1,0 +1,18 @@
+"use strict";
+
+class Component {
+  constructor(props, context) {
+    this.props = props;
+    this.context = context;
+  }
+
+  isComponent() {
+    return true;
+  }
+
+  render() {
+    return "component";
+  }
+}
+
+module.exports = Component;

--- a/packages/electrode-react-webapp/lib/jsx/IndexPage.js
+++ b/packages/electrode-react-webapp/lib/jsx/IndexPage.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const Component = require("./Component");
+
+class IndexPage extends Component {
+  static memoize(props) {
+    return `<!DOCTYPE ${props.DOCTYPE || "html"}>`;
+  }
+}
+
+module.exports = IndexPage;

--- a/packages/electrode-react-webapp/lib/jsx/JsxRenderer.js
+++ b/packages/electrode-react-webapp/lib/jsx/JsxRenderer.js
@@ -43,7 +43,7 @@ class JsxRenderer {
     return this._options.insertTokenIds;
   }
 
-  get tempalteFullPath() {
+  get templateFullPath() {
     return this._options.templateFullPath;
   }
 
@@ -204,7 +204,7 @@ class JsxRenderer {
 
     const id = forRequire ? `require(${element.props._id})` : element.props._id;
 
-    tokenInst = new Token(id, 0, element.props, this.tempalteFullPath);
+    tokenInst = new Token(id, 0, element.props, this.templateFullPath);
     this._tokens[element.props._id] = tokenInst;
 
     this._applyTokenLoad(element, tokenInst);

--- a/packages/electrode-react-webapp/lib/jsx/JsxRenderer.js
+++ b/packages/electrode-react-webapp/lib/jsx/JsxRenderer.js
@@ -64,6 +64,10 @@ class JsxRenderer {
               return context;
             });
           });
+      })
+      .catch(err => {
+        context.result = err;
+        return context;
       });
   }
 
@@ -223,11 +227,6 @@ class JsxRenderer {
 
   getTokenInst(element) {
     return this._tokens[element.props._id];
-  }
-
-  getTokenHandler(element) {
-    const tokenInst = this._tokens[element.props._id];
-    return tokenInst && tokenInst.handler;
   }
 
   _initializeTokenHandlers(filenames) {

--- a/packages/electrode-react-webapp/lib/jsx/JsxRenderer.js
+++ b/packages/electrode-react-webapp/lib/jsx/JsxRenderer.js
@@ -1,0 +1,249 @@
+"use strict";
+
+/* eslint-disable max-statements, prefer-template, complexity */
+
+const assert = require("assert");
+const _ = require("lodash");
+const loadHandler = require("../load-handler");
+const RenderContext = require("../render-context");
+const { omittedCloseTags, expandProps } = require("./utils");
+const Token = require("../token");
+const Promise = require("bluebird");
+
+const createDefer = () => {
+  const defer = {};
+  defer.promise = new Promise((resolve, reject) => {
+    defer.resolve = resolve;
+    defer.reject = reject;
+  });
+  return defer;
+};
+
+class JsxRenderer {
+  constructor(options) {
+    this._options = options;
+
+    this._tokenHandlers = [].concat(this._options.tokenHandlers).filter(x => x);
+    this._handlersMap = {};
+    this._tokens = {};
+    // the same context that gets passed to each token handler's setup function
+    this._handlerContext = _.merge(
+      {
+        user: {
+          // set routeOptions in user also for consistency
+          routeOptions: options.routeOptions
+        }
+      },
+      options
+    );
+    this._template = options.template;
+  }
+
+  get insertTokenIds() {
+    return this._options.insertTokenIds;
+  }
+
+  get tempalteFullPath() {
+    return this._options.templateFullPath;
+  }
+
+  render(options) {
+    const defer = createDefer();
+    const context = new RenderContext(options, this);
+
+    return Promise.each(this._beforeRenders, r => r.beforeRender(context))
+      .then(() => this._render(this._template, context, defer))
+      .then(() => {
+        return defer.promise
+          .then(() => context.output.close())
+          .then(result => {
+            /* istanbul ignore next */
+            return Promise.each(this._afterRenders, r => r.afterRender(context)).then(() => {
+              context.result = context.isVoidStop ? context.voidResult : result;
+
+              return context;
+            });
+          });
+      });
+  }
+
+  _render(element, context, defer) {
+    /* istanbul ignore next */
+    const done = () => defer && defer.resolve();
+
+    if (context.isFullStop || context.isVoidStop) {
+      return done();
+    }
+
+    if (typeof element === "string") {
+      context.output.add(`${element}\n`);
+      return done();
+    } else if (!element) {
+      return done();
+    }
+
+    let close;
+
+    const handleClose = () => {
+      if (close) {
+        context.output.add(`${close}\n`);
+      } else {
+        context.output.add(`\n`);
+      }
+
+      return defer && defer.resolve();
+    };
+
+    const handleElementChildren = () => {
+      if (!element.children) {
+        return handleClose();
+      }
+
+      let ix = 0;
+
+      const nextChild = () => {
+        if (ix >= element.children.length) {
+          return handleClose();
+        } else {
+          const child = element.children[ix++];
+          const promise = this._render(child, context);
+
+          if (promise) {
+            return promise.then(nextChild);
+          } else {
+            return nextChild();
+          }
+        }
+      };
+
+      const promise = nextChild();
+
+      return !defer && promise;
+    };
+
+    const handleElementResult = rendered => {
+      if (!rendered) {
+        return handleElementChildren();
+      }
+
+      if (typeof rendered === "string") {
+        context.output.add(rendered);
+        return handleElementChildren();
+      } else if (rendered.then) {
+        return rendered.then(handleElementChildren).catch(err => {
+          context.handleError(err);
+        });
+      } else {
+        const promise = this._render(rendered, context);
+        if (promise) {
+          return promise.then(handleElementChildren);
+        } else {
+          return handleElementChildren();
+        }
+      }
+    };
+
+    if (element.memoize) {
+      context.output.add(`${element.memoize}\n`);
+    } else if (element.tag) {
+      if (!omittedCloseTags[element.tag]) {
+        close = `</${element.tag}>`;
+        context.output.add(`<${element.tag}${expandProps(element.props)}>`);
+      } else {
+        context.output.add(`<${element.tag}${expandProps(element.props)}/>`);
+      }
+    } else if (!element.type) {
+      return handleElementResult(
+        element(element.props, context, { element, output: context.output })
+      );
+    } else if (element.Construct) {
+      const inst = new element.Construct(element.props, context);
+      return handleElementResult(inst.render(element.props, context));
+    } else {
+      const r = element.type(element.props, context, { element, output: context.output });
+      return handleElementResult(r);
+    }
+
+    return handleElementChildren();
+  }
+
+  initializeRenderer(reset) {
+    if (reset || !this._handlersLookup) {
+      this._initializeTokenHandlers(this._tokenHandlers);
+      this._handlersLookup = this._tokenHandlers.reverse();
+    }
+  }
+
+  _loadTokenHandler(path) {
+    const mod = loadHandler(path);
+    return mod(this._handlerContext, this);
+  }
+
+  _applyTokenLoad(element, inst) {
+    inst.load(this._options, this);
+
+    if (inst.handler) return;
+
+    const handler = this._handlersLookup.find(h => h.tokens.hasOwnProperty(inst.id));
+    if (!handler) return;
+
+    const tkFunc = handler.tokens[inst.id];
+    if (typeof tkFunc === "function") {
+      inst.setHandler(tkFunc);
+    } else {
+      element.memoize = tkFunc;
+    }
+  }
+
+  setupTokenInst(element, forRequire) {
+    let tokenInst = this._tokens[element.props._id];
+
+    if (tokenInst) {
+      return tokenInst;
+    }
+
+    const id = forRequire ? `require(${element.props._id})` : element.props._id;
+
+    tokenInst = new Token(id, 0, element.props, this.tempalteFullPath);
+    this._tokens[element.props._id] = tokenInst;
+
+    this._applyTokenLoad(element, tokenInst);
+
+    return tokenInst;
+  }
+
+  getTokenInst(element) {
+    return this._tokens[element.props._id];
+  }
+
+  getTokenHandler(element) {
+    const tokenInst = this._tokens[element.props._id];
+    return tokenInst && tokenInst.handler;
+  }
+
+  _initializeTokenHandlers(filenames) {
+    this._tokenHandlers = filenames.map(fname => {
+      let handler;
+      if (typeof fname === "string") {
+        handler = this._loadTokenHandler(fname);
+      } else {
+        handler = fname;
+        assert(handler.name, "electrode-react-webapp Template token handler missing name");
+      }
+      if (!handler.name) {
+        handler = {
+          name: fname,
+          tokens: handler
+        };
+      }
+      assert(handler.tokens, "electrode-react-webapp Template token handler missing tokens");
+      this._handlersMap[handler.name] = handler;
+      return handler;
+    });
+
+    this._beforeRenders = this._tokenHandlers.filter(x => x.beforeRender);
+    this._afterRenders = this._tokenHandlers.filter(x => x.afterRender);
+  }
+}
+
+module.exports = JsxRenderer;

--- a/packages/electrode-react-webapp/lib/jsx/JsxRenderer.js
+++ b/packages/electrode-react-webapp/lib/jsx/JsxRenderer.js
@@ -9,6 +9,7 @@ const RenderContext = require("../render-context");
 const { omittedCloseTags, expandProps } = require("./utils");
 const Token = require("../token");
 const Promise = require("bluebird");
+const { TOKEN_HANDLER } = require("../symbols");
 
 const createDefer = () => {
   const defer = {};
@@ -195,7 +196,7 @@ class JsxRenderer {
   _applyTokenLoad(element, inst) {
     inst.load(this._options, this);
 
-    if (inst.handler) return;
+    if (inst[TOKEN_HANDLER]) return;
 
     const handler = this._handlersLookup.find(h => h.tokens.hasOwnProperty(inst.id));
     if (!handler) return;

--- a/packages/electrode-react-webapp/lib/jsx/Literal.js
+++ b/packages/electrode-react-webapp/lib/jsx/Literal.js
@@ -1,0 +1,42 @@
+"use strict";
+
+/* eslint-disable no-unused-vars, no-magic-numbers */
+
+const Path = require("path");
+const Fs = require("fs");
+const _ = require("lodash");
+
+const MEMOIZE = {};
+
+function Literal(props, context, scope) {
+  const renderer = context.asyncTemplate;
+
+  let data;
+
+  if (props.file) {
+    const fp = Path.resolve(props.file);
+
+    if (MEMOIZE[fp]) {
+      data = MEMOIZE[fp];
+    } else {
+      try {
+        data = Fs.readFileSync(fp, _.get(props, "encoding", "utf8"));
+      } catch (err) {
+        const cwd = process.cwd();
+        /* istanbul ignore next */
+        const msg = cwd.length > 3 ? err.message.replace(cwd, "CWD") : err.message;
+        data = `<h1>Literal reading file failed: ${msg}</h1>`;
+      }
+    }
+
+    if (props.memoize !== false) {
+      MEMOIZE[fp] = data;
+    }
+  } else {
+    data = "<h1>Literal props missing file</h1>";
+  }
+
+  return data;
+}
+
+module.exports = Literal;

--- a/packages/electrode-react-webapp/lib/jsx/Literal.js
+++ b/packages/electrode-react-webapp/lib/jsx/Literal.js
@@ -29,7 +29,7 @@ function Literal(props, context, scope) {
       }
     }
 
-    if (props.memoize !== false) {
+    if (props._memoize !== false) {
       MEMOIZE[fp] = data;
     }
   } else {

--- a/packages/electrode-react-webapp/lib/jsx/Require.js
+++ b/packages/electrode-react-webapp/lib/jsx/Require.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const processToken = require("./process-token");
+
+function Require(props, context, scope) {
+  return processToken(props, context, scope, true);
+}
+
+module.exports = Require;

--- a/packages/electrode-react-webapp/lib/jsx/Token.js
+++ b/packages/electrode-react-webapp/lib/jsx/Token.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const processToken = require("./process-token");
+
+function Token(props, context, scope) {
+  return processToken(props, context, scope);
+}
+
+module.exports = Token;

--- a/packages/electrode-react-webapp/lib/jsx/index.js
+++ b/packages/electrode-react-webapp/lib/jsx/index.js
@@ -10,8 +10,14 @@ const JsxRenderer = require("./JsxRenderer");
 function createElement(type, props, ...children) {
   children = children.length > 0 ? children : undefined;
 
+  if (children) {
+    children = children.reduce((a, c) => a.concat(c), []);
+  }
+
   if (!props) {
-    props = {};
+    props = { children };
+  } else {
+    props = Object.assign({ children }, props);
   }
 
   const element = {

--- a/packages/electrode-react-webapp/lib/jsx/index.js
+++ b/packages/electrode-react-webapp/lib/jsx/index.js
@@ -14,7 +14,7 @@ function createElement(type, props, ...children) {
     props = {};
   }
 
-  const x = {
+  const element = {
     type,
     children,
     props
@@ -23,16 +23,16 @@ function createElement(type, props, ...children) {
   const literal = typeof type === "string";
 
   if (literal) {
-    x.tag = type.toLowerCase();
+    element.tag = type.toLowerCase();
   } else if (type.prototype && type.prototype.isComponent) {
-    x.Construct = type;
+    element.Construct = type;
   }
 
   if (!literal && type.memoize && props._memoize !== false) {
-    x.memoize = type.memoize(props, children);
+    element.memoize = type.memoize(props, children);
   }
 
-  return x;
+  return element;
 }
 
 module.exports = {

--- a/packages/electrode-react-webapp/lib/jsx/index.js
+++ b/packages/electrode-react-webapp/lib/jsx/index.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const Component = require("./Component");
+const Token = require("./Token");
+const IndexPage = require("./IndexPage");
+const Require = require("./Require");
+const Literal = require("./Literal");
+const JsxRenderer = require("./JsxRenderer");
+
+function createElement(type, props, ...children) {
+  children = children.length > 0 ? children : undefined;
+
+  if (!props) {
+    props = {};
+  }
+
+  const x = {
+    type,
+    children,
+    props
+  };
+
+  const literal = typeof type === "string";
+
+  if (literal) {
+    x.tag = type.toLowerCase();
+  } else if (type.prototype && type.prototype.isComponent) {
+    x.Construct = type;
+  }
+
+  if (!literal && type.memoize && props._memoize !== false) {
+    x.memoize = type.memoize(props, children);
+  }
+
+  return x;
+}
+
+module.exports = {
+  Component,
+  Token,
+  Literal,
+  IndexPage,
+  Require,
+  JsxRenderer,
+  createElement
+};

--- a/packages/electrode-react-webapp/lib/jsx/process-token.js
+++ b/packages/electrode-react-webapp/lib/jsx/process-token.js
@@ -2,6 +2,8 @@
 
 /* eslint-disable max-params */
 
+const { TOKEN_HANDLER } = require("../symbols");
+
 const _ = require("lodash");
 
 function processToken(props, context, scope, forRequire = false) {
@@ -13,9 +15,7 @@ function processToken(props, context, scope, forRequire = false) {
     return scope.output.add(scope.element.memoize);
   }
 
-  const handler = renderer.getTokenHandler(scope.element);
-
-  if (handler === null) {
+  if (tokenInst[TOKEN_HANDLER] === null) {
     if (renderer.insertTokenIds) {
       return `<!-- ${tokenInst.id} removed due to its handler set to null -->`;
     }
@@ -28,7 +28,7 @@ function processToken(props, context, scope, forRequire = false) {
     );
   }
 
-  const r = handler(context, tokenInst);
+  const r = tokenInst[TOKEN_HANDLER](context, tokenInst);
   return context.handleTokenResult(tokenInst.id, r, err => {
     if (props._insertTokenIds !== false && renderer.insertTokenIds) {
       scope.output.add(`<!-- ${tokenInst.id} END -->`);

--- a/packages/electrode-react-webapp/lib/jsx/process-token.js
+++ b/packages/electrode-react-webapp/lib/jsx/process-token.js
@@ -1,0 +1,43 @@
+"use strict";
+
+/* eslint-disable max-params */
+
+const _ = require("lodash");
+
+function processToken(props, context, scope, forRequire = false) {
+  const renderer = context.asyncTemplate;
+
+  const tokenInst = renderer.setupTokenInst(scope.element, forRequire);
+
+  if (scope.element.memoize) {
+    return scope.output.add(scope.element.memoize);
+  }
+
+  const handler = renderer.getTokenHandler(scope.element);
+
+  if (handler === null) {
+    if (renderer.insertTokenIds) {
+      return `<!-- ${tokenInst.id} removed due to its handler set to null -->`;
+    }
+    return null;
+  }
+
+  if (renderer.insertTokenIds) {
+    scope.output.add(
+      `<!-- BEGIN ${tokenInst.id} props: ${JSON.stringify(_.omit(props, "_id"))} -->\n`
+    );
+  }
+
+  const r = handler(context, tokenInst);
+  return context.handleTokenResult(tokenInst.id, r, err => {
+    if (props._insertTokenIds !== false && renderer.insertTokenIds) {
+      scope.output.add(`<!-- ${tokenInst.id} END -->`);
+    }
+    // if err, then handler has caused/returned an error
+    if (err) {
+      throw err;
+    }
+  });
+}
+
+module.exports = processToken;

--- a/packages/electrode-react-webapp/lib/jsx/utils.js
+++ b/packages/electrode-react-webapp/lib/jsx/utils.js
@@ -1,0 +1,42 @@
+"use strict";
+
+function expandProps(props) {
+  let s = "";
+  for (const key in props) {
+    let v = props[key];
+    if (typeof v === "function") {
+      v = v();
+    }
+
+    s = `${s} ${key}="${v}"`;
+  }
+  return s;
+}
+
+module.exports = {
+  expandProps,
+
+  // For HTML, certain tags should omit their close tag. We keep a whitelist for
+  // those special-case tags.
+
+  // copied from react-dom/server
+
+  omittedCloseTags: {
+    area: true,
+    base: true,
+    br: true,
+    col: true,
+    embed: true,
+    hr: true,
+    img: true,
+    input: true,
+    keygen: true,
+    link: true,
+    meta: true,
+    param: true,
+    source: true,
+    track: true,
+    wbr: true
+    // NOTE: menuitem's close tag should be omitted, but that causes problems.
+  }
+};

--- a/packages/electrode-react-webapp/lib/jsx/utils.js
+++ b/packages/electrode-react-webapp/lib/jsx/utils.js
@@ -1,14 +1,17 @@
 "use strict";
 
-function expandProps(props) {
+function expandProps(props, context) {
   let s = "";
-  for (const key in props) {
-    let v = props[key];
-    if (typeof v === "function") {
-      v = v();
-    }
 
-    s = `${s} ${key}="${v}"`;
+  for (const key in props) {
+    if (key !== "children") {
+      let v = props[key];
+      if (typeof v === "function") {
+        v = v(context);
+      }
+
+      s = `${s} ${key}="${v}"`;
+    }
   }
   return s;
 }

--- a/packages/electrode-react-webapp/lib/react/token-handlers.js
+++ b/packages/electrode-react-webapp/lib/react/token-handlers.js
@@ -217,6 +217,7 @@ window.${key}.ui = ${JSON.stringify(routeOptions.uiConfig)};
 
     [WEBAPP_START_SCRIPT_MARKER]: context => {
       const { webappPrefix } = context.user.routeOptions.uiConfig;
+      /* istanbul ignore next */
       const startFuncName = webappPrefix ? `${webappPrefix}WebappStart` : "webappStart";
       return `<script>
 if (window["${startFuncName}"]) window["${startFuncName}"]();

--- a/packages/electrode-react-webapp/lib/render-execute.js
+++ b/packages/electrode-react-webapp/lib/render-execute.js
@@ -29,7 +29,8 @@ function renderNext(err, xt) {
   };
 
   if (context.isFullStop || context.isVoidStop || xt.stepIndex >= renderSteps.length) {
-    xt.resolve(context.output.close());
+    const r = context.output.close();
+    xt.resolve(r);
     return null;
   } else {
     // TODO: support soft stop

--- a/packages/electrode-react-webapp/lib/token.js
+++ b/packages/electrode-react-webapp/lib/token.js
@@ -35,10 +35,6 @@ class Token {
     this[TEMPLATE_DIR] = this.props[TEMPLATE_DIR] || templateDir || process.cwd();
   }
 
-  get handler() {
-    return this[TOKEN_HANDLER];
-  }
-
   // if token is a module, then load it
   load(options) {
     if (!this.isModule || this.custom !== undefined) return;

--- a/packages/electrode-react-webapp/lib/token.js
+++ b/packages/electrode-react-webapp/lib/token.js
@@ -1,6 +1,6 @@
 "use strict";
 
-/* eslint-disable no-magic-numbers, no-console */
+/* eslint-disable no-magic-numbers, no-console, max-params, max-statements */
 
 const assert = require("assert");
 const loadHandler = require("./load-handler");
@@ -9,7 +9,7 @@ const { TEMPLATE_DIR, TOKEN_HANDLER } = require("./symbols");
 const viewTokenModules = {};
 
 class Token {
-  constructor(id, pos, props) {
+  constructor(id, pos, props, templateDir) {
     this.id = id;
 
     // match `require(path/to/module)`
@@ -32,6 +32,11 @@ class Token {
       this._modCall = [].concat(this.props._call);
     }
     this[TOKEN_HANDLER] = null;
+    this[TEMPLATE_DIR] = this.props[TEMPLATE_DIR] || templateDir || process.cwd();
+  }
+
+  get handler() {
+    return this[TOKEN_HANDLER];
   }
 
   // if token is a module, then load it
@@ -41,7 +46,7 @@ class Token {
     let tokenMod = viewTokenModules[this.id];
 
     if (tokenMod === undefined) {
-      tokenMod = loadHandler(this.modPath, this.props[TEMPLATE_DIR]);
+      tokenMod = loadHandler(this.modPath, this[TEMPLATE_DIR]);
       viewTokenModules[this.id] = tokenMod;
     }
 

--- a/packages/electrode-react-webapp/package.json
+++ b/packages/electrode-react-webapp/package.json
@@ -49,6 +49,7 @@
   "license": "Apache-2.0",
   "files": [
     "lib",
+    "template",
     "index.js"
   ],
   "dependencies": {

--- a/packages/electrode-react-webapp/package.json
+++ b/packages/electrode-react-webapp/package.json
@@ -5,10 +5,19 @@
   "main": "index.js",
   "scripts": {
     "lint": "clap lint",
+    "pre-test": "clap compile",
+    "prepare": "clap compile",
     "test": "clap test",
     "coverage": "clap check",
     "prepublishOnly": "clap check",
     "format": "prettier --write --print-width 100 *.{js,jsx} `find . -type d -d 1 -exec echo '{}/**/*.{js,jsx}' \\; | egrep -v '(/node_modules/|/dist/|/coverage/)'`"
+  },
+  "xclap": {
+    "tasks": {
+      "compile": "babel src-template -D -d template",
+      "test-only": "~[compile, electrode/test-only]",
+      "check": "~[compile, electrode/check]"
+    }
   },
   "homepage": "http://www.electrode.io",
   "repository": {
@@ -53,6 +62,7 @@
     "string-array": "^1.0.0"
   },
   "devDependencies": {
+    "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.4",
     "@babel/preset-env": "^7.4.4",
     "@babel/preset-react": "^7.0.0",
@@ -80,10 +90,10 @@
   "nyc": {
     "all": true,
     "check-coverage": true,
-    "statements": 99,
-    "branches": 99,
-    "functions": 99,
-    "lines": 99,
+    "statements": 100,
+    "branches": 100,
+    "functions": 100,
+    "lines": 100,
     "cache": true,
     "reporter": [
       "lcov",
@@ -95,7 +105,15 @@
       "*clap.js",
       "gulpfile.js",
       "dist",
-      "test"
+      "test",
+      "src-template",
+      "electrode-server2"
+    ],
+    "extension": [
+      ".jsx"
+    ],
+    "require": [
+      "@babel/register"
     ]
   },
   "fyn": {

--- a/packages/electrode-react-webapp/src-template/.babelrc
+++ b/packages/electrode-react-webapp/src-template/.babelrc
@@ -1,0 +1,13 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "8"
+        }
+      }
+    ],
+    "@babel/preset-react"
+  ]
+}

--- a/packages/electrode-react-webapp/src-template/index.jsx
+++ b/packages/electrode-react-webapp/src-template/index.jsx
@@ -1,0 +1,41 @@
+/* @jsx createElement */
+
+const { IndexPage, createElement, Token } = require("../lib/jsx");
+
+const Template = (
+  <IndexPage DOCTYPE="html">
+    <Token _id="INITIALIZE" />
+    <html lang="en">
+      <head>
+        <Token _id="HEAD_INITIALIZE" />
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <Token _id="META_TAGS" />
+        <Token _id="PAGE_TITLE" />
+        <Token _id="CRITICAL_CSS" />
+        <Token _id="APP_CONFIG_DATA" />
+        <Token _id="WEBAPP_HEADER_BUNDLES" />
+        <Token _id="REACT_HELMET_SCRIPTS" />
+        <Token _id="WEBAPP_DLL_BUNDLES" />
+      </head>
+      <Token _id="HEAD_CLOSED" />
+      <body>
+        <div class="js-content">
+          <Token _id="SSR_CONTENT" />
+        </div>
+        <Token _id="AFTER_SSR_CONTENT" />
+        <Token _id="PREFETCH_BUNDLES" />
+        <Token _id="WEBAPP_BODY_BUNDLES" />
+        <Token _id="WEBAPP_START_SCRIPT" />
+        <noscript>
+          <h4>JavaScript is Disabled</h4>
+          <p>Sorry, this webpage requires JavaScript to function correctly.</p>
+          <p>Please enable JavaScript in your browser and reload the page.</p>
+        </noscript>
+      </body>
+      <Token _id="BODY_CLOSED" />
+    </html>
+  </IndexPage>
+);
+
+export default Template;

--- a/packages/electrode-react-webapp/test/data/style2.css
+++ b/packages/electrode-react-webapp/test/data/style2.css
@@ -1,0 +1,3 @@
+.test {
+  color: red;
+}

--- a/packages/electrode-react-webapp/test/jsx-templates/.babelrc
+++ b/packages/electrode-react-webapp/test/jsx-templates/.babelrc
@@ -1,0 +1,13 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "8"
+        }
+      }
+    ],
+    "@babel/preset-react"
+  ]
+}

--- a/packages/electrode-react-webapp/test/jsx-templates/index-1.jsx
+++ b/packages/electrode-react-webapp/test/jsx-templates/index-1.jsx
@@ -1,0 +1,48 @@
+/* @jsx createElement */
+
+const { IndexPage, createElement, Token, Require } = require("../../lib/jsx");
+
+const Template = (
+  <IndexPage DOCTYPE="html">
+    <Token _id="INITIALIZE" />
+    <html blah="blah foo">
+      <head>
+        <Token _id="HEAD_INITIALIZE" />
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <Token _id="META_TAGS" />
+        <Token _id="PAGE_TITLE" />
+        <Token _id="CRITICAL_CSS" />
+        <Token _id="APP_CONFIG_DATA" />
+        <Token _id="WEBAPP_HEADER_BUNDLES" />
+        <Token _id="WEBAPP_DLL_BUNDLES" />
+        <Token _id="user-header-token" />
+      </head>
+      <Token _id="HEAD_CLOSED" />
+      <body>
+        <div>test html-1</div>
+        <Token _id="user-spot-token" />
+        <div class="js-content">
+          <Token _id="user-token-unhandled" />
+          <Token _id="SSR_CONTENT" />
+        </div>
+        <Token _id="AFTER_SSR_CONTENT" />
+        <Token _id="PREFETCH_BUNDLES" />
+        <Token _id="user-promise-token" />
+        <Token _id="WEBAPP_BODY_BUNDLES" />
+        <Token _id="WEBAPP_START_SCRIPT" />
+        <Require _id="../fixtures/custom-1" />
+        <Token _id="user-token-1" />
+        <Token _id="user-token-2" />
+        <noscript>
+          <h4>JavaScript is Disabled</h4>
+          <p>Sorry, this webpage requires JavaScript to function correctly.</p>
+          <p>Please enable JavaScript in your browser and reload the page.</p>
+        </noscript>
+      </body>
+      <Token _id="BODY_CLOSED" />
+    </html>
+  </IndexPage>
+);
+
+export default Template;

--- a/packages/electrode-react-webapp/test/jsx-templates/index-2.jsx
+++ b/packages/electrode-react-webapp/test/jsx-templates/index-2.jsx
@@ -1,0 +1,37 @@
+/* @jsx createElement */
+
+const { IndexPage, createElement, Token, Require } = require("../../lib/jsx");
+
+const Template = (
+  <IndexPage DOCTYPE="html">
+    <Token _id="INITIALIZE" />
+    <html blah="blah foo">
+      <head>
+        <Token _id="HEAD_INITIALIZE" />
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <Token _id="INITIALIZE_HELMET" />
+        <Token _id="META_TAGS" />
+        <Token _id="PAGE_TITLE" />
+        <Token _id="CRITICAL_CSS" />
+      </head>
+      <Token _id="HEAD_CLOSED" />
+      <body>
+        <div>test jsx-2</div>
+        <div class="js-content">
+          <Token _id="SSR_CONTENT" />
+        </div>
+        <Token _id="PREFETCH_BUNDLES" />
+        <Token _id="WEBAPP_BODY_BUNDLES" />
+        <script>if (window.webappStart) webappStart();</script>
+        <noscript>
+          <h4>JavaScript is Disabled</h4>
+          <p>Sorry, this webpage requires JavaScript to function correctly.</p>
+          <p>Please enable JavaScript in your browser and reload the page.</p>
+        </noscript>
+      </body>
+    </html>
+  </IndexPage>
+);
+
+export default Template;

--- a/packages/electrode-react-webapp/test/jsx-templates/style.css
+++ b/packages/electrode-react-webapp/test/jsx-templates/style.css
@@ -1,0 +1,3 @@
+.test {
+  background: black;
+}

--- a/packages/electrode-react-webapp/test/jsx-templates/test1.jsx
+++ b/packages/electrode-react-webapp/test/jsx-templates/test1.jsx
@@ -64,6 +64,7 @@ const Template = () => (
           // test missing file prop
           />
         </style>
+        <script id="test-script" src="http://localhost/test.js" defer />
         <AsyncComponent key="1" indent="=" delay={50}>
           <div id="asyncComponent1">
             test nested async components 1

--- a/packages/electrode-react-webapp/test/jsx-templates/test1.jsx
+++ b/packages/electrode-react-webapp/test/jsx-templates/test1.jsx
@@ -1,14 +1,6 @@
 /* @jsx createElement */
 
-import {
-  render,
-  IndexPage,
-  createElement,
-  Token,
-  Require,
-  Literal,
-  Component
-} from "../../lib/jsx";
+import { IndexPage, createElement, Token, Require, Literal, Component } from "../../lib/jsx";
 
 const getBogelFontUrl = () => {
   return "bogel";

--- a/packages/electrode-react-webapp/test/jsx-templates/test1.jsx
+++ b/packages/electrode-react-webapp/test/jsx-templates/test1.jsx
@@ -29,9 +29,18 @@ function AsyncComponent(props, context, scope) {
   return new Promise(resolve => {
     setTimeout(() => {
       scope.output.add(`${props.indent}async component ${props.key}\n`);
-      resolve();
+      resolve(<div>async component children: {props.children}</div>);
     }, props.delay);
   });
+}
+
+function ChildrenNesting(props) {
+  return (
+    <div>
+      component nesting children
+      {props.children}
+    </div>
+  );
 }
 
 const Template = () => (
@@ -65,14 +74,14 @@ const Template = () => (
           />
         </style>
         <script id="test-script" src="http://localhost/test.js" defer />
-        <AsyncComponent key="1" indent="=" delay={50}>
-          <div id="asyncComponent1">
-            test nested async components 1
-            <AsyncComponent key="2" indent="==" delay={10}>
-              <div id="asyncComponent2">test nested async components 2</div>
-            </AsyncComponent>
-          </div>
-        </AsyncComponent>
+        <ChildrenNesting>
+          <AsyncComponent key="1" indent="=" delay={50}>
+            <div id="asyncComponent1">test nested async components 1</div>
+          </AsyncComponent>
+          <AsyncComponent key="2" indent="==" delay={10}>
+            <div id="asyncComponent2">test nested async components 2</div>
+          </AsyncComponent>
+        </ChildrenNesting>
       </head>
       <body>
         <TestComponent1 test1="hello" />

--- a/packages/electrode-react-webapp/test/jsx-templates/test1.jsx
+++ b/packages/electrode-react-webapp/test/jsx-templates/test1.jsx
@@ -38,7 +38,7 @@ function AsyncComponent(props, context, scope) {
     setTimeout(() => {
       scope.output.add(`${props.indent}async component ${props.key}\n`);
       resolve();
-    }, 5);
+    }, props.delay);
   });
 }
 
@@ -72,11 +72,13 @@ const Template = () => (
           // test missing file prop
           />
         </style>
-        <AsyncComponent key="1" indent="=">
-          test nested async components 1
-          <AsyncComponent key="2" indent="==">
-            <div>test nested async components 2</div>
-          </AsyncComponent>
+        <AsyncComponent key="1" indent="=" delay={50}>
+          <div id="asyncComponent1">
+            test nested async components 1
+            <AsyncComponent key="2" indent="==" delay={10}>
+              <div id="asyncComponent2">test nested async components 2</div>
+            </AsyncComponent>
+          </div>
         </AsyncComponent>
       </head>
       <body>

--- a/packages/electrode-react-webapp/test/jsx-templates/test1.jsx
+++ b/packages/electrode-react-webapp/test/jsx-templates/test1.jsx
@@ -61,9 +61,9 @@ const Template = () => (
         <Require _id="subapp-web/lib/init" />
         <Token _id="CRITICAL_CSS" />
         <style>
-          <Literal memoize={false} file={`${__dirname}/style.css`} />
+          <Literal _memoize={false} file={`${__dirname}/style.css`} />
           <Literal file={`test/data/style2.css`} />
-          <Literal memoize={false} file={`bad-file`} />
+          <Literal _memoize={false} file={`bad-file`} />
           <Literal
             // should be memoized
             file={`test/data/style2.css`}

--- a/packages/electrode-react-webapp/test/jsx-templates/test1.jsx
+++ b/packages/electrode-react-webapp/test/jsx-templates/test1.jsx
@@ -1,0 +1,136 @@
+/* @jsx createElement */
+
+import {
+  render,
+  IndexPage,
+  createElement,
+  Token,
+  Require,
+  Literal,
+  Component
+} from "../../lib/jsx";
+
+const getBogelFontUrl = () => {
+  return "bogel";
+};
+
+const MyTest = (props, context) => {
+  return (
+    <div {...props} v={() => 50}>
+      <Token _id="PAGE_TITLE" />
+      my test
+    </div>
+  );
+};
+
+class TestComponent1 extends Component {
+  constructor(props, context) {
+    super(props, context);
+  }
+
+  render() {
+    return <div>from test component1{this.props.test1}</div>;
+  }
+}
+
+function AsyncComponent(props, context, scope) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      scope.output.add(`${props.indent}async component ${props.key}\n`);
+      resolve();
+    }, 5);
+  });
+}
+
+const Template = () => (
+  <IndexPage DOCTYPE="html">
+    <TestComponent1 />
+    <Token _id="INITIALIZE" />
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link
+          rel="stylesheet"
+          href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+        />
+        <MyTest a={1} b="2" />
+        <link rel="stylesheet" id="bogel-font" href="" />
+        <Token _id="META_TAGS" />
+        <Token _id="PAGE_TITLE" />
+        <Require _id="subapp-web/lib/init" />
+        <Token _id="CRITICAL_CSS" />
+        <style>
+          <Literal memoize={false} file={`${__dirname}/style.css`} />
+          <Literal file={`test/data/style2.css`} />
+          <Literal memoize={false} file={`bad-file`} />
+          <Literal
+            // should be memoized
+            file={`test/data/style2.css`}
+          />
+          <Literal
+          // test missing file prop
+          />
+        </style>
+        <AsyncComponent key="1" indent="=">
+          test nested async components 1
+          <AsyncComponent key="2" indent="==">
+            <div>test nested async components 2</div>
+          </AsyncComponent>
+        </AsyncComponent>
+      </head>
+      <body>
+        <TestComponent1 test1="hello" />
+        <Token _id="user-token-2" />
+        <img src="blah.gif" />
+        <noscript>
+          <h4>JavaScript is Disabled</h4>
+          <p>Sorry, this webpage requires JavaScript to function correctly.</p>
+          <p>Please enable JavaScript in your browser and reload the page.</p>
+        </noscript>
+        <div class="blah" style="background: cyan;">
+          <Require _id="../fixtures/custom-1" />
+          <Require
+            // Do any preparation work need for the Server Side Rendering content
+            // Particular any async data needed for Redux store
+            // This may depend on CCM or SEO so it has to be after those're awaited
+            // If app has provide a content.prepare, then it will be invoked.
+            // It's expected to be async, and fire and forget
+            // It should internally store any state into request.app
+            // For example, an async promise, which would be awaited for later when
+            // content.render is called.
+            // If no prepare step is needed, then app can set a handler that
+            // override this Token to null.
+            // Or just create your own index.html and remove this Token.
+            _id="subapp-web/lib/load"
+            _concurrent
+            name="Header"
+            timestamp
+            startOnLoad
+            elementId="subapp-header01"
+            serverSideRendering
+            hydrateServerData
+            clientSideRendering
+            inlineScript
+          />
+        </div>
+
+        <div class="blah" style="background: green;">
+          <Require
+            _id="subapp-web/lib/load"
+            _concurrent
+            name="MainBody"
+            timestamp
+            elementId="subapp-mainbody"
+            streaming
+            async
+            hydrateServerData
+            serverSideRendering
+          />
+        </div>
+      </body>
+    </html>
+  </IndexPage>
+);
+
+export default Template;

--- a/packages/electrode-react-webapp/test/jsx-templates/test2.jsx
+++ b/packages/electrode-react-webapp/test/jsx-templates/test2.jsx
@@ -1,14 +1,6 @@
 /* @jsx createElement */
 
-import {
-  render,
-  IndexPage,
-  createElement,
-  Token,
-  Require,
-  Literal,
-  Component
-} from "../../lib/jsx";
+import { IndexPage, createElement, Token, Require, Literal, Component } from "../../lib/jsx";
 import { reject } from "any-promise";
 
 const getBogelFontUrl = () => {

--- a/packages/electrode-react-webapp/test/jsx-templates/test2.jsx
+++ b/packages/electrode-react-webapp/test/jsx-templates/test2.jsx
@@ -1,0 +1,105 @@
+/* @jsx createElement */
+
+import {
+  render,
+  IndexPage,
+  createElement,
+  Token,
+  Require,
+  Literal,
+  Component
+} from "../../lib/jsx";
+import { reject } from "any-promise";
+
+const getBogelFontUrl = () => {
+  return "bogel";
+};
+
+const MyTest = (props, context) => {
+  return (
+    <div {...props} v={() => 50}>
+      <Token _id="PAGE_TITLE" />
+      my test
+    </div>
+  );
+};
+
+class TestComponent1 extends Component {
+  constructor(props, context) {
+    super(props, context);
+  }
+
+  render() {
+    return <div>from test component1{this.props.test1}</div>;
+  }
+}
+
+function AsyncComponent(props, context, scope) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (props.fail) {
+        reject(new Error("test async component fail"));
+      } else {
+        scope.output.add(`${props.indent}async component ${props.key}\n`);
+        resolve();
+      }
+    }, props.delay);
+  });
+}
+
+function NestAsyncComponent() {
+  return (
+    <AsyncComponent key="2" indent="==" delay={10} fail={true}>
+      <div id="asyncComponent2">test nested async components failed</div>
+    </AsyncComponent>
+  );
+}
+
+const Template = (
+  <IndexPage DOCTYPE="html">
+    <TestComponent1 />
+    <Token _id="INITIALIZE" />
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <MyTest a={1} b="2" />
+        <link rel="stylesheet" id="bogel-font" href="" />
+        <Token _id="META_TAGS" />
+        <Token _id="PAGE_TITLE" />
+        <Require _id="subapp-web/lib/init" />
+        <Token _id="CRITICAL_CSS" />
+        <style>
+          <Literal _memoize={false} file={`${__dirname}/style.css`} />
+          <Literal file={`test/data/style2.css`} />
+          <Literal _memoize={false} file={`bad-file`} />
+          <Literal
+            // should be memoized
+            file={`test/data/style2.css`}
+          />
+          <Literal
+          // test missing file prop
+          />
+        </style>
+        <NestAsyncComponent>
+          <div id="nestAsync">test nested async components 1</div>
+        </NestAsyncComponent>
+      </head>
+      <body>
+        <TestComponent1 test1="hello" />
+        <Token _id="user-token-2" />
+        <img src="blah.gif" />
+        <noscript>
+          <h4>JavaScript is Disabled</h4>
+          <p>Sorry, this webpage requires JavaScript to function correctly.</p>
+          <p>Please enable JavaScript in your browser and reload the page.</p>
+        </noscript>
+        <div class="blah" style="background: cyan;">
+          <Require _id="../fixtures/custom-1" />
+        </div>
+      </body>
+    </html>
+  </IndexPage>
+);
+
+export default Template;

--- a/packages/electrode-react-webapp/test/jsx-templates/test2.jsx
+++ b/packages/electrode-react-webapp/test/jsx-templates/test2.jsx
@@ -1,7 +1,6 @@
 /* @jsx createElement */
 
 import { IndexPage, createElement, Token, Require, Literal, Component } from "../../lib/jsx";
-import { reject } from "any-promise";
 
 const getBogelFontUrl = () => {
   return "bogel";

--- a/packages/electrode-react-webapp/test/jsx-templates/test3.jsx
+++ b/packages/electrode-react-webapp/test/jsx-templates/test3.jsx
@@ -1,0 +1,53 @@
+/* @jsx createElement */
+
+import { IndexPage, createElement, Token, Require, Literal, Component } from "../../lib/jsx";
+
+function Component1(props) {
+  return (
+    <div>
+      component1 {props.key} {props.children}
+    </div>
+  );
+}
+
+function AsyncChildren(props) {
+  return new Promise(resolve =>
+    setTimeout(() => {
+      resolve(
+        <div>
+          async component {props.key} children: {props.children}
+        </div>
+      );
+    }, 10)
+  );
+}
+
+function NestChildren(props) {
+  return (
+    <div>
+      nesting children
+      {props.children}
+      <Component1 key="+a">
+        <div>inside component1</div>
+      </Component1>
+    </div>
+  );
+}
+
+export default (
+  <IndexPage>
+    <NestChildren>
+      <Component1 key="a" />
+      <Component1 key="b" />
+    </NestChildren>
+
+    <AsyncChildren key="x">
+      <Component1 key="x1" />
+      <NestChildren>
+        <Component1 key="m" />
+        <Component1 key="n" />
+      </NestChildren>
+      <Component1 key="x2" />
+    </AsyncChildren>
+  </IndexPage>
+);

--- a/packages/electrode-react-webapp/test/mocha.opts
+++ b/packages/electrode-react-webapp/test/mocha.opts
@@ -1,2 +1,3 @@
+--require @babel/register
 --require node_modules/electrode-archetype-njs-module-dev/config/test/setup.js
 --recursive

--- a/packages/electrode-react-webapp/test/spec/hapi.index.spec.js
+++ b/packages/electrode-react-webapp/test/spec/hapi.index.spec.js
@@ -8,7 +8,6 @@ const assign = require("object-assign");
 const electrodeServer = require("electrode-server");
 const Path = require("path");
 const xstdout = require("xstdout");
-require("@babel/register");
 const { expect } = require("chai");
 const webapp = require("../../lib/hapi/plugin16");
 const ReactDOMServer = require("react-dom/server");

--- a/packages/electrode-react-webapp/test/spec/jsx/jsx-renderer.spec.js
+++ b/packages/electrode-react-webapp/test/spec/jsx/jsx-renderer.spec.js
@@ -99,6 +99,7 @@ token process module subapp-web/lib/init not found
 
 <h1>Literal props missing file</h1>
 </style>
+<script id="test-script" src="http://localhost/test.js" defer="true"></script>
 =async component 1
 <div id="asyncComponent1">test nested async components 1
 ==async component 2

--- a/packages/electrode-react-webapp/test/spec/jsx/jsx-renderer.spec.js
+++ b/packages/electrode-react-webapp/test/spec/jsx/jsx-renderer.spec.js
@@ -23,16 +23,6 @@ describe("IndexPage", function() {
 });
 
 describe("Jsx Renderer", function() {
-  it("getTokenHandler should return undefined if no token handler", () => {
-    const renderer = new JsxRenderer({
-      insertTokenIds: true,
-      templateFullPath: Path.dirname(require.resolve("../../jsx-templates/test1")),
-      template: Template,
-      tokenHandlers: "./test/fixtures/token-handler"
-    });
-    expect(renderer.getTokenHandler({ props: { _id: "blah" } })).to.equal(undefined);
-  });
-
   it("getTokenInst should return undefined if no token instance", () => {
     const renderer = new JsxRenderer({
       insertTokenIds: true,

--- a/packages/electrode-react-webapp/test/spec/jsx/jsx-renderer.spec.js
+++ b/packages/electrode-react-webapp/test/spec/jsx/jsx-renderer.spec.js
@@ -1,0 +1,150 @@
+"use strict";
+
+const Path = require("path");
+const { JsxRenderer, Component, IndexPage } = require("../../../lib/jsx");
+const Template = require("../../jsx-templates/test1").default;
+
+describe("Component", function() {
+  it("should have isComponent and render method", () => {
+    const x = new Component();
+    expect(x.isComponent()).to.equal(true);
+    expect(x.render()).to.equal("component");
+  });
+});
+
+describe("IndexPage", function() {
+  it("should have static memoize", () => {
+    expect(IndexPage.memoize({})).equal(`<!DOCTYPE html>`);
+    expect(IndexPage.memoize({ DOCTYPE: "blah" })).equal(`<!DOCTYPE blah>`);
+  });
+});
+
+describe("Jsx Renderer", function() {
+  it("getTokenHandler should return undefined if no token handler", () => {
+    const renderer = new JsxRenderer({
+      insertTokenIds: true,
+      templateFullPath: Path.dirname(require.resolve("../../jsx-templates/test1")),
+      template: Template,
+      tokenHandlers: "./test/fixtures/token-handler"
+    });
+    expect(renderer.getTokenHandler({ props: { _id: "blah" } })).to.equal(undefined);
+  });
+
+  it("getTokenInst should return undefined if no token instance", () => {
+    const renderer = new JsxRenderer({
+      insertTokenIds: true,
+      templateFullPath: Path.dirname(require.resolve("../../jsx-templates/test1")),
+      template: Template,
+      tokenHandlers: "./test/fixtures/token-handler"
+    });
+    expect(renderer.getTokenInst({ props: { _id: "blah" } })).to.equal(undefined);
+  });
+
+  it("should have re-entrant initializeRenderer", () => {
+    const renderer = new JsxRenderer({
+      insertTokenIds: true,
+      templateFullPath: Path.dirname(require.resolve("../../jsx-templates/test1")),
+      template: Template,
+      tokenHandlers: "./test/fixtures/token-handler"
+    });
+    renderer.initializeRenderer();
+    renderer.initializeRenderer(true);
+    renderer.initializeRenderer();
+  });
+
+  it("should render index page in JSX", () => {
+    const renderer = new JsxRenderer({
+      insertTokenIds: true,
+      templateFullPath: Path.dirname(require.resolve("../../jsx-templates/test1")),
+      template: Template,
+      tokenHandlers: "./test/fixtures/token-handler"
+    });
+
+    const verify = context => {
+      expect(context.output._result.trim()).equal(`<!DOCTYPE html>
+<div>from test component1
+</div>
+
+<!-- INITIALIZE removed due to its handler set to null -->
+<html lang="en"><head><meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"/>
+<div a="1" b="2" v="50"><!-- BEGIN PAGE_TITLE props: {} -->
+<title>user-handler-title</title><!-- PAGE_TITLE END -->
+my test
+</div>
+
+<link rel="stylesheet" id="bogel-font" href=""/>
+<!-- META_TAGS removed due to its handler set to null -->
+<!-- BEGIN PAGE_TITLE props: {} -->
+<title>user-handler-title</title><!-- PAGE_TITLE END -->
+<!-- BEGIN require(subapp-web/lib/init) props: {} -->
+
+token process module subapp-web/lib/init not found
+<!-- require(subapp-web/lib/init) END -->
+<!-- CRITICAL_CSS removed due to its handler set to null -->
+<style>.test {
+  background: black;
+}
+
+.test {
+  color: red;
+}
+
+<h1>Literal reading file failed: ENOENT: no such file or directory, open 'CWD/bad-file'</h1>
+.test {
+  color: red;
+}
+
+<h1>Literal props missing file</h1>
+</style>
+=async component 1
+test nested async components 1
+==async component 2
+<div>test nested async components 2
+</div>
+
+
+</head>
+<body><div>from test component1
+hello
+</div>
+
+<!-- BEGIN user-token-2 props: {} -->
+<div>user-token-2</div><!-- user-token-2 END -->
+<img src="blah.gif"/>
+<noscript><h4>JavaScript is Disabled
+</h4>
+<p>Sorry, this webpage requires JavaScript to function correctly.
+</p>
+<p>Please enable JavaScript in your browser and reload the page.
+</p>
+</noscript>
+<div class="blah" style="background: cyan;"><!-- BEGIN require(../fixtures/custom-1) props: {} -->
+<div>from custom-1</div><!-- require(../fixtures/custom-1) END -->
+<!-- BEGIN require(subapp-web/lib/load) props: {"_concurrent":true,"name":"Header","timestamp":true,\
+"startOnLoad":true,"elementId":"subapp-header01","serverSideRendering":true,"hydrateServerData":true,\
+"clientSideRendering":true,"inlineScript":true} -->
+
+token process module subapp-web/lib/load not found
+<!-- require(subapp-web/lib/load) END -->
+</div>
+<div class="blah" style="background: green;"><!-- BEGIN require(subapp-web/lib/load) props: \
+{"_concurrent":true,"name":"MainBody","timestamp":true,"elementId":"subapp-mainbody","streaming":true,\
+"async":true,"hydrateServerData":true,"serverSideRendering":true} -->
+
+token process module subapp-web/lib/load not found
+<!-- require(subapp-web/lib/load) END -->
+</div>
+</body>
+</html>`);
+    };
+    renderer.initializeRenderer();
+
+    const promise = renderer.render({});
+    return promise.then(context => {
+      verify(context);
+      return renderer.render({}).then(verify);
+    });
+  });
+});

--- a/packages/electrode-react-webapp/test/spec/jsx/jsx-renderer.spec.js
+++ b/packages/electrode-react-webapp/test/spec/jsx/jsx-renderer.spec.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const Path = require("path");
-const { JsxRenderer, Component, IndexPage } = require("../../../lib/jsx");
+const { JsxRenderer, Component, IndexPage } = require("../../..").jsx;
 const Template = require("../../jsx-templates/test1").default;
 const Template2 = require("../../jsx-templates/test2").default;
 

--- a/packages/electrode-react-webapp/test/spec/jsx/jsx-renderer.spec.js
+++ b/packages/electrode-react-webapp/test/spec/jsx/jsx-renderer.spec.js
@@ -1,9 +1,11 @@
 "use strict";
 
 const Path = require("path");
+const Fs = require("fs");
 const { JsxRenderer, Component, IndexPage } = require("../../..").jsx;
 const Template = require("../../jsx-templates/test1").default;
 const Template2 = require("../../jsx-templates/test2").default;
+const Template3 = require("../../jsx-templates/test3").default;
 
 describe("Component", function() {
   it("should have isComponent and render method", () => {
@@ -53,6 +55,11 @@ describe("Jsx Renderer", function() {
     renderer.initializeRenderer();
   });
 
+  const test1ExpectedOutput = Fs.readFileSync(
+    Path.join(__dirname, "test1-output.txt"),
+    "utf8"
+  ).trim();
+
   it("should render index page in JSX", () => {
     const renderer = new JsxRenderer({
       insertTokenIds: true,
@@ -62,86 +69,15 @@ describe("Jsx Renderer", function() {
     });
 
     const verify = context => {
-      expect(context.output._result.trim()).equal(`<!DOCTYPE html>
-<div>from test component1
-</div>
+      const r = context.output._result
+        .trim()
+        .split("\n")
+        .map(x => x.trimRight())
+        .join("\n");
 
-<!-- INITIALIZE removed due to its handler set to null -->
-<html lang="en"><head><meta charset="UTF-8"/>
-<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"/>
-<div a="1" b="2" v="50"><!-- BEGIN PAGE_TITLE props: {} -->
-<title>user-handler-title</title><!-- PAGE_TITLE END -->
-my test
-</div>
-
-<link rel="stylesheet" id="bogel-font" href=""/>
-<!-- META_TAGS removed due to its handler set to null -->
-<!-- BEGIN PAGE_TITLE props: {} -->
-<title>user-handler-title</title><!-- PAGE_TITLE END -->
-<!-- BEGIN require(subapp-web/lib/init) props: {} -->
-
-token process module subapp-web/lib/init not found
-<!-- require(subapp-web/lib/init) END -->
-<!-- CRITICAL_CSS removed due to its handler set to null -->
-<style>.test {
-  background: black;
-}
-
-.test {
-  color: red;
-}
-
-<h1>Literal reading file failed: ENOENT: no such file or directory, open 'CWD/bad-file'</h1>
-.test {
-  color: red;
-}
-
-<h1>Literal props missing file</h1>
-</style>
-<script id="test-script" src="http://localhost/test.js" defer="true"></script>
-=async component 1
-<div id="asyncComponent1">test nested async components 1
-==async component 2
-<div id="asyncComponent2">test nested async components 2
-</div>
-
-</div>
-
-</head>
-<body><div>from test component1
-hello
-</div>
-
-<!-- BEGIN user-token-2 props: {} -->
-<div>user-token-2</div><!-- user-token-2 END -->
-<img src="blah.gif"/>
-<noscript><h4>JavaScript is Disabled
-</h4>
-<p>Sorry, this webpage requires JavaScript to function correctly.
-</p>
-<p>Please enable JavaScript in your browser and reload the page.
-</p>
-</noscript>
-<div class="blah" style="background: cyan;"><!-- BEGIN require(../fixtures/custom-1) props: {} -->
-<div>from custom-1</div><!-- require(../fixtures/custom-1) END -->
-<!-- BEGIN require(subapp-web/lib/load) props: {"_concurrent":true,"name":"Header","timestamp":true,\
-"startOnLoad":true,"elementId":"subapp-header01","serverSideRendering":true,"hydrateServerData":true,\
-"clientSideRendering":true,"inlineScript":true} -->
-
-token process module subapp-web/lib/load not found
-<!-- require(subapp-web/lib/load) END -->
-</div>
-<div class="blah" style="background: green;"><!-- BEGIN require(subapp-web/lib/load) props: \
-{"_concurrent":true,"name":"MainBody","timestamp":true,"elementId":"subapp-mainbody","streaming":true,\
-"async":true,"hydrateServerData":true,"serverSideRendering":true} -->
-
-token process module subapp-web/lib/load not found
-<!-- require(subapp-web/lib/load) END -->
-</div>
-</body>
-</html>`);
+      expect(r).equal(test1ExpectedOutput);
     };
+
     renderer.initializeRenderer();
 
     const promise = renderer.render({});
@@ -164,6 +100,33 @@ token process module subapp-web/lib/load not found
     const promise = renderer.render({});
     return promise.then(context => {
       expect(context.result.message).equal("test async component fail");
+    });
+  });
+
+  const test3ExpectedOutput = Fs.readFileSync(
+    Path.join(__dirname, "test3-output.txt"),
+    "utf8"
+  ).trim();
+
+  it("should handle component nesting children", () => {
+    const renderer = new JsxRenderer({
+      insertTokenIds: true,
+      templateFullPath: Path.dirname(require.resolve("../../jsx-templates/test3")),
+      template: Template3,
+      tokenHandlers: "./test/fixtures/token-handler"
+    });
+
+    renderer.initializeRenderer();
+
+    const promise = renderer.render({});
+    return promise.then(context => {
+      const r = context.output._result
+        .trim()
+        .split("\n")
+        .map(x => x.trimRight())
+        .join("\n");
+
+      expect(r).to.equal(test3ExpectedOutput);
     });
   });
 });

--- a/packages/electrode-react-webapp/test/spec/jsx/jsx-renderer.spec.js
+++ b/packages/electrode-react-webapp/test/spec/jsx/jsx-renderer.spec.js
@@ -3,6 +3,7 @@
 const Path = require("path");
 const { JsxRenderer, Component, IndexPage } = require("../../../lib/jsx");
 const Template = require("../../jsx-templates/test1").default;
+const Template2 = require("../../jsx-templates/test2").default;
 
 describe("Component", function() {
   it("should have isComponent and render method", () => {
@@ -146,6 +147,22 @@ token process module subapp-web/lib/load not found
     return promise.then(context => {
       verify(context);
       return renderer.render({}).then(verify);
+    });
+  });
+
+  it("should handle failure in nesting async components", () => {
+    const renderer = new JsxRenderer({
+      insertTokenIds: true,
+      templateFullPath: Path.dirname(require.resolve("../../jsx-templates/test2")),
+      template: Template2,
+      tokenHandlers: "./test/fixtures/token-handler"
+    });
+
+    renderer.initializeRenderer();
+
+    const promise = renderer.render({});
+    return promise.then(context => {
+      expect(context.result.message).equal("test async component fail");
     });
   });
 });

--- a/packages/electrode-react-webapp/test/spec/jsx/jsx-renderer.spec.js
+++ b/packages/electrode-react-webapp/test/spec/jsx/jsx-renderer.spec.js
@@ -99,11 +99,12 @@ token process module subapp-web/lib/init not found
 <h1>Literal props missing file</h1>
 </style>
 =async component 1
-test nested async components 1
+<div id="asyncComponent1">test nested async components 1
 ==async component 2
-<div>test nested async components 2
+<div id="asyncComponent2">test nested async components 2
 </div>
 
+</div>
 
 </head>
 <body><div>from test component1

--- a/packages/electrode-react-webapp/test/spec/jsx/test1-output.txt
+++ b/packages/electrode-react-webapp/test/spec/jsx/test1-output.txt
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<div>from test component1
+</div>
+
+<!-- INITIALIZE removed due to its handler set to null -->
+<html lang="en"><head><meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"/>
+<div a="1" b="2" v="50"><!-- BEGIN PAGE_TITLE props: {} -->
+<title>user-handler-title</title><!-- PAGE_TITLE END -->
+my test
+</div>
+
+<link rel="stylesheet" id="bogel-font" href=""/>
+<!-- META_TAGS removed due to its handler set to null -->
+<!-- BEGIN PAGE_TITLE props: {} -->
+<title>user-handler-title</title><!-- PAGE_TITLE END -->
+<!-- BEGIN require(subapp-web/lib/init) props: {} -->
+
+token process module subapp-web/lib/init not found
+<!-- require(subapp-web/lib/init) END -->
+<!-- CRITICAL_CSS removed due to its handler set to null -->
+<style>.test {
+  background: black;
+}
+
+.test {
+  color: red;
+}
+
+<h1>Literal reading file failed: ENOENT: no such file or directory, open 'CWD/bad-file'</h1>
+.test {
+  color: red;
+}
+
+<h1>Literal props missing file</h1>
+</style>
+<script id="test-script" src="http://localhost/test.js" defer="true"></script>
+<div>component nesting children
+=async component 1
+<div>async component children:
+<div id="asyncComponent1">test nested async components 1
+</div>
+</div>
+
+==async component 2
+<div>async component children:
+<div id="asyncComponent2">test nested async components 2
+</div>
+</div>
+
+</div>
+
+</head>
+<body><div>from test component1
+hello
+</div>
+
+<!-- BEGIN user-token-2 props: {} -->
+<div>user-token-2</div><!-- user-token-2 END -->
+<img src="blah.gif"/>
+<noscript><h4>JavaScript is Disabled
+</h4>
+<p>Sorry, this webpage requires JavaScript to function correctly.
+</p>
+<p>Please enable JavaScript in your browser and reload the page.
+</p>
+</noscript>
+<div class="blah" style="background: cyan;"><!-- BEGIN require(../fixtures/custom-1) props: {} -->
+<div>from custom-1</div><!-- require(../fixtures/custom-1) END -->
+<!-- BEGIN require(subapp-web/lib/load) props: {"_concurrent":true,"name":"Header","timestamp":true,"startOnLoad":true,"elementId":"subapp-header01","serverSideRendering":true,"hydrateServerData":true,"clientSideRendering":true,"inlineScript":true} -->
+
+token process module subapp-web/lib/load not found
+<!-- require(subapp-web/lib/load) END -->
+</div>
+<div class="blah" style="background: green;"><!-- BEGIN require(subapp-web/lib/load) props: {"_concurrent":true,"name":"MainBody","timestamp":true,"elementId":"subapp-mainbody","streaming":true,"async":true,"hydrateServerData":true,"serverSideRendering":true} -->
+
+token process module subapp-web/lib/load not found
+<!-- require(subapp-web/lib/load) END -->
+</div>
+</body>
+</html>

--- a/packages/electrode-react-webapp/test/spec/jsx/test3-output.txt
+++ b/packages/electrode-react-webapp/test/spec/jsx/test3-output.txt
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<div>nesting children
+<div>component1
+a
+
+</div>
+
+<div>component1
+b
+
+</div>
+
+<div>component1
++a
+
+<div>inside component1
+</div>
+</div>
+
+</div>
+
+<div>async component
+x
+ children:
+<div>component1
+x1
+
+</div>
+
+<div>nesting children
+<div>component1
+m
+
+</div>
+
+<div>component1
+n
+
+</div>
+
+<div>component1
++a
+
+<div>inside component1
+</div>
+</div>
+
+</div>
+
+<div>component1
+x2
+
+</div>
+
+</div>


### PR DESCRIPTION
TBD: docs

Instead of using a simple string tokenizer template, utilize React's JSX standard for creating the index page template, gaining all the advantages of writing in JSX.

Not React.

Legacy tokens for the template fully supported.
