### PR TITLE
dev-admin server: create a web interface for viewing console log events

### DIFF
--- a/packages/electrode-archetype-react-app-dev/lib/dev-admin/dev-hapi.js
+++ b/packages/electrode-archetype-react-app-dev/lib/dev-admin/dev-hapi.js
@@ -60,7 +60,9 @@ function register(server, options, next) {
             let data;
             try {
               data = fs.readFileSync(name);
+              console.log(data);
             } catch (e) {
+              console.log(e);
               return reply.code(404);
             }
             const type = mime.lookup(name);

--- a/packages/electrode-archetype-react-app-dev/lib/dev-admin/log-parser.js
+++ b/packages/electrode-archetype-react-app-dev/lib/dev-admin/log-parser.js
@@ -1,0 +1,75 @@
+"use strict";
+
+const ck = require("chalker");
+const { Levels } = require("./log-reader");
+
+// eslint-disable-next-line no-control-regex
+const LogParse = /^(?:\u001b\[[0-9]+?m)?([a-z]+)(?:\u001b\[[0-9]+?m)?:(?: ([\s\S]*))?$/;
+// eslint-disable-next-line no-control-regex
+const FyiLogParse = /^(?:\u001b\[[0-9]+?m)?FYI ([a-z]+):(?:\u001b\[[0-9]+?m)?(?: ([\s\S]*))?$/;
+
+const FyiTag = ck`<yellow.inverse>[fyi]</> `;
+const BunyanTag = ck`<cyan.inverse>[byn]</> `;
+const BunyanLevelLookup = {
+  60: "error",
+  50: "error",
+  40: "warn",
+  30: "info",
+  20: "debug",
+  10: "silly"
+};
+const parsers = [
+  {regex: LogParse, prefix: ""},
+  {regex: FyiLogParse, prefix: FyiTag}
+];
+
+function parseRegex(raw, parser) {
+  const match = raw.match(parser.regex);
+  if (!match) {
+    return false;
+  }
+
+  const level = match[1];
+  const message = parser.prefix + (match[2] || ""); // eslint-disable-line no-magic-numbers
+
+  if (!Levels.hasOwnProperty(level)) {
+    // Unrecognized level probably means this is a malformed log line
+    return false;
+  }
+
+  return {
+    level,
+    message
+  };
+}
+
+function parse(raw) {
+  for (let lcv = 0; lcv < parsers.length; lcv++) {
+    const match = parseRegex(raw, parsers[lcv]);
+    if (match) {
+      return match;
+    }
+  }
+
+  try {
+    const bunyanLogLine = JSON.parse(raw);
+    const level = BunyanLevelLookup[bunyanLogLine.level];
+    if (level) {
+      return {
+        level,
+        message: BunyanTag + bunyanLogLine.msg
+      };
+    }
+  } catch (e) {} // eslint-disable-line no-empty
+
+  return {
+    level: "info",
+    message: raw
+  };
+}
+
+module.exports = {
+  BunyanTag,
+  FyiTag,
+  parse
+};

--- a/packages/electrode-archetype-react-app-dev/lib/dev-admin/log-reader.js
+++ b/packages/electrode-archetype-react-app-dev/lib/dev-admin/log-reader.js
@@ -1,0 +1,96 @@
+"use strict";
+
+const AnsiConvert = require("ansi-to-html");
+const ck = require("chalker");
+const fs = require("fs");
+const readline = require("readline");
+const convert = new AnsiConvert();
+
+const DefaultMaxLevel = 6;
+
+const Levels = {
+  error: {
+    color: "red",
+    index: 0,
+    name: "error"
+  },
+  warn: {
+    color: "yellow",
+    index: 1,
+    name: "warn"
+  },
+  info: {
+    index: 2,
+    name: "info"
+  },
+  http: {
+    index: 3,
+    name: "http"
+  },
+  verbose: {
+    index: 4,
+    name: "verbose"
+  },
+  debug: {
+    index: 5,
+    name: "debug"
+  },
+  silly: {
+    index: 6,
+    name: "silly"
+  }
+};
+
+async function getLogsByLine(maxLevel = DefaultMaxLevel, handleLogLine) {
+  return new Promise((resolve) => {
+    const readInterface = readline.createInterface({
+      input: fs.createReadStream("archetype-debug.log")
+    });
+
+    readInterface.on("line", (event) => {
+      event = JSON.parse(event);
+      const levelInfo = Levels[event.level];
+      if (levelInfo.index > maxLevel) {
+        return;
+      }
+      handleLogLine(event);
+    });
+    readInterface.on("close", resolve);
+  });
+}
+
+async function getLogs(maxLevel = DefaultMaxLevel) {
+  const logs = [];
+  await getLogsByLine(maxLevel, (event) => logs.push(event));
+  return logs;
+}
+
+function getLogEventAsAnsi(event) {
+  const levelInfo = Levels[event.level];
+  const name = levelInfo.color
+    ? ck(`<${levelInfo.color}>${levelInfo.name}</>`)
+    : levelInfo.name;
+  return `${name}: ${event.message}`;
+}
+
+function getLogEventAsHtml(event) {
+  const levelInfo = Levels[event.level];
+  const name = levelInfo.color
+    ? `<span style="color: ${levelInfo.color}">${levelInfo.name}</span>`
+    : levelInfo.name;
+  return `${name}: ${convert.toHtml(event.message)}`;
+}
+
+// eslint-disable-next-line no-console
+async function displayLogs(maxLevel = DefaultMaxLevel, show = console.log) {
+  await getLogsByLine(maxLevel, (event) => show(getLogEventAsAnsi(event, show)));
+}
+
+module.exports = {
+  getLogsByLine,
+  getLogs,
+  getLogEventAsAnsi,
+  getLogEventAsHtml,
+  displayLogs,
+  Levels
+};

--- a/packages/electrode-archetype-react-app-dev/lib/dev-admin/log.html
+++ b/packages/electrode-archetype-react-app-dev/lib/dev-admin/log.html
@@ -1,0 +1,85 @@
+<html>
+  <body>
+    <div style="margin-bottom: 10px">
+      <button type="button" onclick="displayLogs();">Refresh</button>
+      <label>
+        <input type="checkbox" id="level.error" checked onclick="levelChangeHandler();" />
+        Error
+      </label>
+      <label>
+        <input type="checkbox" id="level.warn" checked onclick="levelChangeHandler();" />
+        Warn
+      </label>
+      <label>
+        <input type="checkbox" id="level.info" checked onclick="levelChangeHandler();" />
+        Info
+      </label>
+      <label>
+        <input type="checkbox" id="level.http" checked onclick="levelChangeHandler();" />
+        Http
+      </label>
+      <label>
+        <input type="checkbox" id="level.verbose" checked onclick="levelChangeHandler();" />
+        Verbose
+      </label>
+      <label>
+        <input type="checkbox" id="level.debug" checked onclick="levelChangeHandler();" />
+        Debug
+      </label>
+      <label>
+        <input type="checkbox" id="level.silly" checked onclick="levelChangeHandler();" />
+        Silly
+      </label>
+    </div>
+    <div style="border-radius: 10px; background: black; color: gray; padding: 10px;">
+      <pre style="white-space: pre-wrap;" id="logs"></pre>
+    </div>
+    <script>
+      let logs = [];
+      const el = document.getElementById("logs");
+      let lastLevelSelections;
+
+      function getLevelSelections() {
+        const levels = ["error", "warn", "info", "http", "verbose", "debug", "silly"];
+        const levelSelections = {};
+        levels.forEach((level) => {
+          const c = document.getElementById("level." + level);
+          levelSelections[level] = c.checked;
+        });
+        return levelSelections;
+      }
+
+      function resetLogView() {
+        logs = [];
+        el.innerHTML = "";
+      }
+
+      function appendLogView(message) {
+        el.innerHTML += message + "\n";
+      }
+
+      function levelChangeHandler() {
+        resetLogView();
+        displayLogs(getLevelSelections());
+      }
+
+      async function displayLogs(levelSelections) {
+        const logResponse = await fetch("/__electrode_dev/log-events");
+        let newLogs = await logResponse.json();
+        if (lastLevelSelections || !newLogs[0] || (logs[0] && newLogs[0].message !== logs[0].message)) {
+          resetLogView();
+        }
+        lastLevelSelections = levelSelections;
+        newLogs = newLogs.slice(logs.length);
+        newLogs.forEach((event) => {
+          if (levelSelections && !levelSelections[event.level]) {
+            return;
+          }
+          appendLogView(event.message);
+        });
+        logs = logs.concat(newLogs);
+      }
+      displayLogs();
+    </script>
+  </body>
+</html>

--- a/packages/electrode-archetype-react-app-dev/test/spec/dev-admin/log-parser.spec.js
+++ b/packages/electrode-archetype-react-app-dev/test/spec/dev-admin/log-parser.spec.js
@@ -1,0 +1,99 @@
+"use strict";
+
+const expect = require("chai").expect;
+const { BunyanTag, FyiTag, parse } = require("../../../lib/dev-admin/log-parser");
+
+describe("log-parser", function() {
+  it("should return correct level and message for a simple error", () => {
+    const raw = "error: Something unexpected happened";
+    const { level, message } = parse(raw);
+    expect(level).equal("error");
+    expect(message).equal("Something unexpected happened");
+  });
+
+  it("should return correct level and message for a simple info", () => {
+    const raw = "info: Totally normal thing happened";
+    const { level, message } = parse(raw);
+    expect(level).equal("info");
+    expect(message).equal("Totally normal thing happened");
+  });
+
+  it("should return the first level another level is detected midway through the message", () => {
+    const raw = "warn: An issue was detected in electrode error: Unable to load secrets file /secrets/ccm-secrets.json";
+    const { level, message } = parse(raw);
+    expect(level).equal("warn");
+    expect(message).equal("An issue was detected in electrode error: Unable to load secrets file /secrets/ccm-secrets.json");
+  });
+
+  it("should return correct level and message with badge for an FYI error", () => {
+    const raw = "FYI error: Something unexpected happened";
+    const { level, message } = parse(raw);
+    expect(level).equal("error");
+    expect(message).equal(`${FyiTag}Something unexpected happened`);
+  });
+
+  it("should return correct level and message with badge for an FYI info", () => {
+    const raw = "FYI info: Totally normal thing happened";
+    const { level, message } = parse(raw);
+    expect(level).equal("info");
+    expect(message).equal(`${FyiTag}Totally normal thing happened`);
+  });
+
+  it("should return error level and msg with badge for a node-bunyan level 50", () => {
+    const raw = JSON.stringify({
+      "name": "stdout",
+      "hostname": "localhost",
+      "pid": 131072,
+      "tags": ["error"],
+      "msg": "Electrode SOARI service discovery failed",
+      "level": 50,
+      "time": "2019-11-25T23:50:20.353Z"
+    });
+    const { level, message } = parse(raw);
+    expect(level).equal("error");
+    expect(message).equal(`${BunyanTag}Electrode SOARI service discovery failed`);
+  });
+
+  it("should return silly level and msg with badge for a node-bunyan level 10", () => {
+    const raw = JSON.stringify({
+      "name": "stdout",
+      "hostname": "localhost",
+      "pid": 131072,
+      "tags": ["silly"],
+      "msg": "The integers have been added together",
+      "level": 10,
+      "time": "2019-11-25T23:50:20.353Z"
+    });
+    const { level, message } = parse(raw);
+    expect(level).equal("silly");
+    expect(message).equal(`${BunyanTag}The integers have been added together`);
+  });
+
+  it("should return correct level and message with badge for an FYI warning and colon wrapped in color escape code", () => {
+    const raw = "\u001b[33mFYI warn:\u001b[39m electrode-ccm: Unable to load secrets file /secrets/ccm-secrets.json";
+    const { level, message } = parse(raw);
+    expect(level).equal("warn");
+    expect(message).equal(`${FyiTag}electrode-ccm: Unable to load secrets file /secrets/ccm-secrets.json`);
+  });
+
+  it("should preserve color escape codes in message but not in level", () => {
+    const raw = "\u001b[33msilly\u001b[39m: Electrode discoverWithSearch - \u001b[35mdiscovering\u001b[39m {\"environment\": \"qa\"}";
+    const { level, message } = parse(raw);
+    expect(level).equal("silly");
+    expect(message).equal("Electrode discoverWithSearch - \u001b[35mdiscovering\u001b[39m {\"environment\": \"qa\"}");
+  });
+
+  it("should return info for level and raw message for message if the log line has an unknown level", () => {
+    const raw = "fakelevel: Totally normal thing happened";
+    const { level, message } = parse(raw);
+    expect(level).equal("info");
+    expect(message).equal(raw);
+  });
+
+  it("should return info for level and raw message for message if the log line does not match any known format", () => {
+    const raw = "This - is! an? unrecognized# format@";
+    const { level, message } = parse(raw);
+    expect(level).equal("info");
+    expect(message).equal(raw);
+  });
+});

--- a/packages/electrode-archetype-react-app/lib/winston-logger.js
+++ b/packages/electrode-archetype-react-app/lib/winston-logger.js
@@ -18,12 +18,12 @@ const makeWinstonLogger = winston => {
     ],
     transports: [
       new winston.transports.Console({
-        level: "info",
+        level: "error",
         colorize: true,
         prettyPrint: true
       }),
       new winston.transports.File({
-        json: false,
+        json: true,
         maxsize: 10 * 1024 * 1024, // 10 MB
         maxFiles: 1,
         name: "archetype-debug-file",


### PR DESCRIPTION
- Change Winston logger to json mode for easy parsing
- Intercept stdout and stderr in the application server
  - Recognize the following log formats:
    - winston
    - electrode-fyi
    - node-bunyan
  - Attach badge for recognized log formats
  - Use Winston to log parsed message at appropriate log level
- Create a web interface for viewing logs
  - Filter by specific log levels (e.g. debug, info, error)
  - Refresh the logs to see the newest lines
  - Preserve console ansi coloring
- Create a console interface in the dev-admin server to display logs
  - Menu item to display all logs ("l")
  - Menu items to display only logs with at least a certain level ("0" - "6")