### PR TITLE
no-ssr-sync flag added to reload client only without app server restart

### DIFF
--- a/packages/electrode-archetype-react-app/arch-clap.js
+++ b/packages/electrode-archetype-react-app/arch-clap.js
@@ -846,7 +846,7 @@ Individual .babelrc files were generated for you in src/client and src/server
       dep: [".init-bundle.valid.log"],
       desc: "Start app's node server in watch mode with nodemon",
       task: function() {
-        const watches = (archetype.webpack.devMiddleware
+        const watches = (archetype.webpack.devMiddleware || this.argv.includes("--no-ssr-sync")
           ? []
           : [Path.join(eTmpDir, "bundle.valid.log")]
         )
@@ -867,9 +867,10 @@ Individual .babelrc files were generated for you in src/client and src/server
           nodeRunApp = quote(Path.relative(process.cwd(), serverRun));
         }
 
+        let taskArguments = this.argv.includes("--no-ssr-sync") ? "" : taskArgs(this.argv).join(" ");
         return mkCmd(
           `~$nodemon`,
-          taskArgs(this.argv).join(" "),
+          taskArguments,
           archetype.webpack.devMiddleware ? "" : "-C",
           `--delay 1 --ext js,jsx,json,yaml,log,ts,tsx ${watches}`,
           `${nodeRunApp}`

--- a/packages/electrode-archetype-react-app/arch-clap.js
+++ b/packages/electrode-archetype-react-app/arch-clap.js
@@ -867,7 +867,7 @@ Individual .babelrc files were generated for you in src/client and src/server
           nodeRunApp = quote(Path.relative(process.cwd(), serverRun));
         }
 
-        let taskArguments = this.argv.includes("--no-ssr-sync") ? "" : taskArgs(this.argv).join(" ");
+        const taskArguments = taskArgs(this.argv.filter( x => x !== "--no-ssr-sync" )).join( " " );
         return mkCmd(
           `~$nodemon`,
           taskArguments,


### PR DESCRIPTION
Added the no-ssr-sync flag in dev task which will only build webpack for any client side code change and the change will load in UI without page refresh. It won't restart app server every time.