### PR TITLE
fix(throw on missing stats.json)

### DIFF
--- a/packages/subapp-web/lib/util.js
+++ b/packages/subapp-web/lib/util.js
@@ -235,7 +235,11 @@ const utils = {
     try {
       stats = JSON.parse(Fs.readFileSync(Path.resolve(statsPath)).toString());
     } catch (err) {
-      return {};
+      throw new Error(
+        `Couldn't find stats.json at ${Path.resolve(
+          statsPath
+        )}. Please ensure environment is set up correctly. (Did you run 'clap dev'?)`
+      );
     }
 
     const assets = {};

--- a/packages/subapp-web/test/spec/util.spec.js
+++ b/packages/subapp-web/test/spec/util.spec.js
@@ -26,9 +26,10 @@ describe("loadAssetsFromStats", () => {
     expect(assets).to.not.have.own.property("manifest");
   });
 
-  it("should return empty assets if stats.json does not exist", () => {
-    const assets = loadAssetsFromStats("some path");
-    expect(assets).be.empty;
+  it("should throw if stats.json does not exist", () => {
+    expect(
+        () => loadAssetsFromStats("some path")
+    ).to.throw();
   });
 });
 


### PR DESCRIPTION
#problem 

the `loadAssetsFromStats` function will return an empty object when `stats.json` cannot be found. This results in undefined behavior downstream: see the code path in #1558 as an example.
Should this fail -- whether from unexpected behavior or invalid inputs, the error delivered to the end-user is unrelated to the original failure.

#solution 

Instead of preempting a file io error by returning an empty object, the function should throw with a helpful message. If consumers expect the file to be missing, the callsite should handle as necessary. Otherwise, the end-user get's an idea of what failed.

closes #1558 
