### PR TITLE
Do not fail the optional-check for dual-selection

### DIFF
--- a/packages/electrode-archetype-opt-critical-css/optional-check.js
+++ b/packages/electrode-archetype-opt-critical-css/optional-check.js
@@ -160,12 +160,15 @@ it excludes this package ${myName} - skip installing`
   if (appDep) {
     if (options.hasOwnProperty(optionalTagName)) {
       return done(
-        false,
+        true,
         `
-  ERROR
-  ERROR: you have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
-  ERROR: Please specify only one of those.
-  ERROR
+  WARNING
+  WARNING: You have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
+  WARNING: Defaulting to ${myName} to enabled.
+  WARNING: Because enabling features in archetype/config will be deprecated in the next archetype version,
+  WARNING: it is recommended that you remove ${optionalTagName} from your archetype/config options if you wish
+  WARNING: to keep ${myName} enabled.
+  WARNING
   `
       );
     }

--- a/packages/electrode-archetype-opt-eslint/optional-check.js
+++ b/packages/electrode-archetype-opt-eslint/optional-check.js
@@ -160,12 +160,15 @@ it excludes this package ${myName} - skip installing`
   if (appDep) {
     if (options.hasOwnProperty(optionalTagName)) {
       return done(
-        false,
+        true,
         `
-  ERROR
-  ERROR: you have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
-  ERROR: Please specify only one of those.
-  ERROR
+  WARNING
+  WARNING: You have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
+  WARNING: Defaulting to ${myName} to enabled.
+  WARNING: Because enabling features in archetype/config will be deprecated in the next archetype version,
+  WARNING: it is recommended that you remove ${optionalTagName} from your archetype/config options if you wish
+  WARNING: to keep ${myName} enabled.
+  WARNING
   `
       );
     }

--- a/packages/electrode-archetype-opt-flow/optional-check.js
+++ b/packages/electrode-archetype-opt-flow/optional-check.js
@@ -160,12 +160,15 @@ it excludes this package ${myName} - skip installing`
   if (appDep) {
     if (options.hasOwnProperty(optionalTagName)) {
       return done(
-        false,
+        true,
         `
-  ERROR
-  ERROR: you have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
-  ERROR: Please specify only one of those.
-  ERROR
+  WARNING
+  WARNING: You have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
+  WARNING: Defaulting to ${myName} to enabled.
+  WARNING: Because enabling features in archetype/config will be deprecated in the next archetype version,
+  WARNING: it is recommended that you remove ${optionalTagName} from your archetype/config options if you wish
+  WARNING: to keep ${myName} enabled.
+  WARNING
   `
       );
     }

--- a/packages/electrode-archetype-opt-inferno/optional-check.js
+++ b/packages/electrode-archetype-opt-inferno/optional-check.js
@@ -160,12 +160,15 @@ it excludes this package ${myName} - skip installing`
   if (appDep) {
     if (options.hasOwnProperty(optionalTagName)) {
       return done(
-        false,
+        true,
         `
-  ERROR
-  ERROR: you have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
-  ERROR: Please specify only one of those.
-  ERROR
+  WARNING
+  WARNING: You have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
+  WARNING: Defaulting to ${myName} to enabled.
+  WARNING: Because enabling features in archetype/config will be deprecated in the next archetype version,
+  WARNING: it is recommended that you remove ${optionalTagName} from your archetype/config options if you wish
+  WARNING: to keep ${myName} enabled.
+  WARNING
   `
       );
     }

--- a/packages/electrode-archetype-opt-jest/optional-check.js
+++ b/packages/electrode-archetype-opt-jest/optional-check.js
@@ -160,12 +160,15 @@ it excludes this package ${myName} - skip installing`
   if (appDep) {
     if (options.hasOwnProperty(optionalTagName)) {
       return done(
-        false,
+        true,
         `
-  ERROR
-  ERROR: you have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
-  ERROR: Please specify only one of those.
-  ERROR
+  WARNING
+  WARNING: You have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
+  WARNING: Defaulting to ${myName} to enabled.
+  WARNING: Because enabling features in archetype/config will be deprecated in the next archetype version,
+  WARNING: it is recommended that you remove ${optionalTagName} from your archetype/config options if you wish
+  WARNING: to keep ${myName} enabled.
+  WARNING
   `
       );
     }

--- a/packages/electrode-archetype-opt-karma/optional-check.js
+++ b/packages/electrode-archetype-opt-karma/optional-check.js
@@ -160,12 +160,15 @@ it excludes this package ${myName} - skip installing`
   if (appDep) {
     if (options.hasOwnProperty(optionalTagName)) {
       return done(
-        false,
+        true,
         `
-  ERROR
-  ERROR: you have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
-  ERROR: Please specify only one of those.
-  ERROR
+  WARNING
+  WARNING: You have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
+  WARNING: Defaulting to ${myName} to enabled.
+  WARNING: Because enabling features in archetype/config will be deprecated in the next archetype version,
+  WARNING: it is recommended that you remove ${optionalTagName} from your archetype/config options if you wish
+  WARNING: to keep ${myName} enabled.
+  WARNING
   `
       );
     }

--- a/packages/electrode-archetype-opt-less/optional-check.js
+++ b/packages/electrode-archetype-opt-less/optional-check.js
@@ -160,12 +160,15 @@ it excludes this package ${myName} - skip installing`
   if (appDep) {
     if (options.hasOwnProperty(optionalTagName)) {
       return done(
-        false,
+        true,
         `
-  ERROR
-  ERROR: you have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
-  ERROR: Please specify only one of those.
-  ERROR
+  WARNING
+  WARNING: You have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
+  WARNING: Defaulting to ${myName} to enabled.
+  WARNING: Because enabling features in archetype/config will be deprecated in the next archetype version,
+  WARNING: it is recommended that you remove ${optionalTagName} from your archetype/config options if you wish
+  WARNING: to keep ${myName} enabled.
+  WARNING
   `
       );
     }

--- a/packages/electrode-archetype-opt-mocha/optional-check.js
+++ b/packages/electrode-archetype-opt-mocha/optional-check.js
@@ -160,12 +160,15 @@ it excludes this package ${myName} - skip installing`
   if (appDep) {
     if (options.hasOwnProperty(optionalTagName)) {
       return done(
-        false,
+        true,
         `
-  ERROR
-  ERROR: you have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
-  ERROR: Please specify only one of those.
-  ERROR
+  WARNING
+  WARNING: You have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
+  WARNING: Defaulting to ${myName} to enabled.
+  WARNING: Because enabling features in archetype/config will be deprecated in the next archetype version,
+  WARNING: it is recommended that you remove ${optionalTagName} from your archetype/config options if you wish
+  WARNING: to keep ${myName} enabled.
+  WARNING
   `
       );
     }

--- a/packages/electrode-archetype-opt-phantomjs/optional-check.js
+++ b/packages/electrode-archetype-opt-phantomjs/optional-check.js
@@ -160,12 +160,15 @@ it excludes this package ${myName} - skip installing`
   if (appDep) {
     if (options.hasOwnProperty(optionalTagName)) {
       return done(
-        false,
+        true,
         `
-  ERROR
-  ERROR: you have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
-  ERROR: Please specify only one of those.
-  ERROR
+  WARNING
+  WARNING: You have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
+  WARNING: Defaulting to ${myName} to enabled.
+  WARNING: Because enabling features in archetype/config will be deprecated in the next archetype version,
+  WARNING: it is recommended that you remove ${optionalTagName} from your archetype/config options if you wish
+  WARNING: to keep ${myName} enabled.
+  WARNING
   `
       );
     }

--- a/packages/electrode-archetype-opt-postcss/optional-check.js
+++ b/packages/electrode-archetype-opt-postcss/optional-check.js
@@ -160,12 +160,15 @@ it excludes this package ${myName} - skip installing`
   if (appDep) {
     if (options.hasOwnProperty(optionalTagName)) {
       return done(
-        false,
+        true,
         `
-  ERROR
-  ERROR: you have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
-  ERROR: Please specify only one of those.
-  ERROR
+  WARNING
+  WARNING: You have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
+  WARNING: Defaulting to ${myName} to enabled.
+  WARNING: Because enabling features in archetype/config will be deprecated in the next archetype version,
+  WARNING: it is recommended that you remove ${optionalTagName} from your archetype/config options if you wish
+  WARNING: to keep ${myName} enabled.
+  WARNING
   `
       );
     }

--- a/packages/electrode-archetype-opt-pwa/optional-check.js
+++ b/packages/electrode-archetype-opt-pwa/optional-check.js
@@ -160,12 +160,15 @@ it excludes this package ${myName} - skip installing`
   if (appDep) {
     if (options.hasOwnProperty(optionalTagName)) {
       return done(
-        false,
+        true,
         `
-  ERROR
-  ERROR: you have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
-  ERROR: Please specify only one of those.
-  ERROR
+  WARNING
+  WARNING: You have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
+  WARNING: Defaulting to ${myName} to enabled.
+  WARNING: Because enabling features in archetype/config will be deprecated in the next archetype version,
+  WARNING: it is recommended that you remove ${optionalTagName} from your archetype/config options if you wish
+  WARNING: to keep ${myName} enabled.
+  WARNING
   `
       );
     }

--- a/packages/electrode-archetype-opt-react-intl/optional-check.js
+++ b/packages/electrode-archetype-opt-react-intl/optional-check.js
@@ -160,12 +160,15 @@ it excludes this package ${myName} - skip installing`
   if (appDep) {
     if (options.hasOwnProperty(optionalTagName)) {
       return done(
-        false,
+        true,
         `
-  ERROR
-  ERROR: you have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
-  ERROR: Please specify only one of those.
-  ERROR
+  WARNING
+  WARNING: You have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
+  WARNING: Defaulting to ${myName} to enabled.
+  WARNING: Because enabling features in archetype/config will be deprecated in the next archetype version,
+  WARNING: it is recommended that you remove ${optionalTagName} from your archetype/config options if you wish
+  WARNING: to keep ${myName} enabled.
+  WARNING
   `
       );
     }

--- a/packages/electrode-archetype-opt-react/optional-check.js
+++ b/packages/electrode-archetype-opt-react/optional-check.js
@@ -160,12 +160,15 @@ it excludes this package ${myName} - skip installing`
   if (appDep) {
     if (options.hasOwnProperty(optionalTagName)) {
       return done(
-        false,
+        true,
         `
-  ERROR
-  ERROR: you have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
-  ERROR: Please specify only one of those.
-  ERROR
+  WARNING
+  WARNING: You have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
+  WARNING: Defaulting to ${myName} to enabled.
+  WARNING: Because enabling features in archetype/config will be deprecated in the next archetype version,
+  WARNING: it is recommended that you remove ${optionalTagName} from your archetype/config options if you wish
+  WARNING: to keep ${myName} enabled.
+  WARNING
   `
       );
     }

--- a/packages/electrode-archetype-opt-sass/optional-check.js
+++ b/packages/electrode-archetype-opt-sass/optional-check.js
@@ -160,12 +160,15 @@ it excludes this package ${myName} - skip installing`
   if (appDep) {
     if (options.hasOwnProperty(optionalTagName)) {
       return done(
-        false,
+        true,
         `
-  ERROR
-  ERROR: you have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
-  ERROR: Please specify only one of those.
-  ERROR
+  WARNING
+  WARNING: You have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
+  WARNING: Defaulting to ${myName} to enabled.
+  WARNING: Because enabling features in archetype/config will be deprecated in the next archetype version,
+  WARNING: it is recommended that you remove ${optionalTagName} from your archetype/config options if you wish
+  WARNING: to keep ${myName} enabled.
+  WARNING
   `
       );
     }

--- a/packages/electrode-archetype-opt-sinon/optional-check.js
+++ b/packages/electrode-archetype-opt-sinon/optional-check.js
@@ -160,12 +160,15 @@ it excludes this package ${myName} - skip installing`
   if (appDep) {
     if (options.hasOwnProperty(optionalTagName)) {
       return done(
-        false,
+        true,
         `
-  ERROR
-  ERROR: you have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
-  ERROR: Please specify only one of those.
-  ERROR
+  WARNING
+  WARNING: You have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
+  WARNING: Defaulting to ${myName} to enabled.
+  WARNING: Because enabling features in archetype/config will be deprecated in the next archetype version,
+  WARNING: it is recommended that you remove ${optionalTagName} from your archetype/config options if you wish
+  WARNING: to keep ${myName} enabled.
+  WARNING
   `
       );
     }

--- a/packages/electrode-archetype-opt-stylus/optional-check.js
+++ b/packages/electrode-archetype-opt-stylus/optional-check.js
@@ -160,12 +160,15 @@ it excludes this package ${myName} - skip installing`
   if (appDep) {
     if (options.hasOwnProperty(optionalTagName)) {
       return done(
-        false,
+        true,
         `
-  ERROR
-  ERROR: you have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
-  ERROR: Please specify only one of those.
-  ERROR
+  WARNING
+  WARNING: You have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
+  WARNING: Defaulting to ${myName} to enabled.
+  WARNING: Because enabling features in archetype/config will be deprecated in the next archetype version,
+  WARNING: it is recommended that you remove ${optionalTagName} from your archetype/config options if you wish
+  WARNING: to keep ${myName} enabled.
+  WARNING
   `
       );
     }

--- a/packages/electrode-archetype-opt-typescript/optional-check.js
+++ b/packages/electrode-archetype-opt-typescript/optional-check.js
@@ -160,12 +160,15 @@ it excludes this package ${myName} - skip installing`
   if (appDep) {
     if (options.hasOwnProperty(optionalTagName)) {
       return done(
-        false,
+        true,
         `
-  ERROR
-  ERROR: you have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
-  ERROR: Please specify only one of those.
-  ERROR
+  WARNING
+  WARNING: You have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
+  WARNING: Defaulting to ${myName} to enabled.
+  WARNING: Because enabling features in archetype/config will be deprecated in the next archetype version,
+  WARNING: it is recommended that you remove ${optionalTagName} from your archetype/config options if you wish
+  WARNING: to keep ${myName} enabled.
+  WARNING
   `
       );
     }

--- a/packages/opt-archetype-check/optional-check.js
+++ b/packages/opt-archetype-check/optional-check.js
@@ -160,12 +160,15 @@ it excludes this package ${myName} - skip installing`
   if (appDep) {
     if (options.hasOwnProperty(optionalTagName)) {
       return done(
-        false,
+        true,
         `
-  ERROR
-  ERROR: you have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
-  ERROR: Please specify only one of those.
-  ERROR
+  WARNING
+  WARNING: You have ${myName} in your package.json *and* ${optionalTagName} in your archetype/config options.
+  WARNING: Defaulting to ${myName} to enabled.
+  WARNING: Because enabling features in archetype/config will be deprecated in the next archetype version,
+  WARNING: it is recommended that you remove ${optionalTagName} from your archetype/config options if you wish
+  WARNING: to keep ${myName} enabled.
+  WARNING
   `
       );
     }


### PR DESCRIPTION
- If both archetype config and package.json contain a reference to the feature package, default to enabled (even if the archetype config specifies disabled).
- Display message as a warning instead of an error.
- Display additional information indicating that using archetype/config to enable features is going to be deprecated 