### PR TITLE
scan subapp dir for reducers and create HMR createStore method

### DIFF
--- a/packages/subapp-redux/lib/index.js
+++ b/packages/subapp-redux/lib/index.js
@@ -10,8 +10,13 @@ module.exports = {
       __redux: true
     };
 
-    if (!subapp.reduxCreateStore && !subapp.reduxReducers) {
-      extras.reduxCreateStore = initialState => createStore(x => x, initialState || {});
+    if (!subapp.reduxCreateStore) {
+      extras._genReduxCreateStore = "subapp";
+      if (subapp.reduxReducers) {
+        extras.reduxCreateStore = initialState => createStore(subapp.reduxReducers, initialState);
+      } else {
+        extras.reduxCreateStore = initialState => createStore(x => x, initialState || {});
+      }
     }
 
     return registerSubApp(Object.assign(extras, subapp));

--- a/packages/subapp-redux/src/index.jsx
+++ b/packages/subapp-redux/src/index.jsx
@@ -59,8 +59,13 @@ export function reduxLoadSubApp(info) {
     __redux: true
   };
 
-  if (!info.reduxCreateStore && !info.reduxReducers) {
-    extras.reduxCreateStore = initialState => createStore(x => x, initialState || {});
+  if (!info.reduxCreateStore) {
+    extras._genReduxCreateStore = "subapp";
+    if (info.reduxReducers) {
+      extras.reduxCreateStore = initialState => createStore(info.reduxReducers, initialState);
+    } else {
+      extras.reduxCreateStore = initialState => createStore(x => x, initialState || {});
+    }
   }
 
   return loadSubApp(Object.assign(extras, info), renderStart);

--- a/packages/subapp-util/lib/index.js
+++ b/packages/subapp-util/lib/index.js
@@ -28,40 +28,73 @@ function removeExt(f) {
   return ix > 0 ? f.substring(0, ix) : f;
 }
 
+//
+// scan a subapp's directory for additional things:
+// - server side entry in server.js, server-{name}.js, server-{verbatimName}.js
+// - reducers directory, reducers[.js|.jsx|.ts|.tsx]
+//
+function scanSubAppAdditions(dir, manifest) {
+  const { name, verbatimName } = manifest;
+  // does subapp dir contain a file matching server.*, server-<name>.* pattern
+  const entries = ["server.", name && `server-${name}.`, verbatimName && `server-${verbatimName}.`]
+    .filter(x => x)
+    .map(x => x.toLowerCase());
+
+  const scanned = scanDir.sync({
+    dir,
+    grouping: true,
+    filterExt: [".js", ".jsx", ".ts", ".tsx"],
+    filterDir: x => x === "reducers" && "dir",
+    filter: x => {
+      if (entries.find(e => x.toLowerCase().startsWith(e))) {
+        return "server";
+      } else if (x.startsWith("reducers")) {
+        return "reducers";
+      }
+    },
+    maxLevel: 0
+  });
+
+  if (!manifest.serverEntry && scanned.server) {
+    manifest.serverEntry = scanned.server[0];
+  }
+
+  const reducers = (scanned.dir && scanned.dir[0]) || (scanned.reducers && scanned.reducers[0]);
+
+  if (!manifest.reducers && reducers) {
+    manifest.reducers = reducers;
+  }
+}
+
 function scanSubApp(name, verbatimName, dir, file) {
   const subAppDir = Path.dirname(file);
   const subAppFullPath = Path.resolve(dir, subAppDir);
-
-  // does subapp dir contain a file matching server.*, server-<name>.* pattern
-  const entries = ["server.", `server-${name}.`, `server-${verbatimName}.`].map(x =>
-    x.toLowerCase()
-  );
-
-  const serverEntry = scanDir.sync({
-    dir: subAppFullPath,
-    filterExt: [".js", ".jsx", ".ts", ".tsx"],
-    filter: x => entries.find(e => x.toLowerCase().startsWith(e)),
-    maxLevel: 0
-  })[0];
 
   const manifest = {
     // fullDir: subAppFullPath,
     subAppDir,
     type: "app",
     name,
-    entry: removeExt(Path.basename(file)),
-    serverEntry: serverEntry ? removeExt(serverEntry) : undefined
+    verbatimName,
+    entry: removeExt(Path.basename(file))
   };
+
+  scanSubAppAdditions(subAppFullPath, manifest);
 
   return manifest;
 }
 
 function determineName(file) {
   const dirName = Path.basename(Path.dirname(file));
+  //
   // convert dir name to mix case to use as subapp name
   // skip parts before a . to allow naming subapp dirs like 01.app1
+  //
+  // verbatimName is subapp's dir as named
+  //
   const verbatimName = dirName.substr(dirName.indexOf(".") + 1);
 
+  // verbatimName converted to mix case by removing any . or -
   const name = verbatimName.replace(/^(.)|-(.)/g, (a, b, c) =>
     b ? b.toUpperCase() : c && c.toUpperCase()
   );
@@ -104,6 +137,7 @@ function scanSubAppsFromDir(srcDir, maxLevel = Infinity) {
       const fullDir = Path.join(fullSrcDir, subAppDir);
       const manifest = es6Require(Path.join(fullSrcDir, mani));
       const subapp = Object.assign({ subAppDir }, manifest);
+      scanSubAppAdditions(fullDir, subapp);
       subApps[manifest.name] = subApps[MAP_BY_PATH_SYM][fullDir] = subapp;
       return null;
     } catch (error) {

--- a/packages/subapp-util/lib/index.js
+++ b/packages/subapp-util/lib/index.js
@@ -51,6 +51,7 @@ function scanSubAppAdditions(dir, manifest) {
       } else if (x.startsWith("reducers")) {
         return "reducers";
       }
+      return false;
     },
     maxLevel: 0
   });

--- a/samples/poc-subapp/fyn-lock.yaml
+++ b/samples/poc-subapp/fyn-lock.yaml
@@ -6307,7 +6307,7 @@ fsevents:
  1.2.9:
   hasI: 1
   $: sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==
-  _: 'https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz'
+  _: 'http://npme.walmart.com/fsevents/-/fsevents-1.2.9.tgz'
   dependencies:
    nan: ^2.12.1
    node-pre-gyp: ^0.12.0
@@ -7179,16 +7179,16 @@ ignore-styles:
   $: sha1-tJ7yJ0va/NikiAqWa/440aC/RnE=
   _: 'https://registry.npmjs.org/ignore-styles/-/ignore-styles-5.0.1.tgz'
 image-size:
- _latest: 0.8.1
+ _latest: 0.7.4
  _:
   ^0.4.0: 0.4.0
   '^0.5.0,~0.5.0': 0.5.5
  0.5.5:
   $: sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=
-  _: 'https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz'
+  _: 'http://npme.walmart.com/image-size/-/image-size-0.5.5.tgz'
  0.4.0:
   $: sha1-1LTh9hlS5MvBzqmmsMkV/stwdRA=
-  _: 'https://registry.npmjs.org/image-size/-/image-size-0.4.0.tgz'
+  _: 'http://npme.walmart.com/image-size/-/image-size-0.4.0.tgz'
 import-cwd:
  _:
   ^2.0.0: 2.1.0
@@ -9693,7 +9693,7 @@ mime:
   _: 'https://registry.npmjs.org/mime/-/mime-1.6.0.tgz'
  1.4.1:
   $: sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
-  _: 'https://registry.npmjs.org/mime/-/mime-1.4.1.tgz'
+  _: 'http://npme.walmart.com/mime/-/mime-1.4.1.tgz'
 mime-db:
  _:
   '1.x.x,~1.37.0': 1.37.0
@@ -10052,13 +10052,13 @@ node-forge:
   ^0.7.6: 0.7.6
  0.7.6:
   $: sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==
-  _: 'https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz'
+  _: 'http://npme.walmart.com/node-forge/-/node-forge-0.7.6.tgz'
  0.7.5:
   $: sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==
   _: 'https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz'
  0.6.49:
   $: sha1-8e6V1ddGI5OP4Z1piqWibVTS9g8=
-  _: 'https://registry.npmjs.org/node-forge/-/node-forge-0.6.49.tgz'
+  _: 'http://npme.walmart.com/node-forge/-/node-forge-0.6.49.tgz'
 node-gyp:
  _:
   ^3.8.0: 3.8.0
@@ -12064,7 +12064,7 @@ promise:
   ^7.1.1: 7.3.1
  7.3.1:
   $: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
-  _: 'https://registry.npmjs.org/promise/-/promise-7.3.1.tgz'
+  _: 'http://npme.walmart.com/promise/-/promise-7.3.1.tgz'
   dependencies:
    asap: ~2.0.3
 promise-each:
@@ -13707,7 +13707,7 @@ source-map:
   ~0.2.0: 0.2.0
  0.7.3:
   $: sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
-  _: 'https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz'
+  _: 'http://npme.walmart.com/source-map/-/source-map-0.7.3.tgz'
  0.6.1:
   $: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
   _: 'https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz'
@@ -13716,12 +13716,12 @@ source-map:
   _: 'https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz'
  0.4.4:
   $: sha1-66T12pwNyZneaAMti092FzZSA2s=
-  _: 'https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz'
+  _: 'http://npme.walmart.com/source-map/-/source-map-0.4.4.tgz'
   dependencies:
    amdefine: '>=0.0.4'
  0.2.0:
   $: sha1-2rc/vPwrqBm03gO9b26qSBZLP50=
-  _: 'https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz'
+  _: 'http://npme.walmart.com/source-map/-/source-map-0.2.0.tgz'
   dependencies:
    amdefine: '>=0.0.4'
 source-map-resolve:
@@ -14791,7 +14791,7 @@ uglify-js:
   ^3.1.4: 3.4.9
  3.4.9:
   $: sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==
-  _: 'https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz'
+  _: 'http://npme.walmart.com/uglify-js/-/uglify-js-3.4.9.tgz'
   dependencies:
    commander: ~2.17.1
    source-map: ~0.6.1
@@ -15058,7 +15058,7 @@ ursa-optional:
  0.9.10:
   hasI: 1
   $: sha512-RvEbhnxlggX4MXon7KQulTFiJQtLJZpSb9ZSa7ZTkOW0AzqiVTaLjI4vxaSzJBDH9dwZ3ltZadFiBaZslp6haA==
-  _: 'https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.9.10.tgz'
+  _: 'http://npme.walmart.com/ursa-optional/-/ursa-optional-0.9.10.tgz'
   dependencies:
    bindings: ^1.3.0
    nan: ^2.11.1

--- a/samples/poc-subapp/src/02.main-body/main-body.jsx
+++ b/samples/poc-subapp/src/02.main-body/main-body.jsx
@@ -6,9 +6,8 @@ import { Router, Route, Switch } from "react-router-dom";
 import { Products } from "../components/products";
 import { Navigation } from "../components/navigation";
 import { Deals } from "../components/deals";
-import { createStore } from "redux";
-import reducers from "./reducers";
 import { reduxLoadSubApp } from "subapp-redux";
+import reduxReducers from "./reducers";
 
 const Home = () => {
   return (
@@ -71,17 +70,5 @@ export default reduxLoadSubApp({
 
   prepare: async () => {},
 
-  reduxReducers: "./reducers",
-
-  reduxCreateStore: initialState => {
-    const store = createStore(reducers, initialState);
-
-    if (module.hot) {
-      module.hot.accept("./reducers", () => {
-        store.replaceReducer(require("./reducers").default);
-      });
-    }
-
-    return store;
-  }
+  reduxReducers
 });

--- a/samples/poc-subapp/xclap.js
+++ b/samples/poc-subapp/xclap.js
@@ -2,7 +2,7 @@
  * Tell Electrode app archetype that you want to use ES6 syntax in your server code
  */
 
-process.env.SERVER_ES6 = true;
+// process.env.SERVER_ES6 = true;
 
 process.env.WEBPACK_DEV_MIDDLEWARE = true;
 


### PR DESCRIPTION
Redux store reducers hot module reload requires user's `createStore` method to detect code change and accept hot module update, but also need to call `store.replaceReducers`.
This is a fairly tricky thing to do automatically, so the approach is to assume user's reducers is named as `reducers[.js|.jsx]`, and generate a JS to import it and provide a `createStore` method for the subapp to hot accept module and replace reducers.

But if user's subapp provide its own `reduxCreateStore` method, then nothing is done.  User needs to handle HMR and `store.replaceReducers`
