### PR TITLE
Default index template if none is specified

### DIFF
--- a/packages/electrode-react-webapp/README.md
+++ b/packages/electrode-react-webapp/README.md
@@ -273,6 +273,13 @@ const config = {
 };
 ```
 
+## Development
+To run tests
+```sh
+% fyn
+% clap check
+```
+
 [npm-image]: https://badge.fury.io/js/electrode-react-webapp.svg
 [npm-url]: https://npmjs.org/package/electrode-react-webapp
 [daviddm-image]: https://david-dm.org/electrode-io/electrode/status.svg?path=packages/electrode-react-webapp

--- a/packages/electrode-react-webapp/lib/react-webapp.js
+++ b/packages/electrode-react-webapp/lib/react-webapp.js
@@ -94,7 +94,13 @@ function makeRouteHandler(routeOptions) {
   }
 
   const render = (options, templateSelection) => {
-    const asyncTemplate = initializeTemplate(templateSelection || defaultSelection, routeOptions);
+    let selection = Object.assign({}, defaultSelection);
+    if (templateSelection && (templateSelection.htmlFile || templateSelection.templateFile)) {
+      delete selection.htmlFile;
+      delete selection.templateFile;
+    }
+    selection = Object.assign(selection, templateSelection || {});
+    const asyncTemplate = initializeTemplate(selection, routeOptions);
     return asyncTemplate.render(options);
   };
 

--- a/packages/electrode-react-webapp/test/spec/hapi17.index.spec.js
+++ b/packages/electrode-react-webapp/test/spec/hapi17.index.spec.js
@@ -758,6 +758,7 @@ describe("hapi 17 electrode-react-webapp", () => {
     });
   });
 
+
   it("should use top level htmlFile and return response headers", () => {
     configOptions.prodBundleBase = "http://awesome-cdn.com/myapp/";
     configOptions.stats = "test/data/stats-test-one-bundle.json";

--- a/packages/electrode-react-webapp/test/spec/hapi17.jsx-index.spec.js
+++ b/packages/electrode-react-webapp/test/spec/hapi17.jsx-index.spec.js
@@ -62,6 +62,10 @@ const getConfig = () => {
                       pageTitle: "test page title 1"
                     }
                   };
+                } else if (request.query.template === "4") {
+                  return {
+                    tokenHandlers: Path.join(__dirname, "../fixtures/token-handler")
+                  };
                 }
                 return null; // select default
               },
@@ -712,7 +716,7 @@ describe("hapi 17 electrode-react-webapp with jsx template", () => {
     });
   });
 
-  it.skip("should use top level htmlFile and return response headers", () => {
+   it.skip("should use top level htmlFile and return response headers", () => {
     configOptions.prodBundleBase = "http://awesome-cdn.com/myapp/";
     configOptions.stats = "test/data/stats-test-one-bundle.json";
     configOptions.htmlFile = "test/data/index-1.html";
@@ -1831,6 +1835,23 @@ describe("hapi 17 electrode-react-webapp with jsx template", () => {
             stopServer(server);
             throw err;
           });
+      });
+    });
+
+    it("should render with selectTemplate even if htmlFile is not specified", () => {
+      return electrodeServer(config).then(server => {
+        return server.inject({
+          method: "GET",
+          url: "/select?template=4"
+        })
+        .then(res => {
+          expect(res.statusCode).equal(200);
+          stopServer(server);
+        })
+        .catch(err => {
+          stopServer(server);
+          throw err;
+        });
       });
     });
 


### PR DESCRIPTION
500 error when specifying a tokenHandler without specifying an index template file.

Render did not pickup the default index template file.