### PR TITLE
If devOnly is undefined, default to true.

### DIFF
--- a/packages/electrode-archetype-react-app/lib/features.js
+++ b/packages/electrode-archetype-react-app/lib/features.js
@@ -218,10 +218,18 @@ class Feature {
     }
     const dependencies = { ...pkg.dependencies };
     const devDependencies = { ...pkg.devDependencies };
-    if (enabled && this.electrodeOptArchetype.devOnly) {
+
+    let devOnly = true;
+    if (this.electrodeOptArchetype.devOnly !== undefined) {
+      devOnly = this.electrodeOptArchetype.devOnly;
+    } else if (this.package && this.package.electrodeOptArchetype.devOnly !== undefined) {
+      devOnly = this.package.electrodeOptArchetype.devOnly;
+    }
+
+    if (enabled && devOnly) {
       delete dependencies[this.packageName];
       devDependencies[this.packageName] = `^${this.installedVersion || this.npmVersion}`;
-    } else if (enabled && !this.electrodeOptArchetype.devOnly) {
+    } else if (enabled && !devOnly) {
       dependencies[this.packageName] = `^${this.installedVersion || this.npmVersion}`;
       delete devDependencies[this.packageName];
     } else {


### PR DESCRIPTION
Also, search for devOnly in locally installed package if not available in npm registry data.