### PR TITLE
Fix config fail to load

### DIFF
--- a/packages/electrode-archetype-react-app-dev/config/webpack/util/generate-config.js
+++ b/packages/electrode-archetype-react-app-dev/config/webpack/util/generate-config.js
@@ -35,7 +35,7 @@ function searchUserCustomConfig(options) {
     },
     {
       dir: archPath,
-      file: options.configFilename
+      file: configFilename
     }
   ];
 


### PR DESCRIPTION
`webpack.config.js`, `webpack.config.dev.js` failed to load from the `./archetype/config` directory.  it looks for 'production.js', 'development.js' instead, which is not backward compatible with existing apps.