### PR TITLE
Subapp redux store sharing

### DIFF
--- a/packages/subapp-redux/src/index.jsx
+++ b/packages/subapp-redux/src/index.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, hydrate } from "react-dom";
 import { Provider } from "react-redux";
 import { loadSubApp } from "subapp-web";
-import { createStore } from "redux";
+import { getReduxCreateStore } from "./shared";
 export { hotReloadSubApp } from "subapp-web";
 
 //
@@ -61,12 +61,9 @@ export function reduxLoadSubApp(info) {
 
   if (!info.reduxCreateStore) {
     extras._genReduxCreateStore = "subapp";
-    if (info.reduxReducers) {
-      extras.reduxCreateStore = initialState => createStore(info.reduxReducers, initialState);
-    } else {
-      extras.reduxCreateStore = initialState => createStore(x => x, initialState || {});
-    }
   }
 
-  return loadSubApp(Object.assign(extras, info), renderStart);
+  return loadSubApp(Object.assign(extras, info, {
+    reduxCreateStore: getReduxCreateStore(info)
+  }), renderStart);
 }

--- a/packages/subapp-redux/src/shared.js
+++ b/packages/subapp-redux/src/shared.js
@@ -1,0 +1,66 @@
+const { combineReducers, createStore } = require("redux");
+
+const shared = typeof window !== "undefined" ? window : global;
+
+function clearSharedStore() {
+  delete shared.namedStores;
+}
+
+function getSharedStore(name) {
+  name = name === true ? "" : name;
+  shared.namedStores = shared.namedStores || {};
+  return shared.namedStores[name] || {};
+}
+
+function setSharedStore(name, contents) {
+  name = name === true ? "" : name;
+  shared.namedStores = shared.namedStores || {};
+  shared.namedStores[name] = contents;
+}
+
+function getReduxCreateStore(info) {
+  return function(initialState) {
+    if (info.reduxShareStore) {
+      let { store, reducers } = getSharedStore(info.reduxShareStore);
+      if (store) {
+        if (info.reduxReducers) {
+          if (typeof info.reduxReducers !== "object") {
+            throw "When using reduxShareStore to share stores, reduxReducers must be an object of named reducers.";
+          }
+          reducers = { ...reducers, ...info.reduxReducers };
+          const rootReducer = combineReducers(reducers);
+          store.replaceReducer(rootReducer);
+        }
+      } else if (info.reduxCreateStore) {
+        if (!store) {
+          store = info.reduxCreateStore(initialState);
+        }
+      } else {
+        if (typeof info.reduxReducers !== "object") {
+          throw "When using reduxShareStore to share stores, reduxReducers must be an object of named reducers.";
+        }
+        reducers = info.reduxReducers;
+        const rootReducer = combineReducers(reducers);
+        store = createStore(rootReducer, initialState);
+      }
+      setSharedStore(info.reduxShareStore, { store, reducers });
+      return store;
+    }
+
+    if (info.reduxCreateStore) {
+      return info.reduxCreateStore(initialState);
+    }
+
+    let reducer;
+    if (typeof info.reduxReducers === "function") {
+      reducer = info.reduxReducers;
+    } else if (typeof info.reduxReducers === "object") {
+      reducer = combineReducers(info.reduxReducers);
+    } else {
+      reducer = x => x;
+    }
+    return createStore(reducer, initialState);
+  };
+}
+
+module.exports = { getReduxCreateStore, getSharedStore, setSharedStore, clearSharedStore };

--- a/packages/subapp-redux/test/spec/index.spec.js
+++ b/packages/subapp-redux/test/spec/index.spec.js
@@ -1,11 +1,121 @@
 "use strict";
 
 const subappRedux = require("../..");
+const { getReduxCreateStore, clearSharedStore } = require("../../src/shared");
 const { getSubAppContainer } = require("subapp-util");
 
+const SimpleReducer = (x = true) => x;
+
 describe("subapp-redux", function() {
+  afterEach(() => {
+    clearSharedStore();
+  });
+
   it("should load redux subapp", () => {
     subappRedux.reduxLoadSubApp({ name: "foo" });
     expect(getSubAppContainer().foo).to.exist;
+  });
+
+  it("should create store based on reduxCreateStore if it is passed", () => {
+    const store = getReduxCreateStore({
+      reduxCreateStore: () => 5
+    })({});
+
+    expect(store).to.equal(5);
+  });
+
+  it("should use true reduxShareStore to name and persist primary store instance", () => {
+    const defaultStore = getReduxCreateStore({
+      reduxReducers: { a: SimpleReducer },
+      reduxShareStore: true
+    })({});
+
+    const defaultStore2 = getReduxCreateStore({
+      reduxReducers: { a: SimpleReducer },
+      reduxShareStore: true
+    })({});
+
+    expect(defaultStore).to.equal(defaultStore2);
+  });
+
+  it("should not conflate true reduxShareStore with named reduxShareStore", () => {
+    const defaultStore = getReduxCreateStore({
+      reduxReducers: { a: SimpleReducer },
+      reduxShareStore: true
+    })({});
+
+    const green = getReduxCreateStore({
+      reduxReducers: { a: SimpleReducer },
+      reduxShareStore: "green"
+    })({});
+
+    expect(defaultStore).to.not.equal(green);
+  });
+
+  it("should use string reduxShareStore to name and persist store instances", () => {
+    const blue = getReduxCreateStore({
+      reduxReducers: { a: SimpleReducer },
+      reduxShareStore: "blue"
+    })({});
+
+    const blue2 = getReduxCreateStore({
+      reduxReducers: { a: SimpleReducer },
+      reduxShareStore: "blue"
+    })({});
+
+    expect(blue).to.equal(blue2);
+  });
+
+  it("should not conflate two different reduxShareStore keys", () => {
+    const blue = getReduxCreateStore({
+      reduxReducers: { a: SimpleReducer },
+      reduxShareStore: "blue"
+    })({});
+
+    const green = getReduxCreateStore({
+      reduxReducers: { a: SimpleReducer },
+      reduxShareStore: "green"
+    })({});
+
+
+    expect(blue).to.not.equal(green);
+  });
+
+  it("should create and share a store based on reduxCreateStore", () => {
+    getReduxCreateStore({
+      reduxCreateStore: () => 5,
+      reduxShareStore: true
+    })({});
+
+    const store = getReduxCreateStore({
+      reduxShareStore: true
+    })({});
+
+    expect(store).to.equal(5);
+  });
+
+  it("should not allow functional reducers in a shared store", () => {
+    expect(() => {
+      getReduxCreateStore({
+        reduxReducers: x => x,
+        reduxShareStore: true
+      })({});
+    }).to.throw();
+  });
+
+  it("should combine named reducers when sharing a store", () => {
+    getReduxCreateStore({
+      reduxReducers: { pi: (x = 3.146) => x},
+      reduxShareStore: true
+    })({});
+
+    const store = getReduxCreateStore({
+      reduxReducers: { sqrt2: (x = 1.414) => x},
+      reduxShareStore: true
+    })({});
+
+    const state = store.getState();
+    expect(state.pi).to.equal(3.146);
+    expect(state.sqrt2).to.equal(1.414);
   });
 });


### PR DESCRIPTION
This introduces a new option for `reduxLoadSubApp` named `reduxShareStore`. This can be either `true` (to use the default store) or a string (to use a named store). When using a shared store, the `reduxReducers` option must be an object of named reducers so the system can properly merge them, or the store must use the `reduxCreateStore` option (which will ignore the `reduxReducers` attribute). 