### PR TITLE
optional check skip if user dep on a diff major version

### DIFF
--- a/packages/electrode-archetype-opt-react/package.json
+++ b/packages/electrode-archetype-opt-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrode-archetype-opt-react",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Electrode NodeJS/React Optional Archetype - react",
   "main": "optional-check.js",
   "homepage": "http://www.electrode.io",

--- a/packages/opt-archetype-check/package.json
+++ b/packages/opt-archetype-check/package.json
@@ -4,7 +4,7 @@
   "description": "common code for electrode optional archetype checking",
   "main": "optional-check.js",
   "scripts": {
-    "test": "exit 0"
+    "test": "node test/test1.js"
   },
   "keywords": [],
   "author": "Joel Chen <xchen@walmartlabs.com>",

--- a/packages/opt-archetype-check/test/test1.js
+++ b/packages/opt-archetype-check/test/test1.js
@@ -1,0 +1,19 @@
+"use strict";
+
+const assert = require("assert");
+
+const { isSameMajorVersion } = require("../optional-check");
+
+assert(isSameMajorVersion("1.0.0", "1.2.1") === true);
+
+assert(isSameMajorVersion("~1.0.0", "1.2.1") === true);
+
+assert(isSameMajorVersion("^1.1.0", "1.2.1") === true);
+
+assert(isSameMajorVersion("0.1.0", "0.1.2") === true);
+assert(isSameMajorVersion("~0.1.1", "0.1.3") === true);
+assert(isSameMajorVersion("^0.1.1", "0.1.3") === true);
+
+assert(isSameMajorVersion("1.0.0", "2.2.1") === false);
+assert(isSameMajorVersion("~1.0.0", "2.2.1") === false);
+assert(isSameMajorVersion("^1.0.0", "2.2.1") === false);


### PR DESCRIPTION
This allow archetype to include an opt archetype by default, but user can specify another one in their `devDependencies` with a diff major version to override.
