### PR TITLE
no need to restart app server for client changes

### DIFF
--- a/packages/electrode-archetype-react-app/arch-clap.js
+++ b/packages/electrode-archetype-react-app/arch-clap.js
@@ -863,7 +863,7 @@ Individual .babelrc files were generated for you in src/client and src/server
       dep: [".init-bundle.valid.log"],
       desc: "Start app's node server in watch mode with nodemon",
       task: function() {
-        const watches = (archetype.webpack.devMiddleware
+        const watches = (archetype.webpack.devMiddleware || this.argv.includes("--no-ssr-sync")
           ? []
           : [Path.join(eTmpDir, "bundle.valid.log")]
         )
@@ -884,9 +884,10 @@ Individual .babelrc files were generated for you in src/client and src/server
           nodeRunApp = quote(Path.relative(process.cwd(), serverRun));
         }
 
+        let taskArguments = this.argv.includes("--no-ssr-sync") ? "" : taskArgs(this.argv).join(" ");
         return mkCmd(
           `~$nodemon`,
-          taskArgs(this.argv).join(" "),
+          taskArguments,
           archetype.webpack.devMiddleware ? "" : "-C",
           `--delay 1 --ext js,jsx,json,yaml,log,ts,tsx ${watches}`,
           `${nodeRunApp}`

--- a/packages/electrode-archetype-react-app/arch-clap.js
+++ b/packages/electrode-archetype-react-app/arch-clap.js
@@ -784,6 +784,23 @@ Individual .babelrc files were generated for you in src/client and src/server
       }
     },
 
+    "client-dev": {
+      desc: "Start your app with watch in hot mode for client changes only",
+      dep: [".development-env"],
+      task: () => {
+        if (!Fs.existsSync(".isomorphic-loader-config.json")) {
+          Fs.writeFileSync(".isomorphic-loader-config.json", JSON.stringify({}));
+        }
+        return [
+          ".set.css-module.env",
+          ".webpack-dev",
+          archetype.webpack.devMiddleware
+            ? ["server-admin", "generate-service-worker"]
+            : ["wds.dev", "client-watch", "generate-service-worker"]
+        ];
+      }
+    },
+
     hot: {
       desc: "Start app dev with hot reload enabled",
       task: () => {
@@ -874,6 +891,20 @@ Individual .babelrc files were generated for you in src/client and src/server
           `--delay 1 --ext js,jsx,json,yaml,log,ts,tsx ${watches}`,
           `${nodeRunApp}`
         );
+      }
+    },
+
+    "client-watch": {
+      dep: [".init-bundle.valid.log"],
+      desc: "Start app's client server in watch mode with node. It detects only client changes.",
+      task: () => {
+        AppMode.setEnv(AppMode.src.dir);
+        const nodeRunApp = AppMode.isSrc
+          ? `node ${archetype.dir}/support/babel-run ${AppMode.src.server}`
+          : `node ${AppMode.src.server}`;
+          return exec(
+            `${nodeRunApp}`
+          );
       }
     },
 


### PR DESCRIPTION
When there is any client side code changes, I observed that the webpack is built along with app server restart. It takes a lot of time to reflect the client side change after webpack built and server restart.
For e.g. in Itempage, I saw it takes around ~61 secs to reflect the change. But if we don't do server restart, this takes ~20 secs to reflect the change.

we can include `client-dev` command in script so that developer who needs to see only client side change can run this command.