### PR TITLE
use process.send to transfer isomorphic config from wds to app

### DIFF
--- a/packages/electrode-archetype-react-app-dev/lib/dev-admin/admin-server.js
+++ b/packages/electrode-archetype-react-app-dev/lib/dev-admin/admin-server.js
@@ -1,6 +1,6 @@
 "use strict";
 
-/* eslint-disable no-console, no-process-exit, complexity */
+/* eslint-disable complexity */
 /* eslint-disable no-magic-numbers, max-len, max-statements, prefer-template */
 
 const Path = require("path");
@@ -34,7 +34,6 @@ class AdminServer {
     this._wds = ck`<gray.inverse>[wds]</> `;
     this._proxy = ck`<green.inverse>[proxy]</> `;
     this._io.setup();
-    // this.setupConsoleInterface();
     this.handleUserInput();
     await this.startWebpackDevServer();
     await this.startAppServer();

--- a/packages/electrode-archetype-react-app-dev/lib/dev-admin/admin-server.js
+++ b/packages/electrode-archetype-react-app-dev/lib/dev-admin/admin-server.js
@@ -8,8 +8,10 @@ const _ = require("lodash");
 const boxen = require("boxen");
 const ck = require("chalker");
 const chokidar = require("chokidar");
-const readline = require("readline");
+const WebpackDevRelay = require("./webpack-dev-relay");
 const { fork } = require("child_process");
+const ConsoleIO = require("./console-io");
+const makeDefer = require("@xarc/defer");
 
 const APP_SERVER_NAME = "your app server";
 const DEV_SERVER_NAME = "Electrode webpack dev server";
@@ -18,35 +20,33 @@ const PROXY_SERVER_NAME = "Electrode Dev Proxy";
 const DEV_PROXY_ENABLED = Boolean(process.env.APP_SERVER_PORT);
 
 class AdminServer {
-  constructor(args) {
+  constructor(args, options) {
     this._opts = args.opts;
     this._passThru = args._;
     this._messageId = 1;
     this._saveWebpackReportData = undefined;
+    this._webpackDevRelay = new WebpackDevRelay();
     this._servers = {};
+    this._io = (options && options.inputOutput) || new ConsoleIO();
   }
 
   async start() {
     this._wds = ck`<gray.inverse>[wds]</> `;
     this._proxy = ck`<green.inverse>[proxy]</> `;
-    this.setupConsoleInterface();
+    this._io.setup();
+    // this.setupConsoleInterface();
     this.handleUserInput();
-    await this.startDevServer();
+    await this.startWebpackDevServer();
     await this.startAppServer();
     if (DEV_PROXY_ENABLED) {
       // to debug dev proxy
       // await this.startProxyServer("--inspect-brk");
       await this.startProxyServer();
     }
-    setTimeout(() => this.showConsoleMenu(), 100);
+    setTimeout(() => this.showMenu(), 100);
   }
 
-  setupConsoleInterface() {
-    readline.emitKeypressEvents(process.stdin);
-    process.stdin.setRawMode(true);
-  }
-
-  showConsoleMenu() {
+  showMenu() {
     const proxyItem = DEV_PROXY_ENABLED ? "<magenta>P</> - Restart Dev Proxy " : "";
     const menu = ck`              <green.inverse>   Electrode Dev Admin Console   </>
 
@@ -55,7 +55,7 @@ class AdminServer {
  <white.inverse>For Electrode webpack dev server</>  ${this._wds}
    <magenta>W</> - Restart <magenta>E</> - <cyan>inspect-brk</> mode <magenta>R</> - <cyan>inspect</> mode <magenta>X</> - Kill&nbsp;
  ${proxyItem}<magenta>M</> - Show this menu <magenta>Q</> - Shutdown`;
-    console.log(boxen(menu, { margin: { left: 5 } }));
+    this._io.show(boxen(menu, { margin: { left: 5 } }));
   }
 
   getServer(name) {
@@ -67,9 +67,10 @@ class AdminServer {
     const info = this.getServer(name);
     if (info._child) {
       info._child.once("exit", (code, signal) => {
-        console.log(ck`<orange>${name} exited code ${code} - signal ${signal}</orange>`);
+        this._io.show(ck`<orange>${name} exited code ${code} - signal ${signal}</orange>`);
         info._child = undefined;
         info._starting = false;
+        this._webpackDevRelay.setAppServer(null);
       });
     }
   }
@@ -92,60 +93,48 @@ class AdminServer {
     }
   }
 
-  async _getUserInput() {
-    return new Promise(resolve => {
-      process.stdin.once("keypress", (str, key) => {
-        resolve({ str: str && str.toLowerCase(), key });
-      });
-    });
+  async _quit() {
+    this._io.show(ck`<magenta>admin server exit, shutting down servers</magenta>`);
+    if (this._appWatcher) {
+      this._appWatcher.close();
+    }
+    await Promise.all([
+      this.kill(DEV_SERVER_NAME, "SIGINT"),
+      this.kill(APP_SERVER_NAME, "SIGINT"),
+      this.kill(PROXY_SERVER_NAME, "SIGINT")
+    ]);
+    this._io.exit();
+  }
+
+  async processCommand(str) {
+    const handlers = {
+      q: () => this._quit(),
+      m: () => this.showMenu(),
+      // app server
+      a: () => this.startAppServer(),
+      d: () => this.startAppServer("--inspect-brk"),
+      i: () => this.startAppServer("--inspect"),
+      k: () => this.kill(APP_SERVER_NAME, "SIGINT"),
+      // webpack dev server
+      w: () => this.startWebpackDevServer(),
+      e: () => this.startWebpackDevServer("--inspect-brk"),
+      r: () => this.startWebpackDevServer("--inspect"),
+      x: () => this.kill(DEV_SERVER_NAME, "SIGINT"),
+      // dev proxy server
+      p: () => DEV_PROXY_ENABLED && this.signal(PROXY_SERVER_NAME, "SIGHUP")
+    };
+    return handlers[str] && (await handlers[str]());
   }
 
   async handleUserInput() {
-    const { str, key } = await this._getUserInput();
-    if (str === "q") {
-      console.log(ck`<magenta>admin server exit, shutting down servers</magenta>`);
-      if (this._appWatcher) {
-        this._appWatcher.close();
-      }
-      await this.kill(DEV_SERVER_NAME, "SIGINT");
-      await this.kill(APP_SERVER_NAME, "SIGINT");
-      await this.kill(PROXY_SERVER_NAME, "SIGINT");
-      process.exit();
-    } else if ((key.ctrl && key.name === "c") || str === "m") {
-      // allow user to press ctrl+c to bring up console menu
-      this.showConsoleMenu();
-    } else if (str === "w") {
-      this.startDevServer();
-    } else if (str === "e") {
-      this.startDevServer("--inspect-brk");
-    } else if (str === "r") {
-      this.startDevServer("--inspect");
-    } else if (str === "x") {
-      await this.kill(DEV_SERVER_NAME, "SIGINT");
-    } else if (str === "a") {
-      this.startAppServer();
-    } else if (str === "k") {
-      await this.kill(APP_SERVER_NAME, "SIGINT");
-    } else if (str === "d") {
-      this.startAppServer("--inspect-brk");
-    } else if (str === "i") {
-      this.startAppServer("--inspect");
-    } else if (DEV_PROXY_ENABLED && str === "p") {
-      this.signal(PROXY_SERVER_NAME, "SIGHUP");
-    }
+    const { str } = await this._io.getUserInput();
+    await this.processCommand(str);
     process.nextTick(() => this.handleUserInput());
   }
 
-  _handleWebpackReport(data) {
-    const appInfo = this.getServer(APP_SERVER_NAME);
-    if (appInfo._child) {
-      data.id = this._messageId++;
-      appInfo._child.send(data);
-    } else {
-      this._saveWebpackReportData = data;
-    }
-  }
-
+  //
+  // Start a server
+  //
   async startServer(options) {
     const { name, debug, killKey } = options;
 
@@ -154,9 +143,8 @@ class AdminServer {
     const info = this._servers[name];
     info.options = options;
     info.name = name;
-
     if (info._starting) {
-      console.log(
+      this._io.show(
         ck`<yellow.inverse> Start ${name} already in progress - press<magenta> ${killKey} </>to kill it.</>`
       );
       return;
@@ -195,7 +183,7 @@ class AdminServer {
     };
 
     const re = info._child ? "Res" : "S";
-    console.log(ck`<orange>${re}tarting ${name}${debugMsg}</orange>`);
+    this._io.show(ck`<orange>${re}tarting ${name}${debugMsg}</orange>`);
     await this.kill(name, "SIGINT");
 
     start();
@@ -207,7 +195,10 @@ class AdminServer {
     info._starting = false;
   }
 
-  async startDevServer(debug) {
+  //
+  // start webpack dev server
+  //
+  async startWebpackDevServer(debug) {
     let currentStatusMessage;
     let hasStatusMessage = false;
 
@@ -252,15 +243,21 @@ class AdminServer {
       info._child.stdout.on("data", data => log(process.stdout, data));
       info._child.stderr.on("data", data => log(process.stderr, data));
 
-      return new Promise(resolve => {
-        info._child.on("message", data => {
-          if (data.name === "webpack-report") {
-            this._handleWebpackReport(data);
-            resolve();
-          }
-        });
+      this._webpackDevRelay.setWebpackServer(info._child);
 
-        info._child.on("exit", () => {
+      return new Promise(resolve => {
+        const listenForReport = () =>
+          info._child.once("message", data => {
+            if (data.name === "webpack-report") {
+              resolve();
+            } else {
+              listenForReport();
+            }
+          });
+
+        listenForReport();
+
+        info._child.once("exit", () => {
           resolve();
         });
       });
@@ -298,6 +295,7 @@ class AdminServer {
         });
 
         await this.waitForAppServerStart(info);
+        this._webpackDevRelay.setAppServer(info._child);
       }
     });
   }
@@ -323,56 +321,75 @@ class AdminServer {
   async waitForAppServerStart(info) {
     let startTimeout;
     let started = false;
-    let deferRes;
+    const defer = makeDefer();
 
-    const promise = new Promise(resolve => (deferRes = resolve));
+    const pendingMessages = [];
 
-    const markStarted = data => {
-      if (started) return;
-      data = data || {};
+    let messageHandler; // eslint-disable-line
+
+    const processPending = () => {
+      if (pendingMessages.length > 0) {
+        messageHandler(pendingMessages.shift());
+        setTimeout(processPending);
+      }
+    };
+
+    const checkStarted = data => {
+      if (started) {
+        return true;
+      }
+
       if (data.name === "timeout") {
-        console.log(ck`<orange>WARNING: Did not receive start event from \
+        this._io.show(ck`<orange>WARNING: Did not receive start event from \
 ${info.name} - assuming it started.</>`);
       } else if (data.name !== "app-setup") {
-        info._child.once("message", markStarted);
-        return;
+        pendingMessages.push(data);
+        return false;
       } else {
-        console.log(ck`<orange>${info.name} started</>`);
+        this._io.show(ck`<orange>${info.name} started</>`);
       }
+
       started = true;
-      if (startTimeout) clearTimeout(startTimeout);
+      clearTimeout(startTimeout);
+      setTimeout(processPending);
 
-      setTimeout(() => {
-        if (this._saveWebpackReportData && info._child) {
-          info._child.send(this._saveWebpackReportData);
-        }
+      return started;
+    };
 
-        this.watchServer(info.name);
-        deferRes();
-      }, 100);
+    messageHandler = (data = {}) => {
+      if (!checkStarted(data)) {
+        return;
+      }
+
+      info._child.removeListener("message", messageHandler);
+      this.watchServer(info.name);
+      defer.resolve();
     };
 
     const handleTimeout = () => {
       startTimeout = undefined;
       if (info._child) {
-        markStarted({ name: "timeout" });
+        messageHandler({ name: "timeout" });
       }
     };
 
     info._child.once("exit", () => {
       clearTimeout(startTimeout);
-      deferRes();
+      defer.resolve();
     });
 
-    info._child.once("message", markStarted);
+    info._child.on("message", messageHandler);
 
     if (info.options.noTimeoutCheck !== true) {
       startTimeout = setTimeout(handleTimeout, 5000);
     }
 
-    return promise;
+    return defer.promise;
   }
 
+  //
+  // watches files change and restart a server
+  //
   watchServer(name) {
     let timer;
 

--- a/packages/electrode-archetype-react-app-dev/lib/dev-admin/console-io.js
+++ b/packages/electrode-archetype-react-app-dev/lib/dev-admin/console-io.js
@@ -1,0 +1,33 @@
+"use strict";
+
+const readline = require("readline");
+
+class ConsoleIO {
+  constructor() {}
+
+  setup() {
+    readline.emitKeypressEvents(process.stdin);
+    process.stdin.setRawMode(true);
+  }
+
+  async getUserInput() {
+    return new Promise(resolve => {
+      process.stdin.once("keypress", (str, key) => {
+        if (key.ctrl && key.name === "c") {
+          str = "m";
+        }
+        resolve({ str: str && str.toLowerCase(), key });
+      });
+    });
+  }
+
+  show(...args) {
+    console.log(...args);
+  }
+
+  exit() {
+    process.exit();
+  }
+}
+
+module.exports = ConsoleIO;

--- a/packages/electrode-archetype-react-app-dev/lib/dev-admin/console-io.js
+++ b/packages/electrode-archetype-react-app-dev/lib/dev-admin/console-io.js
@@ -1,5 +1,7 @@
 "use strict";
 
+/* eslint-disable no-console, no-process-exit */
+
 const readline = require("readline");
 
 class ConsoleIO {

--- a/packages/electrode-archetype-react-app-dev/lib/dev-admin/middleware.js
+++ b/packages/electrode-archetype-react-app-dev/lib/dev-admin/middleware.js
@@ -175,7 +175,7 @@ class Middleware {
     // of loading them from config.assetsFile, so no need to transfer that
     // from Mem FS to physical disk.
     const waitIsoLock = cb => {
-      if (Fs.existsSync(isoLockfile) || !Fs.existsSync(isoConfigFile)) {
+      if (!process.send && (Fs.existsSync(isoLockfile) || !Fs.existsSync(isoConfigFile))) {
         return setTimeout(() => waitIsoLock(cb), 50);
       } else {
         return cb();

--- a/packages/electrode-archetype-react-app-dev/lib/dev-admin/webpack-dev-relay.js
+++ b/packages/electrode-archetype-react-app-dev/lib/dev-admin/webpack-dev-relay.js
@@ -1,0 +1,95 @@
+"use strict";
+//
+// relay message between the webpack dev server and app server in dev mode
+//
+
+const _ = require("lodash");
+
+const WEBPACK_DEV_MESSAGES = [
+  // received config from isomorphic-loader webpack plugin
+  "isomorphic-loader-config",
+  // received webpack compile report, for refresh assets in SSR
+  "webpack-report",
+  // received webpack compile stats
+  "webpack-stats"
+];
+
+class WebpackDevRelay {
+  constructor() {
+    this._webpackData = {};
+    this._servers = {};
+  }
+
+  //
+  // When webpack is in dev server mode, all the compiled assets are written to
+  // an in-memory filesystem and served through a http server at the default port
+  // 2992 (env.WEBPACK_DEV_PORT).  App server needs these information:
+  // - webpack's stats output to determine the assets to load for its web pages.
+  // - isormophic assets config to determine assets to load during SSR
+  // - webpack's incremental compile report to determine assets to refresh for SSR
+  //
+  // When the app server first starts up, it must wait for webpack dev server
+  // to get the initial webpack stats and isomorphic config.
+  // - If app server restarts, the admin server must send existing webpack result to it.
+  // - If webpack dev server restarts, it will send new stats to the appserver
+  //
+  // - stats is written to a temp file on disk currently.
+  //
+  receiveWebpackDevMessage(data) {
+    if (WEBPACK_DEV_MESSAGES.indexOf(data.name) >= 0) {
+      this._webpackData[data.name] = data;
+      if (this._servers.app) {
+        this._servers.app.child.send(data);
+      }
+    } else {
+      console.log("Unknown message received from webpack dev server", data.name); // eslint-disable-line
+    }
+  }
+
+  receiveAppServerMessage() {}
+
+  _setServer(name, child, handlers) {
+    const info = this._servers[name];
+    if (info) {
+      for (const event in info.handlers) {
+        info.child.removeListener(event, info.handlers[event]);
+      }
+      this._servers[name] = undefined;
+    }
+
+    if (!child) return undefined;
+    this._servers[name] = { child, handlers };
+
+    for (const event in handlers) {
+      child.on(event, handlers[event]);
+    }
+
+    return info;
+  }
+
+  setWebpackServer(child) {
+    this._setServer("wds", child, {
+      message: data => this.receiveWebpackDevMessage(data),
+      exit: () => {
+        this._webpackData = {};
+        this._setServer("wds", null);
+      }
+    });
+  }
+
+  setAppServer(child) {
+    this._setServer("app", child, {
+      message: data => this.receiveAppServerMessage(data),
+      exit: () => this._setServer("app", null)
+    });
+    if (child) {
+      setTimeout(() => {
+        _.each(this._webpackData, data => {
+          child.send(data);
+        });
+      }, 1);
+    }
+  }
+}
+
+module.exports = WebpackDevRelay;

--- a/packages/electrode-archetype-react-app-dev/package.json
+++ b/packages/electrode-archetype-react-app-dev/package.json
@@ -47,6 +47,7 @@
     "@jchip/redbird": "^1.0.0",
     "@loadable/babel-plugin": "^5.10.0",
     "@loadable/webpack-plugin": "^5.7.1",
+    "@xarc/defer": "^1.0.0",
     "acorn": "^6.0.5",
     "ansi-to-html": "^0.6.8",
     "autoprefixer": "^9.6.0",
@@ -76,7 +77,7 @@
     "finalhandler": "^1.1.1",
     "fs-extra": "^0.26.5",
     "identity-obj-proxy": "^3.0.0",
-    "isomorphic-loader": "^2.1.1",
+    "isomorphic-loader": "^2.2.0",
     "nyc": "^14.1.1",
     "jsonfile": "^2.2.2",
     "loader-utils": "^1.1.0",
@@ -137,7 +138,8 @@
     "electrode-archetype-njs-module-dev": "^3.0.0",
     "electrode-archetype-react-app": "../electrode-archetype-react-app",
     "mock-require": "^3.0.3",
-    "prettier": "^1.14.2"
+    "prettier": "^1.14.2",
+    "run-verify": "^1.2.1"
   },
   "engines": {
     "node": ">= 6",

--- a/packages/electrode-archetype-react-app-dev/package.json
+++ b/packages/electrode-archetype-react-app-dev/package.json
@@ -77,7 +77,7 @@
     "finalhandler": "^1.1.1",
     "fs-extra": "^0.26.5",
     "identity-obj-proxy": "^3.0.0",
-    "isomorphic-loader": "^2.2.0",
+    "isomorphic-loader": "^3.0.0",
     "nyc": "^14.1.1",
     "jsonfile": "^2.2.2",
     "loader-utils": "^1.1.0",

--- a/packages/electrode-archetype-react-app-dev/test/spec/dev-admin/webpack-dev-relay.spec.js
+++ b/packages/electrode-archetype-react-app-dev/test/spec/dev-admin/webpack-dev-relay.spec.js
@@ -1,0 +1,102 @@
+"use strict";
+
+const { EventEmitter } = require("events");
+const WebpackDevRelay = require("../../../lib/dev-admin/webpack-dev-relay");
+const { asyncVerify } = require("run-verify");
+const _ = require("lodash");
+
+describe.only("webpack-dev-relay", function() {
+  it("should clear webpack dev data if dev server exits", () => {
+    const wdr = new WebpackDevRelay();
+    const wds = new EventEmitter();
+
+    wdr.setWebpackServer(wds);
+    wds.emit("message", { name: "webpack-report", valid: true, id: 3 });
+    expect(wdr._webpackData).to.have.property("webpack-report");
+    wds.emit("exit");
+    expect(wdr._webpackData).to.deep.equal({});
+    expect(wdr._servers._wds).equal(undefined);
+  });
+
+  it("should clear app if app server exits", () => {
+    const wdr = new WebpackDevRelay();
+    const app = new EventEmitter();
+
+    wdr.setAppServer(app);
+    app.emit("exit");
+    expect(wdr._webpackData).to.deep.equal({});
+    expect(wdr._servers._app).equal(undefined);
+  });
+
+  it("should ignore unknown WDS message", () => {
+    const wdr = new WebpackDevRelay();
+    const wds = new EventEmitter();
+
+    wdr.setWebpackServer(wds);
+    wds.emit("message", { name: "unknown" });
+    expect(wdr._webpackData).to.deep.equal({});
+  });
+
+  // wds started and ready
+  // then app start
+  // expect app to receive results from wds
+  it("should send exist webpack data to new app", () => {
+    const wdr = new WebpackDevRelay();
+    const wds = new EventEmitter();
+    wdr.setWebpackServer(wds);
+    wds.emit("message", { name: "webpack-report", valid: true, id: 1 });
+    wds.emit("message", { name: "webpack-report", valid: true, id: 2 });
+    wds.emit("message", { name: "webpack-report", valid: true, id: 3 });
+    wds.emit("message", { name: "isomorphic-loader-config", valid: true });
+    wds.emit("message", { name: "webpack-stats", valid: true });
+    const app = new EventEmitter();
+    app.send = data => app.emit("message", data);
+    const recv = [];
+    return asyncVerify(
+      next => {
+        app.on("message", data => {
+          recv.push(data);
+          if (recv.length === 3) next(null, recv);
+        });
+        wdr.setAppServer(app);
+      },
+      r => {
+        const s = _.sortBy(r, "name");
+        expect(s[0]).to.include({ name: "isomorphic-loader-config", valid: true });
+        expect(s[1]).to.include({ name: "webpack-report", valid: true, id: 3 });
+        expect(s[2]).to.include({ name: "webpack-stats", valid: true });
+      }
+    );
+  });
+
+  it("should relay webpack message to app", () => {
+    const wdr = new WebpackDevRelay();
+    const wds = new EventEmitter();
+    const app = new EventEmitter();
+    app.send = data => app.emit("message", data);
+
+    wdr.setWebpackServer(wds);
+    wdr.setAppServer(app);
+
+    wds.emit("message", { name: "webpack-report", valid: true, id: 1 });
+    wds.emit("message", { name: "webpack-report", valid: true, id: 2 });
+    wds.emit("message", { name: "webpack-report", valid: true, id: 3 });
+    wds.emit("message", { name: "isomorphic-loader-config", valid: true });
+    wds.emit("message", { name: "webpack-stats", valid: true });
+    const recv = [];
+    return asyncVerify(
+      next => {
+        app.on("message", data => {
+          recv.push(data);
+          if (recv.length === 3) next(null, recv);
+        });
+      },
+      r => {
+        const s = _.sortBy(r, "name");
+        expect(s[0]).to.include({ name: "isomorphic-loader-config", valid: true });
+        expect(s[1]).to.include({ name: "webpack-report", valid: true, id: 3 });
+        expect(s[2]).to.include({ name: "webpack-stats", valid: true });
+      }
+    );
+  });
+});

--- a/packages/electrode-archetype-react-app/package.json
+++ b/packages/electrode-archetype-react-app/package.json
@@ -32,7 +32,7 @@
     "@babel/runtime": "^7.1.5",
     "css-modules-require-hook": "^4.0.2",
     "ignore-styles": "^5.0.1",
-    "isomorphic-loader": "^2.1.1",
+    "isomorphic-loader": "^2.2.0",
     "optional-require": "^1.0.0",
     "subapp-util": "^1.0.2"
   },

--- a/packages/electrode-archetype-react-app/package.json
+++ b/packages/electrode-archetype-react-app/package.json
@@ -32,7 +32,7 @@
     "@babel/runtime": "^7.1.5",
     "css-modules-require-hook": "^4.0.2",
     "ignore-styles": "^5.0.1",
-    "isomorphic-loader": "^2.2.0",
+    "isomorphic-loader": "^3.0.0",
     "optional-require": "^1.0.0",
     "subapp-util": "^1.0.2"
   },

--- a/samples/hapi-app/fyn-lock.yaml
+++ b/samples/hapi-app/fyn-lock.yaml
@@ -1906,6 +1906,13 @@
    '@webassemblyjs/ast': 1.8.5
    '@webassemblyjs/wast-parser': 1.8.5
    '@xtuc/long': 4.2.2
+'@xarc/defer':
+ _latest: 1.0.0
+ _:
+  ^1.0.0: 1.0.0
+ 1.0.0:
+  $: sha512-sRz93+umHI40pmTn0l17oCd0pkRN8lJ8e3yvtOT8xPDFMPIkDslnQOCwntYt49RMPJD9ez7Jl2IFE3xnVj9Kew==
+  _: 'https://registry.npmjs.org/@xarc/defer/-/defer-1.0.0.tgz'
 '@xtuc/ieee754':
  _latest: 1.2.0
  _:
@@ -5324,7 +5331,7 @@ electrode-archetype-react-app:
    '@babel/runtime': ^7.1.5
    css-modules-require-hook: ^4.0.2
    ignore-styles: ^5.0.1
-   isomorphic-loader: ^2.1.1
+   isomorphic-loader: ^3.0.0
    optional-require: ^1.0.0
    subapp-util: ^1.0.2
   optionalDependencies:
@@ -5354,6 +5361,7 @@ electrode-archetype-react-app-dev:
    '@jchip/redbird': ^1.0.0
    '@loadable/babel-plugin': ^5.10.0
    '@loadable/webpack-plugin': ^5.7.1
+   '@xarc/defer': ^1.0.0
    acorn: ^6.0.5
    ansi-to-html: ^0.6.8
    autoprefixer: ^9.6.0
@@ -5383,7 +5391,7 @@ electrode-archetype-react-app-dev:
    finalhandler: ^1.1.1
    fs-extra: ^0.26.5
    identity-obj-proxy: ^3.0.0
-   isomorphic-loader: ^2.1.1
+   isomorphic-loader: ^3.0.0
    nyc: ^14.1.1
    jsonfile: ^2.2.2
    loader-utils: ^1.1.0
@@ -5554,17 +5562,16 @@ electrode-server:
 electrode-static-paths:
  _latest: 3.0.0
  _:
-  ^2.0.1: 2.0.4
- 2.0.4:
+  ^3.0.0: 3.0.0
+ 3.0.0:
   top: 1
-  $: sha512-E/AifPS2kw/Yro9YKzll+0ku6Vsb2qzerqFD87d9DQu5wI/lkWWXXLdvhpw1064mT8oZzpW9xRn+kQq+tJNyWw==
-  _: 'https://registry.npmjs.org/electrode-static-paths/-/electrode-static-paths-2.0.4.tgz'
+  $: sha512-Y8Ojt1XWRhiwIfW9UXYBbIH7FLWDKx7TFVgTZcsXRhx8oQcjj0wC/9zIl1XqZnqU9MaBIU5zlZIm6sDJKFfKOw==
+  _: 'https://registry.npmjs.org/electrode-static-paths/-/electrode-static-paths-3.0.0.tgz'
   dependencies:
    chalk: ^2.4.2
-   electrode-hapi-compat: ^1.0.0
    lodash: ^4.17.11
   peerDependencies:
-   inert: '^4.0.0 || ^5.0.0'
+   '@hapi/inert': ^5.2.0
 electrode-ui-config:
  _latest: 1.3.1-fynlocal_h
  _:
@@ -8391,12 +8398,12 @@ isobject:
   dependencies:
    isarray: 1.0.0
 isomorphic-loader:
- _latest: 2.1.1
+ _latest: 3.0.0
  _:
-  ^2.1.1: 2.1.1
- 2.1.1:
-  $: sha512-rPs8mD9Vv32Ob4CU0X9HYXdQmDoUv77qRq4Kx+TLCOKZ9sj1KULLIRvERPFGCc7fz+CSRcQL07RQcUVaXk+7ug==
-  _: 'https://registry.npmjs.org/isomorphic-loader/-/isomorphic-loader-2.1.1.tgz'
+  ^3.0.0: 3.0.0
+ 3.0.0:
+  $: sha512-YCEVK5lrs2trGcfd84xkBsnfHEp8zlUb0KcmC1ZdcQKvIZk7q8hsUzK/WPPLm934qVIOmoo/RDGBA7C2j9shMw==
+  _: 'https://registry.npmjs.org/isomorphic-loader/-/isomorphic-loader-3.0.0.tgz'
   dependencies:
    deep-extend: ^0.6.0
    lockfile: ^1.0.4

--- a/samples/hapi-app/package.json
+++ b/samples/hapi-app/package.json
@@ -47,7 +47,7 @@
     "electrode-react-webapp": "^3.2.0",
     "electrode-redux-router-engine": "^2.1.8",
     "electrode-server": "^3.0.0",
-    "electrode-static-paths": "^2.0.1",
+    "electrode-static-paths": "^3.0.0",
     "electrode-ui-config": "^1.1.2",
     "@hapi/good": "^8.2.4",
     "@hapi/good-console": "^8.1.2",

--- a/samples/universal-react-node/fyn-lock.yaml
+++ b/samples/universal-react-node/fyn-lock.yaml
@@ -1555,6 +1555,13 @@
    '@webassemblyjs/ast': 1.8.5
    '@webassemblyjs/wast-parser': 1.8.5
    '@xtuc/long': 4.2.2
+'@xarc/defer':
+ _latest: 1.0.0
+ _:
+  ^1.0.0: 1.0.0
+ 1.0.0:
+  $: sha512-sRz93+umHI40pmTn0l17oCd0pkRN8lJ8e3yvtOT8xPDFMPIkDslnQOCwntYt49RMPJD9ez7Jl2IFE3xnVj9Kew==
+  _: 'https://registry.npmjs.org/@xarc/defer/-/defer-1.0.0.tgz'
 '@xtuc/ieee754':
  _latest: 1.2.0
  _:
@@ -5199,6 +5206,8 @@ electrode-archetype-opt-jest:
   dependencies:
    '@types/jest': ^23.3.14
    babel-jest: ^23.6.0
+   enzyme: ^3.0.0
+   enzyme-adapter-react-16: ^1.1.0
    eslint-plugin-jest: ^21.27.2
    jest: ^23.6.0
 electrode-archetype-opt-karma:
@@ -5211,6 +5220,11 @@ electrode-archetype-opt-karma:
   _: ../../packages/electrode-archetype-opt-karma
   dependencies:
    babel-plugin-istanbul: ^5.1.0
+   chai: ^4.0.0
+   chai-as-promised: ^7.1.1
+   chai-shallowly: ^1.0.0
+   enzyme: ^3.0.0
+   enzyme-adapter-react-16: ^1.1.0
    karma: ^3.1.1
    karma-chrome-launcher: ^2.2.0
    karma-coverage: ^2.0.0
@@ -5245,6 +5259,11 @@ electrode-archetype-opt-mocha:
   _: ../../packages/electrode-archetype-opt-mocha
   dependencies:
    '@types/mocha': 5.2.7
+   chai: ^4.0.0
+   chai-as-promised: ^7.1.1
+   chai-shallowly: ^1.0.0
+   enzyme: ^3.0.0
+   enzyme-adapter-react-16: ^1.1.0
    mocha: ^4.0.0
 electrode-archetype-opt-phantomjs:
  _latest: 1.0.1-fynlocal_h
@@ -5303,6 +5322,16 @@ electrode-archetype-opt-react:
   dependencies:
    react: ^16.0.0
    react-dom: ^16.0.0
+electrode-archetype-opt-react-intl:
+ _latest: 1.0.0-fynlocal_h
+ _:
+  ../electrode-archetype-opt-react-intl: 1.0.0-fynlocal_h
+ 1.0.0-fynlocal_h:
+  hasPI: 1
+  $: local
+  _: ../../packages/electrode-archetype-opt-react-intl
+  dependencies:
+   react-intl: ^2.1.3
 electrode-archetype-opt-sass:
  _latest: 1.0.8-fynlocal_h
  _:
@@ -5348,10 +5377,10 @@ electrode-archetype-opt-typescript:
    typescript: ^3.2.1
    '@babel/preset-typescript': ^7.1.0
 electrode-archetype-react-app:
- _latest: 6.5.15-fynlocal_h
+ _latest: 6.5.16-fynlocal_h
  _:
-  ../../packages/electrode-archetype-react-app: 6.5.15-fynlocal_h
- 6.5.15-fynlocal_h:
+  ../../packages/electrode-archetype-react-app: 6.5.16-fynlocal_h
+ 6.5.16-fynlocal_h:
   top: 1
   $: local
   _: ../../packages/electrode-archetype-react-app
@@ -5359,17 +5388,17 @@ electrode-archetype-react-app:
    '@babel/runtime': ^7.1.5
    css-modules-require-hook: ^4.0.2
    ignore-styles: ^5.0.1
-   isomorphic-loader: ^2.1.1
+   isomorphic-loader: ^3.0.0
    optional-require: ^1.0.0
    subapp-util: ^1.0.2
   optionalDependencies:
    electrode-archetype-opt-inferno: ^0.2.10
    electrode-archetype-opt-react: ^2.0.3
 electrode-archetype-react-app-dev:
- _latest: 6.5.15-fynlocal_h
+ _latest: 6.5.16-fynlocal_h
  _:
-  ../../packages/electrode-archetype-react-app-dev: 6.5.15-fynlocal_h
- 6.5.15-fynlocal_h:
+  ../../packages/electrode-archetype-react-app-dev: 6.5.16-fynlocal_h
+ 6.5.16-fynlocal_h:
   top: 1
   $: local
   _: ../../packages/electrode-archetype-react-app-dev
@@ -5389,6 +5418,7 @@ electrode-archetype-react-app-dev:
    '@jchip/redbird': ^1.0.0
    '@loadable/babel-plugin': ^5.10.0
    '@loadable/webpack-plugin': ^5.7.1
+   '@xarc/defer': ^1.0.0
    acorn: ^6.0.5
    ansi-to-html: ^0.6.8
    autoprefixer: ^9.6.0
@@ -5403,9 +5433,6 @@ electrode-archetype-react-app-dev:
    babel-plugin-transform-react-remove-prop-types: ^0.4.20
    batch: ^0.6.1
    boxen: ^2.1.0
-   chai: ^4.0.0
-   chai-as-promised: ^7.1.1
-   chai-shallowly: ^1.0.0
    chalker: ^1.1.1
    chokidar: ^2.0.4
    convert-source-map: ^1.5.0
@@ -5416,14 +5443,12 @@ electrode-archetype-react-app-dev:
    electrode-hapi-compat: ^1.2.0
    electrode-node-resolver: ^2.0.0
    electrode-webpack-reporter: ^0.5.1
-   enzyme: ^3.0.0
-   enzyme-adapter-react-16: ^1.1.0
    file-loader: ^2.0.0
    filter-scan-dir: ^1.0.9
    finalhandler: ^1.1.1
    fs-extra: ^0.26.5
    identity-obj-proxy: ^3.0.0
-   isomorphic-loader: ^2.1.1
+   isomorphic-loader: ^3.0.0
    nyc: ^14.1.1
    jsonfile: ^2.2.2
    loader-utils: ^1.1.0
@@ -5438,8 +5463,6 @@ electrode-archetype-react-app-dev:
    optional-require: ^1.0.0
    prop-types: ^15.5.6
    raw-loader: ^0.5.1
-   react-intl: ^2.1.0
-   react-test-renderer: ^16.1.1
    regenerator-runtime: ^0.13.2
    request: ^2.88.0
    require-at: ^1.0.2
@@ -5474,6 +5497,7 @@ electrode-archetype-react-app-dev:
    electrode-archetype-opt-postcss: ^1.0.3
    electrode-archetype-opt-pwa: ^1.0.5
    electrode-archetype-opt-react: ^2.0.3
+   electrode-archetype-opt-react-intl: ^1.0.0
    electrode-archetype-opt-sass: ^1.0.8
    electrode-archetype-opt-stylus: ^1.0.1
    electrode-archetype-opt-sinon: ^1.0.2
@@ -8860,12 +8884,12 @@ isomorphic-fetch:
    node-fetch: ^1.0.1
    whatwg-fetch: '>=0.10.0'
 isomorphic-loader:
- _latest: 2.1.1
+ _latest: 3.0.0
  _:
-  ^2.1.1: 2.1.1
- 2.1.1:
-  $: sha512-rPs8mD9Vv32Ob4CU0X9HYXdQmDoUv77qRq4Kx+TLCOKZ9sj1KULLIRvERPFGCc7fz+CSRcQL07RQcUVaXk+7ug==
-  _: 'https://registry.npmjs.org/isomorphic-loader/-/isomorphic-loader-2.1.1.tgz'
+  ^3.0.0: 3.0.0
+ 3.0.0:
+  $: sha512-YCEVK5lrs2trGcfd84xkBsnfHEp8zlUb0KcmC1ZdcQKvIZk7q8hsUzK/WPPLm934qVIOmoo/RDGBA7C2j9shMw==
+  _: 'https://registry.npmjs.org/isomorphic-loader/-/isomorphic-loader-3.0.0.tgz'
   dependencies:
    deep-extend: ^0.6.0
    lockfile: ^1.0.4
@@ -14021,9 +14045,9 @@ react-dom:
   peerDependencies:
    react: ^16.0.0
 react-intl:
- _latest: 2.8.0
+ _latest: 3.4.0
  _:
-  ^2.1.0: 2.8.0
+  ^2.1.3: 2.8.0
  2.8.0:
   $: sha512-1cSasNkHxZOXYYhms9Q1tSEWF8AWZQNq3nPLB/j8mYV0ZTSt2DhGQXHfKrKQMu4cgj9J1Crqg7xFPICTBgzqtQ==
   _: 'https://registry.npmjs.org/react-intl/-/react-intl-2.8.0.tgz'
@@ -14157,7 +14181,7 @@ react-router-dom:
 react-test-renderer:
  _latest: 16.8.6
  _:
-  '^16.0.0-0,^16.1.1': 16.8.6
+  ^16.0.0-0: 16.8.6
  16.8.6:
   $: sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==
   _: 'https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.6.tgz'


### PR DESCRIPTION
With dev-admin server, it's possible to setup IPC between webpack dev server and app server through `process.send`.  Use that to transfer isomorphic config from WDS to app, instead of a file on disk and relying on file watcher, causing all kinds of timing issues.