### PR TITLE
transpile src to multi targets

### DIFF
--- a/packages/subapp-web/.babelrc.js
+++ b/packages/subapp-web/.babelrc.js
@@ -1,7 +1,13 @@
-module.exports = {
-  presets: [
-    ["@babel/env", { modules: "auto" }],
-    "@babel/react",
-    process.env.MINIFY ? "minify" : undefined
-  ].filter(x => x)
-};
+const envOpts = { modules: "auto" };
+
+if (process.env.BABEL_ENV === "src-node") {
+  Object.assign(envOpts, { targets: { node: "10" } });
+}
+
+const presets = [["@babel/env", envOpts], "@babel/react"];
+
+if (process.env.MINIFY) {
+  presets.push("minify");
+}
+
+module.exports = { presets };

--- a/packages/subapp-web/.gitignore
+++ b/packages/subapp-web/.gitignore
@@ -1,3 +1,4 @@
 browser
 dist
 *-lock.*
+node-dist

--- a/packages/subapp-web/lib/index.js
+++ b/packages/subapp-web/lib/index.js
@@ -4,7 +4,7 @@
 
 const { registerSubApp } = require("subapp-util");
 
-const { default: makeSubAppSpec } = require("../browser/make-subapp-spec");
+const { default: makeSubAppSpec } = require("../node-dist/make-subapp-spec");
 
 const { setupFramework } = require("./util");
 

--- a/packages/subapp-web/package.json
+++ b/packages/subapp-web/package.json
@@ -5,10 +5,10 @@
   "browser": "browser/index.js",
   "main": "lib/index.js",
   "scripts": {
-    "test": "clap check",
-    "coverage": "clap check",
-    "build": "clap -x -n compile minify",
-    "compile": "babel src -d browser --source-maps"
+    "test": "clap -x compile check",
+    "coverage": "clap -x compile check",
+    "build": "clap compile",
+    "prepublishOnly": "clap compile"
   },
   "keywords": [
     "web",
@@ -23,7 +23,8 @@
   "files": [
     "lib",
     "browser",
-    "dist"
+    "dist",
+    "node-dist"
   ],
   "dependencies": {
     "history": "^4.9.0",

--- a/packages/subapp-web/xclap.js
+++ b/packages/subapp-web/xclap.js
@@ -1,7 +1,17 @@
 const xclap = require("xclap");
+const { env, exec, concurrent } = xclap;
+
 xclap.load({
-  minify: xclap.exec("babel src -d dist --source-maps", {
-    execOptions: { env: { MINIFY: "true" } }
+  compile: concurrent("compile-browser", "compile-dist", "compile-node"),
+  "compile-browser": exec("babel src -d browser --delete-dir-on-start --source-maps", {
+    env: { BABEL_ENV: "src-browser" }
+  }),
+  "compile-dist": exec("babel src -d dist --delete-dir-on-start --source-maps", {
+    env: { MINIFY: "true", BABEL_ENV: "src-dist" }
+  }),
+  "compile-node": exec("babel src -d node-dist --delete-dir-on-start --source-maps", {
+    env: { BABEL_ENV: "src-node" }
   })
 });
+
 require("electrode-archetype-njs-module-dev")();


### PR DESCRIPTION
transpile the code in `src` to three targets:

1. `browser` - uniminify code meant for browser (for development)
2. `dist` - minified code for browser
3. `node-dist` - code for node.js
