### PR TITLE
[feat] add support for proposal decorators

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/archetype.js
+++ b/packages/electrode-archetype-react-app-dev/config/archetype.js
@@ -78,6 +78,8 @@ const babelConfigSpec = {
   enableFlow: { env: "ENABLE_BABEL_FLOW", default: true },
   // require the @flow directive in source to enable FlowJS type stripping
   flowRequireDirective: { env: "FLOW_REQUIRE_DIRECTIVE", default: false },
+  proposalDecorators: { env: "BABEL_PROPOSAL_DECORATORS", default: false },
+  legacyDecorators: { env: "BABEL_LEGACY_DECORATORS", default: true },
   transformClassProps: { env: "BABEL_CLASS_PROPS", default: false },
   looseClassProps: { env: "BABEL_CLASS_PROPS_LOOSE", default: true },
   envTargets: {

--- a/packages/electrode-archetype-react-app-dev/config/babel/babelrc-client.js
+++ b/packages/electrode-archetype-react-app-dev/config/babel/babelrc-client.js
@@ -8,6 +8,8 @@ const {
   enableTypeScript,
   flowRequireDirective,
   enableFlow,
+  proposalDecorators,
+  legacyDecorators,
   transformClassProps,
   looseClassProps,
   enableDynamicImport
@@ -24,6 +26,12 @@ const basePlugins = [
   ...(enableDynamicImport
     ? ["@babel/plugin-syntax-dynamic-import", "@loadable/babel-plugin"]
     : [false]),
+  // allow decorators on class and method
+  // Note: This must go before @babel/plugin-proposal-class-properties
+  (enableTypeScript || proposalDecorators) && [
+    "@babel/plugin-proposal-decorators",
+    { legacy: legacyDecorators }
+  ],
   //
   // allow class properties. loose option compile to assignment expression instead
   // of Object.defineProperty.

--- a/packages/electrode-archetype-react-app-dev/package.json
+++ b/packages/electrode-archetype-react-app-dev/package.json
@@ -30,6 +30,7 @@
     "@babel/cli": "^7.1.5",
     "@babel/core": "^7.1.6",
     "@babel/plugin-proposal-class-properties": "^7.2.1",
+    "@babel/plugin-proposal-decorators": "^7.4.4",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-transform-flow-strip-types": "^7.2.0",


### PR DESCRIPTION
maybe need to add support for decorators, which will be helpful for `mobx` users, since mobx uses decorators much. 

and the plugin `@babel/plugin-proposal-decorators` needs to be put before `@babel/plugin-proposal-class-properties`, which is not easy to override in users' `src/client/.babelrc.js`, since the merged `plugins` cannot change the order of original plugins.