### PR TITLE
set babel env target for dev mode with archetype v5

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/babel.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/babel.js
@@ -11,7 +11,6 @@ module.exports = function(options) {
   const { options: babelLoaderOptions = {}, ...rest } = archetype.babel.extendLoader;
   const isProduction =
     process.env.BABEL_ENV === "production" || process.env.NODE_ENV === "production";
-  const isDevelopment = process.env.NODE_ENV === "development";
   const getBabelrcClient = () => {
     const babelrcClient = JSON.parse(
       Fs.readFileSync(require.resolve("../../babel/babelrc-client-multitargets"))
@@ -26,7 +25,7 @@ module.exports = function(options) {
         targets,
         useBuiltIns: "entry",
         corejs: "2",
-        modules: isProduction || (isDevelopment && target !== "default") ? false : "commonjs"
+        modules: isProduction ? false : "commonjs"
       }
     ]);
     babelrcClient.presets = babelrcClient.presets.concat(presets);

--- a/packages/electrode-archetype-react-app-dev/config/webpack/partial/babel.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/partial/babel.js
@@ -11,6 +11,7 @@ module.exports = function(options) {
   const { options: babelLoaderOptions = {}, ...rest } = archetype.babel.extendLoader;
   const isProduction =
     process.env.BABEL_ENV === "production" || process.env.NODE_ENV === "production";
+  const isDevelopment = process.env.NODE_ENV === "development";
   const getBabelrcClient = () => {
     const babelrcClient = JSON.parse(
       Fs.readFileSync(require.resolve("../../babel/babelrc-client-multitargets"))
@@ -25,7 +26,7 @@ module.exports = function(options) {
         targets,
         useBuiltIns: "entry",
         corejs: "2",
-        modules: isProduction ? false : "commonjs"
+        modules: isProduction || (isDevelopment && target !== "default") ? false : "commonjs"
       }
     ]);
     babelrcClient.presets = babelrcClient.presets.concat(presets);

--- a/packages/electrode-archetype-react-app/arch-clap.js
+++ b/packages/electrode-archetype-react-app/arch-clap.js
@@ -83,10 +83,12 @@ function setDevelopmentEnv() {
 }
 
 function setDevelopmentTarget(args) {
-  const idx = args.findIndex(arg => arg.startsWith("--target"));
-  if (idx >= 0) {
-    const [arg] = args.splice(idx, 1);
-    process.env.ENV_TARGET = arg.substr("--target=".length);
+  if (archetype.babel.target === "default") {
+    const idx = args.findIndex(arg => arg.startsWith("--target"));
+    if (idx >= 0) {
+      const [arg] = args.splice(idx, 1);
+      process.env.ENV_TARGET = arg.substr("--target=".length);
+    }
   }
 }
 
@@ -357,6 +359,10 @@ function makeTasks(xclap) {
   const buildDistDirs = babelEnvTargetsArr
     .filter(name => name !== "default")
     .map(name => `dist-${name}`);
+
+  const setEnvTarget = target => {
+    process.env.ENV_TARGET = target;
+  };
 
   let tasks = {
     ".mk-prod-dir": () =>
@@ -654,6 +660,8 @@ Individual .babelrc files were generated for you in src/client and src/server
     "cov-frontend-85": () => checkFrontendCov("85"),
     "cov-frontend-95": () => checkFrontendCov("95"),
 
+    "dev-target-es6": () => setEnvTarget("es6"),
+
     debug: ["build-dev-static", "server-debug"],
     devbrk: ["dev --inspect-brk"],
     dev: {
@@ -675,6 +683,12 @@ Individual .babelrc files were generated for you in src/client and src/server
           ].filter(x => x)
         ];
       }
+    },
+
+    "dev-es6": {
+      desc:
+        "Start your app with watch in development mode with webpack-dev-server with ENV_TARGET=es6",
+      task: ["dev-target-es6", "dev"]
     },
 
     "dev-static": {

--- a/packages/electrode-archetype-react-app/arch-clap.js
+++ b/packages/electrode-archetype-react-app/arch-clap.js
@@ -660,8 +660,6 @@ Individual .babelrc files were generated for you in src/client and src/server
     "cov-frontend-85": () => checkFrontendCov("85"),
     "cov-frontend-95": () => checkFrontendCov("95"),
 
-    "dev-target-es6": () => setEnvTarget("es6"),
-
     debug: ["build-dev-static", "server-debug"],
     devbrk: ["dev --inspect-brk"],
     dev: {
@@ -688,7 +686,7 @@ Individual .babelrc files were generated for you in src/client and src/server
     "dev-es6": {
       desc:
         "Start your app with watch in development mode with webpack-dev-server with ENV_TARGET=es6",
-      task: ["dev-target-es6", "dev"]
+      task: ["dev --target=es6"]
     },
 
     "dev-static": {

--- a/packages/electrode-archetype-react-app/arch-clap.js
+++ b/packages/electrode-archetype-react-app/arch-clap.js
@@ -82,6 +82,14 @@ function setDevelopmentEnv() {
   process.env.NODE_ENV = "development";
 }
 
+function setDevelopmentTarget(args) {
+  const idx = args.findIndex(arg => arg.startsWith("--target"));
+  if (idx >= 0) {
+    const [arg] = args.splice(idx, 1);
+    process.env.ENV_TARGET = arg.substr("--target=".length);
+  }
+}
+
 function setWebpackHot() {
   process.env.HMR = "true";
 }
@@ -656,7 +664,7 @@ Individual .babelrc files were generated for you in src/client and src/server
           Fs.writeFileSync(".isomorphic-loader-config.json", JSON.stringify({}));
         }
         const args = taskArgs(this.argv);
-
+        setDevelopmentTarget(args);
         return [
           ".set.babel.env",
           ".webpack-dev",


### PR DESCRIPTION
define `envTargets` in `archetype/config/index.js`
use `clap dev --target=es6` or alias `clap dev-es6`