### PR TITLE
Fixing electrode redirect issue (only returns 302). 

### DIFF
--- a/packages/electrode-react-webapp/lib/hapi/plugin16.js
+++ b/packages/electrode-react-webapp/lib/hapi/plugin16.js
@@ -28,7 +28,7 @@ const DefaultHandleRoute = (request, reply, handler, content, routeOptions) => {
         respond = reply(data);
       } else if (HttpStatus.redirect[status]) {
         respond = reply.redirect(data.path);
-        return respond;
+        return respond.code(status);
       } else if (status >= 200 && status < 300) {
         respond = reply(getDataHtml(data));
       } else if (routeOptions.responseForBadStatus) {

--- a/packages/electrode-react-webapp/lib/hapi/plugin17.js
+++ b/packages/electrode-react-webapp/lib/hapi/plugin17.js
@@ -28,7 +28,7 @@ const DefaultHandleRoute = (request, h, handler, content, routeOptions) => {
         respond = h.response(data);
       } else if (HttpStatus.redirect[status]) {
         respond = h.redirect(data.path);
-        return respond;
+        return respond.code(status);
       } else if (status >= 200 && status < 300) {
         respond = h.response(getDataHtml(data));
       } else if (routeOptions.responseForBadStatus) {


### PR DESCRIPTION
Summary:
Currently electrode returns 302 for any redirect response.
Added hapijs redirectcode to the response stream