### PR TITLE
fix: add helpful output to admin console and dev proxy

### DIFF
--- a/packages/xarc-app-dev/lib/dev-admin/admin-server.js
+++ b/packages/xarc-app-dev/lib/dev-admin/admin-server.js
@@ -78,7 +78,7 @@ class AdminServer {
     const info = this.getServer(name);
     if (info._child) {
       info._child.once("exit", (code, signal) => {
-        this._io.show(ck`<orange>${name} exited code ${code} - signal ${signal}</orange>`);
+        this._io.show(ck`<orange>${name} (PID: ${info._child.pid}) exited code ${code} ${signal ? "- signal " + signal : ""}</orange>`);
         info._child = undefined;
         info._starting = false;
         this._webpackDevRelay.setAppServer(null);
@@ -421,7 +421,7 @@ ${info.name} - assuming it started.</>`);
         pendingMessages.push(data);
         return false;
       } else {
-        this._io.show(ck`<orange>${info.name} started</>`);
+        this._io.show(ck`<orange>${info.name} (PID: ${info._child.pid}) started</>`);
       }
 
       started = true;

--- a/packages/xarc-app-dev/lib/dev-admin/redbird-proxy.js
+++ b/packages/xarc-app-dev/lib/dev-admin/redbird-proxy.js
@@ -78,6 +78,22 @@ const makeUrl = (host, port, pathname = "", protocol = "http") => {
   });
 };
 
+// eslint-disable-next-line max-params
+const getLineForTree = (host) => (tree, [envVarName, port], idx, arr) => {
+  const boxChar = idx === arr.length - 1 ? "└" : "├";
+
+  return `${tree}  ${boxChar}─http://${host}:${port} (${envVarName.replace(/port/ig, "")})\n`;
+};
+
+const buildProxyTree = (options) => {
+  const {host, port} = options;
+  const portTree = Object.entries(options)
+                         .filter(([k]) => k !== "port" && k.match(/port/ig))
+                         .reduce(getLineForTree(host), "");
+
+  return `http://${host}:${port} (proxy) \n${portTree}`;
+};
+
 const startProxy = options => {
   options = Object.assign(
     {
@@ -204,9 +220,10 @@ ${rules
   }
 
   console.log(
-    ck`Electrode dev proxy server running, \
-status at <green>http://${host}:${options.port}/__proxy_admin/status</>`
-  );
+    ck`Electrode dev proxy server running:
+
+${buildProxyTree(options)}
+View status at <green>http://${host}:${options.port}/__proxy_admin/status</>`);
   console.log(ck`You can access your app at <green>http://${host}:${options.port}</>`);
 };
 


### PR DESCRIPTION
# problem

It's not immediately obvious from the dev-admin panel what processes are associated with what port. This can lead to some confusion, as outlined [here](https://github.com/electrode-io/electrode/issues/1559)

# solution 

Make the dev admin panel more transparent without being verbose, with things a dev will want/need to see at some point:

* Output pid alongside the process that's started / stopped, e.g.:
  * "your app server (PID: 59264) started"
  * "your app server (PID: 59264) exited code 0"
* Output tree to communicate proxy associations: 
  * <img width="513" alt="Screen Shot 2020-03-16 at 4 49 25 PM" src="https://user-images.githubusercontent.com/2519820/76808964-7d248980-67a6-11ea-894d-c84eb1d0fce9.png">

Additional Small change: 
 
* Removed signal reporting when falsy:
  * ""your app server exited code 0 ~signal: null~"

closes #1559 
