### PR TITLE
[minor][dep] update react router dependencies to support 5.1+ releases

### DIFF
--- a/packages/electrode-redux-router-engine/package.json
+++ b/packages/electrode-redux-router-engine/package.json
@@ -48,9 +48,9 @@
     "@loadable/server": "^5.9.0",
     "optional-require": "^1.0.0",
     "react-redux": "^4.4.5 || ^5.x.x",
-    "react-router": "^4.3.1",
-    "react-router-config": "^1.0.0-beta.4",
-    "react-router-dom": "^4.3.1",
+    "react-router": "^5.1.2",
+    "react-router-config": "^5.1.1",
+    "react-router-dom": "^5.1.2",
     "redux": "^4.0.0 || ^3.6.0"
   },
   "peerDependencies": {

--- a/samples/universal-react-node/fyn-lock.yaml
+++ b/samples/universal-react-node/fyn-lock.yaml
@@ -1132,7 +1132,7 @@
 '@babel/runtime':
  _latest: 7.4.3
  _:
-  '^7.0.0,^7.1.2,^7.1.5': 7.4.3
+  '^7.0.0,^7.1.2,^7.1.5,^7.4.0': 7.4.3
   ^7.4.4: 7.4.5
  7.4.5:
   $: sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
@@ -5143,10 +5143,10 @@ ejs:
   $: sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==
   _: 'https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz'
 electrode-archetype-opt-critical-css:
- _latest: 1.0.1-fynlocal_h
+ _latest: 1.0.2-fynlocal_h
  _:
-  ../electrode-archetype-opt-critical-css: 1.0.1-fynlocal_h
- 1.0.1-fynlocal_h:
+  ../electrode-archetype-opt-critical-css: 1.0.2-fynlocal_h
+ 1.0.2-fynlocal_h:
   hasPI: 1
   $: local
   _: ../../packages/electrode-archetype-opt-critical-css
@@ -5154,10 +5154,10 @@ electrode-archetype-opt-critical-css:
    clean-css: ^4.2.1
    penthouse: ^2.2.0
 electrode-archetype-opt-eslint:
- _latest: 1.0.1-fynlocal_h
+ _latest: 1.0.2-fynlocal_h
  _:
-  ../electrode-archetype-opt-eslint: 1.0.1-fynlocal_h
- 1.0.1-fynlocal_h:
+  ../electrode-archetype-opt-eslint: 1.0.2-fynlocal_h
+ 1.0.2-fynlocal_h:
   hasPI: 1
   $: local
   _: ../../packages/electrode-archetype-opt-eslint
@@ -5169,10 +5169,10 @@ electrode-archetype-opt-eslint:
    eslint-plugin-flowtype: ^2.49.3
    eslint-plugin-react: ^7.4.0
 electrode-archetype-opt-flow:
- _latest: 1.0.0-fynlocal_h
+ _latest: 1.0.1-fynlocal_h
  _:
-  ../electrode-archetype-opt-flow: 1.0.0-fynlocal_h
- 1.0.0-fynlocal_h:
+  ../electrode-archetype-opt-flow: 1.0.1-fynlocal_h
+ 1.0.1-fynlocal_h:
   hasPI: 1
   $: local
   _: ../../packages/electrode-archetype-opt-flow
@@ -5181,18 +5181,18 @@ electrode-archetype-opt-flow:
    flow-bin: ^0.74.0
    flow-typed: ^2.4.0
 electrode-archetype-opt-inferno:
- _latest: 0.2.9-fynlocal_h
+ _latest: 0.2.10-fynlocal_h
  _:
-  ../electrode-archetype-opt-inferno: 0.2.9-fynlocal_h
- 0.2.9-fynlocal_h:
+  ../electrode-archetype-opt-inferno: 0.2.10-fynlocal_h
+ 0.2.10-fynlocal_h:
   optFailed: 1
   $: local
   _: ../../packages/electrode-archetype-opt-inferno
 electrode-archetype-opt-jest:
- _latest: 1.0.1-fynlocal_h
+ _latest: 1.0.2-fynlocal_h
  _:
-  ../electrode-archetype-opt-jest: 1.0.1-fynlocal_h
- 1.0.1-fynlocal_h:
+  ../electrode-archetype-opt-jest: 1.0.2-fynlocal_h
+ 1.0.2-fynlocal_h:
   hasPI: 1
   $: local
   _: ../../packages/electrode-archetype-opt-jest
@@ -5202,10 +5202,10 @@ electrode-archetype-opt-jest:
    eslint-plugin-jest: ^21.27.2
    jest: ^23.6.0
 electrode-archetype-opt-karma:
- _latest: 2.0.4-fynlocal_h
+ _latest: 2.0.5-fynlocal_h
  _:
-  ../electrode-archetype-opt-karma: 2.0.4-fynlocal_h
- 2.0.4-fynlocal_h:
+  ../electrode-archetype-opt-karma: 2.0.5-fynlocal_h
+ 2.0.5-fynlocal_h:
   hasPI: 1
   $: local
   _: ../../packages/electrode-archetype-opt-karma
@@ -5213,7 +5213,7 @@ electrode-archetype-opt-karma:
    babel-plugin-istanbul: ^5.1.0
    karma: ^3.1.1
    karma-chrome-launcher: ^2.2.0
-   karma-coverage: ^1.1.2
+   karma-coverage: ^2.0.0
    karma-firefox-launcher: ^1.1.0
    karma-ie-launcher: ^1.0.0
    karma-intl-shim: ^1.0.3
@@ -5225,10 +5225,10 @@ electrode-archetype-opt-karma:
    karma-spec-reporter: 0.0.32
    karma-webpack: 4.0.0-rc.3
 electrode-archetype-opt-less:
- _latest: 1.0.0-fynlocal_h
+ _latest: 1.0.1-fynlocal_h
  _:
-  ../electrode-archetype-opt-less: 1.0.0-fynlocal_h
- 1.0.0-fynlocal_h:
+  ../electrode-archetype-opt-less: 1.0.1-fynlocal_h
+ 1.0.1-fynlocal_h:
   hasPI: 1
   $: local
   _: ../../packages/electrode-archetype-opt-less
@@ -5236,10 +5236,10 @@ electrode-archetype-opt-less:
    less: ^3.9.0
    less-loader: ^4.1.0
 electrode-archetype-opt-mocha:
- _latest: 1.0.1-fynlocal_h
+ _latest: 1.0.2-fynlocal_h
  _:
-  ../electrode-archetype-opt-mocha: 1.0.1-fynlocal_h
- 1.0.1-fynlocal_h:
+  ../electrode-archetype-opt-mocha: 1.0.2-fynlocal_h
+ 1.0.2-fynlocal_h:
   hasPI: 1
   $: local
   _: ../../packages/electrode-archetype-opt-mocha
@@ -5247,10 +5247,10 @@ electrode-archetype-opt-mocha:
    '@types/mocha': 5.2.7
    mocha: ^4.0.0
 electrode-archetype-opt-phantomjs:
- _latest: 1.0.0-fynlocal_h
+ _latest: 1.0.1-fynlocal_h
  _:
-  ../electrode-archetype-opt-phantomjs: 1.0.0-fynlocal_h
- 1.0.0-fynlocal_h:
+  ../electrode-archetype-opt-phantomjs: 1.0.1-fynlocal_h
+ 1.0.1-fynlocal_h:
   hasPI: 1
   $: local
   _: ../../packages/electrode-archetype-opt-phantomjs
@@ -5259,10 +5259,10 @@ electrode-archetype-opt-phantomjs:
    karma-phantomjs-shim: ^1.5.0
    phantomjs-prebuilt: ^2.1.16
 electrode-archetype-opt-postcss:
- _latest: 1.0.2-fynlocal_h
+ _latest: 1.0.3-fynlocal_h
  _:
-  ../electrode-archetype-opt-postcss: 1.0.2-fynlocal_h
- 1.0.2-fynlocal_h:
+  ../electrode-archetype-opt-postcss: 1.0.3-fynlocal_h
+ 1.0.3-fynlocal_h:
   hasPI: 1
   $: local
   _: ../../packages/electrode-archetype-opt-postcss
@@ -5276,10 +5276,10 @@ electrode-archetype-opt-postcss:
    postcss-scss: ^1.0.6
    sugarss: ^1.0.1
 electrode-archetype-opt-pwa:
- _latest: 1.0.4-fynlocal_h
+ _latest: 1.0.5-fynlocal_h
  _:
-  ../electrode-archetype-opt-pwa: 1.0.4-fynlocal_h
- 1.0.4-fynlocal_h:
+  ../electrode-archetype-opt-pwa: 1.0.5-fynlocal_h
+ 1.0.5-fynlocal_h:
   hasPI: 1
   $: local
   _: ../../packages/electrode-archetype-opt-pwa
@@ -5293,10 +5293,10 @@ electrode-archetype-opt-pwa:
    web-app-manifest-loader: ^0.1.1
    webpack-disk-plugin: 0.0.2
 electrode-archetype-opt-react:
- _latest: 2.0.2-fynlocal_h
+ _latest: 2.0.3-fynlocal_h
  _:
-  ../electrode-archetype-opt-react: 2.0.2-fynlocal_h
- 2.0.2-fynlocal_h:
+  ../electrode-archetype-opt-react: 2.0.3-fynlocal_h
+ 2.0.3-fynlocal_h:
   hasPI: 1
   $: local
   _: ../../packages/electrode-archetype-opt-react
@@ -5304,10 +5304,10 @@ electrode-archetype-opt-react:
    react: ^16.0.0
    react-dom: ^16.0.0
 electrode-archetype-opt-sass:
- _latest: 1.0.7-fynlocal_h
+ _latest: 1.0.8-fynlocal_h
  _:
-  ../electrode-archetype-opt-sass: 1.0.7-fynlocal_h
- 1.0.7-fynlocal_h:
+  ../electrode-archetype-opt-sass: 1.0.8-fynlocal_h
+ 1.0.8-fynlocal_h:
   hasPI: 1
   $: local
   _: ../../packages/electrode-archetype-opt-sass
@@ -5315,10 +5315,10 @@ electrode-archetype-opt-sass:
    node-sass: ^4.9.3
    sass-loader: ^6.0.6
 electrode-archetype-opt-sinon:
- _latest: 1.0.1-fynlocal_h
+ _latest: 1.0.2-fynlocal_h
  _:
-  ../electrode-archetype-opt-sinon: 1.0.1-fynlocal_h
- 1.0.1-fynlocal_h:
+  ../electrode-archetype-opt-sinon: 1.0.2-fynlocal_h
+ 1.0.2-fynlocal_h:
   hasPI: 1
   $: local
   _: ../../packages/electrode-archetype-opt-sinon
@@ -5326,10 +5326,10 @@ electrode-archetype-opt-sinon:
    sinon: ^4.0.0
    sinon-chai: ^2.14.0
 electrode-archetype-opt-stylus:
- _latest: 1.0.0-fynlocal_h
+ _latest: 1.0.1-fynlocal_h
  _:
-  ../electrode-archetype-opt-stylus: 1.0.0-fynlocal_h
- 1.0.0-fynlocal_h:
+  ../electrode-archetype-opt-stylus: 1.0.1-fynlocal_h
+ 1.0.1-fynlocal_h:
   hasPI: 1
   $: local
   _: ../../packages/electrode-archetype-opt-stylus
@@ -5337,10 +5337,10 @@ electrode-archetype-opt-stylus:
    stylus: ^0.54.7
    stylus-relative-loader: ^3.4.0
 electrode-archetype-opt-typescript:
- _latest: 1.0.1-fynlocal_h
+ _latest: 1.0.2-fynlocal_h
  _:
-  ../electrode-archetype-opt-typescript: 1.0.1-fynlocal_h
- 1.0.1-fynlocal_h:
+  ../electrode-archetype-opt-typescript: 1.0.2-fynlocal_h
+ 1.0.2-fynlocal_h:
   hasPI: 1
   $: local
   _: ../../packages/electrode-archetype-opt-typescript
@@ -5348,10 +5348,10 @@ electrode-archetype-opt-typescript:
    typescript: ^3.2.1
    '@babel/preset-typescript': ^7.1.0
 electrode-archetype-react-app:
- _latest: 6.5.12-fynlocal_h
+ _latest: 6.5.13-fynlocal_h
  _:
-  ../../packages/electrode-archetype-react-app: 6.5.12-fynlocal_h
- 6.5.12-fynlocal_h:
+  ../../packages/electrode-archetype-react-app: 6.5.13-fynlocal_h
+ 6.5.13-fynlocal_h:
   top: 1
   $: local
   _: ../../packages/electrode-archetype-react-app
@@ -5363,13 +5363,13 @@ electrode-archetype-react-app:
    optional-require: ^1.0.0
    subapp-util: ^1.0.2
   optionalDependencies:
-   electrode-archetype-opt-inferno: ^0.2.9
-   electrode-archetype-opt-react: ^2.0.2
+   electrode-archetype-opt-inferno: ^0.2.10
+   electrode-archetype-opt-react: ^2.0.3
 electrode-archetype-react-app-dev:
- _latest: 6.5.12-fynlocal_h
+ _latest: 6.5.13-fynlocal_h
  _:
-  ../../packages/electrode-archetype-react-app-dev: 6.5.12-fynlocal_h
- 6.5.12-fynlocal_h:
+  ../../packages/electrode-archetype-react-app-dev: 6.5.13-fynlocal_h
+ 6.5.13-fynlocal_h:
   top: 1
   $: local
   _: ../../packages/electrode-archetype-react-app-dev
@@ -5424,7 +5424,6 @@ electrode-archetype-react-app-dev:
    fs-extra: ^0.26.5
    identity-obj-proxy: ^3.0.0
    isomorphic-loader: ^2.1.1
-   istanbul: ^0.4.5
    nyc: ^14.1.1
    jsonfile: ^2.2.2
    loader-utils: ^1.1.0
@@ -5463,22 +5462,22 @@ electrode-archetype-react-app-dev:
    xenv-config: ^1.3.0
    xsh: ^0.4.4
   optionalDependencies:
-   electrode-archetype-opt-critical-css: ^1.0.1
-   electrode-archetype-opt-eslint: ^1.0.1
-   electrode-archetype-opt-flow: ^1.0.0
-   electrode-archetype-opt-inferno: ^0.2.9
-   electrode-archetype-opt-jest: ^1.0.1
-   electrode-archetype-opt-karma: ^2.0.4
-   electrode-archetype-opt-less: ^1.0.0
-   electrode-archetype-opt-mocha: ^1.0.1
-   electrode-archetype-opt-phantomjs: ^1.0.0
-   electrode-archetype-opt-postcss: ^1.0.2
-   electrode-archetype-opt-pwa: ^1.0.4
-   electrode-archetype-opt-react: ^2.0.2
-   electrode-archetype-opt-sass: ^1.0.7
-   electrode-archetype-opt-stylus: ^1.0.0
-   electrode-archetype-opt-sinon: ^1.0.1
-   electrode-archetype-opt-typescript: ^1.0.1
+   electrode-archetype-opt-critical-css: ^1.0.2
+   electrode-archetype-opt-eslint: ^1.0.2
+   electrode-archetype-opt-flow: ^1.0.1
+   electrode-archetype-opt-inferno: ^0.2.10
+   electrode-archetype-opt-jest: ^1.0.2
+   electrode-archetype-opt-karma: ^2.0.5
+   electrode-archetype-opt-less: ^1.0.1
+   electrode-archetype-opt-mocha: ^1.0.2
+   electrode-archetype-opt-phantomjs: ^1.0.1
+   electrode-archetype-opt-postcss: ^1.0.3
+   electrode-archetype-opt-pwa: ^1.0.5
+   electrode-archetype-opt-react: ^2.0.3
+   electrode-archetype-opt-sass: ^1.0.8
+   electrode-archetype-opt-stylus: ^1.0.1
+   electrode-archetype-opt-sinon: ^1.0.2
+   electrode-archetype-opt-typescript: ^1.0.2
   peerDependencies:
    electrode-archetype-react-app: ^6.0.0
 electrode-bundle-analyzer:
@@ -5577,9 +5576,9 @@ electrode-redux-router-engine:
    '@loadable/server': ^5.9.0
    optional-require: ^1.0.0
    react-redux: '^4.4.5 || ^5.x.x'
-   react-router: ^4.3.1
-   react-router-config: ^1.0.0-beta.4
-   react-router-dom: ^4.3.1
+   react-router: ^5.1.2
+   react-router-config: ^5.1.1
+   react-router-dom: ^5.1.2
    redux: '^4.0.0 || ^3.6.0'
   peerDependencies:
    react: '^16.0.0 || ^15.3.1 || ^0.14.8'
@@ -7423,6 +7422,13 @@ growly:
  1.3.0:
   $: sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
   _: 'https://registry.npmjs.org/growly/-/growly-1.3.0.tgz'
+gud:
+ _latest: 1.0.0
+ _:
+  ^1.0.0: 1.0.0
+ 1.0.0:
+  $: sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
+  _: 'https://registry.npmjs.org/gud/-/gud-1.0.0.tgz'
 handle-thing:
  _latest: 2.0.0
  _:
@@ -7679,9 +7685,9 @@ hex-color-regex:
   $: sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
   _: 'https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz'
 history:
- _latest: 4.9.0
+ _latest: 4.10.1
  _:
-  ^4.7.2: 4.9.0
+  ^4.9.0: 4.9.0
  4.9.0:
   $: sha512-H2DkjCjXf0Op9OAr6nJ56fcRkTSNrUiv41vNJ6IswJjif6wlpZK0BTfFbi7qK9dXLSYZxkq5lBsj3vUjlYBYZA==
   _: 'https://registry.npmjs.org/history/-/history-4.9.0.tgz'
@@ -7719,7 +7725,7 @@ hoek:
 hoist-non-react-statics:
  _latest: 3.3.0
  _:
-  '^2.5.0,^2.5.5': 2.5.5
+  ^2.5.5: 2.5.5
   '^3.1.0,^3.3.0': 3.3.0
  3.3.0:
   $: sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
@@ -8873,7 +8879,7 @@ isstream:
 istanbul:
  _latest: 0.4.5
  _:
-  '^0.4.0,^0.4.5': 0.4.5
+  ^0.4.0: 0.4.5
  0.4.5:
   $: sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=
   _: 'https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz'
@@ -9793,16 +9799,21 @@ karma-chrome-launcher:
    fs-access: ^1.0.0
    which: ^1.2.1
 karma-coverage:
- _latest: 1.1.2
+ _latest: 2.0.1
  _:
-  ^1.1.2: 1.1.2
- 1.1.2:
-  $: sha512-eQawj4Cl3z/CjxslYy9ariU4uDh7cCNFZHNWXWRpl0pNeblY/4wHR7M7boTYXWrn9bY0z2pZmr11eKje/S/hIw==
-  _: 'https://registry.npmjs.org/karma-coverage/-/karma-coverage-1.1.2.tgz'
+  ^2.0.0: 2.0.1
+ 2.0.1:
+  $: sha512-SnFkHsnLsaXfxkey51rRN9JDLAEKYW2Lb0qOEvcruukk0NkSNDkjobNDZPt9Ni3kIhLZkLtpGOz661hN7OaZvQ==
+  _: 'https://registry.npmjs.org/karma-coverage/-/karma-coverage-2.0.1.tgz'
   dependencies:
    dateformat: ^1.0.6
    istanbul: ^0.4.0
-   lodash: ^4.17.0
+   istanbul-lib-coverage: ^2.0.5
+   istanbul-lib-instrument: ^3.3.0
+   istanbul-lib-report: ^2.0.8
+   istanbul-lib-source-maps: ^3.0.6
+   istanbul-reports: ^2.2.4
+   lodash: ^4.17.11
    minimatch: ^3.0.0
    source-map: ^0.5.1
 karma-firefox-launcher:
@@ -10270,7 +10281,7 @@ lodash:
  _latest: 4.17.11
  _:
   '^3.2.0,^3.5.0': 3.10.1
-  '^4.0.0,^4.0.1,^4.11.1,^4.13.1,^4.15.0,^4.17.0,^4.17.10,^4.17.11,^4.17.4,^4.17.5,^4.2.0,^4.3.0,^4.5.0,^4.5.1,^4.6.1,~4.17.10': 4.17.11
+  '^4.0.0,^4.0.1,^4.11.1,^4.13.1,^4.15.0,^4.17.10,^4.17.11,^4.17.4,^4.17.5,^4.2.0,^4.3.0,^4.5.0,^4.5.1,^4.6.1,~4.17.10': 4.17.11
   ^4.17.13: 4.17.15
   ~2.4.1: 2.4.2
  4.17.15:
@@ -10980,6 +10991,20 @@ min-document:
   _: 'https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz'
   dependencies:
    dom-walk: ^0.1.0
+mini-create-react-context:
+ _latest: 0.3.2
+ _:
+  ^0.3.0: 0.3.2
+ 0.3.2:
+  $: sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==
+  _: 'https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz'
+  dependencies:
+   gud: ^1.0.0
+   tiny-warning: ^1.0.2
+   '@babel/runtime': ^7.4.0
+  peerDependencies:
+   prop-types: ^15.0.0
+   react: '^0.14.0 || ^15.0.0 || ^16.0.0'
 mini-css-extract-plugin:
  _latest: 0.7.0
  _:
@@ -14079,48 +14104,54 @@ react-redux:
    react: '^0.14.0 || ^15.0.0-0 || ^16.0.0-0'
    redux: '^2.0.0 || ^3.0.0 || ^4.0.0-0'
 react-router:
- _latest: 5.0.0
+ _latest: 5.1.2
  _:
-  ^4.3.1: 4.3.1
- 4.3.1:
-  $: sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==
-  _: 'https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz'
+  '5.1.2,^5.1.2': 5.1.2
+ 5.1.2:
+  $: sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==
+  _: 'https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz'
   dependencies:
-   history: ^4.7.2
-   hoist-non-react-statics: ^2.5.0
-   invariant: ^2.2.4
+   '@babel/runtime': ^7.1.2
+   history: ^4.9.0
+   hoist-non-react-statics: ^3.1.0
    loose-envify: ^1.3.1
+   mini-create-react-context: ^0.3.0
    path-to-regexp: ^1.7.0
-   prop-types: ^15.6.1
-   warning: ^4.0.1
+   prop-types: ^15.6.2
+   react-is: ^16.6.0
+   tiny-invariant: ^1.0.2
+   tiny-warning: ^1.0.0
   peerDependencies:
    react: '>=15'
 react-router-config:
- _latest: 5.0.0
+ _latest: 5.1.1
  _:
-  ^1.0.0-beta.4: 1.0.0-beta.4
- 1.0.0-beta.4:
+  ^5.1.1: 5.1.1
+ 5.1.1:
   top: 1
-  $: sha512-4jWfQK+PNAYeMU7dZ5h/dNDTReVjm41p761+XP+II360Jz5TfzHiuP27tAasIQ+JcGWwX2l2dCWG8jEmcS5SBA==
-  _: 'https://registry.npmjs.org/react-router-config/-/react-router-config-1.0.0-beta.4.tgz'
+  $: sha512-DuanZjaD8mQp1ppHjgnnUnyOlqYXZVjnov/JzFhjLEwd3Z4dYjMSnqrEzzGThH47vpCOqPPwJM2FtthLeJ8Pbg==
+  _: 'https://registry.npmjs.org/react-router-config/-/react-router-config-5.1.1.tgz'
+  dependencies:
+   '@babel/runtime': ^7.1.2
   peerDependencies:
    react: '>=15'
-   react-router: ^4.2.0
+   react-router: '>=5'
 react-router-dom:
- _latest: 5.0.0
+ _latest: 5.1.2
  _:
-  ^4.3.1: 4.3.1
- 4.3.1:
+  ^5.1.2: 5.1.2
+ 5.1.2:
   top: 1
-  $: sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==
-  _: 'https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz'
+  $: sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==
+  _: 'https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz'
   dependencies:
-   history: ^4.7.2
-   invariant: ^2.2.4
+   '@babel/runtime': ^7.1.2
+   history: ^4.9.0
    loose-envify: ^1.3.1
-   prop-types: ^15.6.1
-   react-router: ^4.3.1
-   warning: ^4.0.1
+   prop-types: ^15.6.2
+   react-router: 5.1.2
+   tiny-invariant: ^1.0.2
+   tiny-warning: ^1.0.0
   peerDependencies:
    react: '>=15'
 react-test-renderer:
@@ -16407,7 +16438,7 @@ tiny-invariant:
 tiny-warning:
  _latest: 1.0.2
  _:
-  ^1.0.0: 1.0.2
+  '^1.0.0,^1.0.2': 1.0.2
  1.0.2:
   $: sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q==
   _: 'https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.2.tgz'
@@ -17149,15 +17180,6 @@ walker:
   _: 'https://registry.npmjs.org/walker/-/walker-1.0.7.tgz'
   dependencies:
    makeerror: 1.0.x
-warning:
- _latest: 4.0.3
- _:
-  ^4.0.1: 4.0.3
- 4.0.3:
-  $: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
-  _: 'https://registry.npmjs.org/warning/-/warning-4.0.3.tgz'
-  dependencies:
-   loose-envify: ^1.0.0
 watch:
  _latest: 1.0.2
  _:

--- a/samples/universal-react-node/package.json
+++ b/samples/universal-react-node/package.json
@@ -46,8 +46,8 @@
     "mongojs": "^2.4.0",
     "normalize.css": "^8.0.1",
     "react-notify-toast": "^0.4.1",
-    "react-router-config": "^1.0.0-beta.4",
-    "react-router-dom": "^4.3.1",
+    "react-router-config": "^5.1.1",
+    "react-router-dom": "^5.1.2",
     "react-vendor-dll": "../react-vendor-dll",
     "uuid": "^3.0.1"
   },


### PR DESCRIPTION
Attempting to address [this issue](https://github.com/electrode-io/electrode/issues/1178) since our own app within WMLabs is also being blocked from upgrading React Router to anything greater than 4.3 (latest is 5.1+ which supports hooks, which we would really love to use).

5 is a drop-in replacement especially since it's actually 4.4, but the team messed up the dependencies and had to do a major version bump [explanation here](https://reacttraining.com/blog/react-router-v5/#why-the-major-version-bump)

Following the contributing instructions, the sample app does run successfully after the changes. Please let me know if I should adjust anything! Perhaps we also need to widen the dependencies? I'm very new to package management at this scale 😅ex:

```
"react-router": "^5.1.2 || ^4.3.1",
"react-router-config": "^5.1.1 || ^1.0.0-beta.4",
"react-router-dom": "^5.1.2 || ^4.3.1",
```