### PR TITLE
fix: remove content hash from chunk names

### DIFF
--- a/packages/subapp-web/lib/util.js
+++ b/packages/subapp-web/lib/util.js
@@ -56,9 +56,11 @@ const utils = {
     assert(entryPoints, `subapp-web: no entry point found for ${name}`);
 
     //
-    // Normal entry output bundles are generated as <entryName>.bundle[.dev].js, like header.bundle.js
+    // Normal entry output bundles are generated as <entryName>.bundle[.dev].js,
+    // like header.bundle.js
     // See xarc-webpack/lib/partial/[output, dev]
-    // The plugin SplitChunksPlugin generate chunks with name as <entryName>.~<hash>.bundle[.dev].js
+    // The plugin SplitChunksPlugin generate chunks with name as
+    // <entryName>.~<hash>.bundle[.dev].js
     // See xarc-webpack/lib/partial/subapp-chunks.js
     //
     const matchEntry = x => x.startsWith(`${entryName}.bundle`) || x.startsWith(`${entryName}.~`);

--- a/packages/subapp-web/lib/util.js
+++ b/packages/subapp-web/lib/util.js
@@ -55,12 +55,13 @@ const utils = {
     const entryPoints = assets.entryPoints[entryName];
     assert(entryPoints, `subapp-web: no entry point found for ${name}`);
 
-    // without webpack optimization.runtimeChunk the entry point bundles are generated
-    // as <entryName>.bundle.js, like header.bundle.js
-    // but with runtimeChunk, the entry point are generated with hash
-    // as <hash>.<entryName>.js
-    // So check both cases.
-    const matchEntry = x => x === `${entryName}.bundle.js` || x.endsWith(`.${entryName}.js`);
+    //
+    // Normal entry output bundles are generated as <entryName>.bundle[.dev].js, like header.bundle.js
+    // See xarc-webpack/lib/partial/[output, dev]
+    // The plugin SplitChunksPlugin generate chunks with name as <entryName>.~<hash>.bundle[.dev].js
+    // See xarc-webpack/lib/partial/subapp-chunks.js
+    //
+    const matchEntry = x => x.startsWith(`${entryName}.bundle`) || x.startsWith(`${entryName}.~`);
     // map all IDs to actual assets
     const bundleAssets = entryPoints
       .map(id => {

--- a/packages/xarc-webpack/lib/partials/dev.js
+++ b/packages/xarc-webpack/lib/partials/dev.js
@@ -69,7 +69,8 @@ module.exports = function() {
     devServer: devServerConfig,
     output: {
       publicPath: makePublicPath(),
-      filename: "[name].bundle.dev.js"
+      filename: "[name].bundle.dev.js",
+      chunkFilename: "[name].bundle.dev.js"
     },
     devtool: "inline-source-map",
     // TODO: why is this here and duplicates what's in extract-style partial?  This is causing

--- a/packages/xarc-webpack/lib/partials/output.js
+++ b/packages/xarc-webpack/lib/partials/output.js
@@ -31,9 +31,7 @@ module.exports = () => ({
     path: getOutputPath(),
     pathinfo: inspectpack, // Enable path information for inspectpack
     publicPath: "/js/",
-    chunkFilename: babel.hasMultiTargets
-      ? `${babel.target}.[contenthash].[name].js`
-      : "[contenthash].[name].js",
+    chunkFilename: getOutputFilename(),
     filename: getOutputFilename()
   }
 });

--- a/packages/xarc-webpack/lib/partials/subapp-chunks.js
+++ b/packages/xarc-webpack/lib/partials/subapp-chunks.js
@@ -16,7 +16,9 @@ function hashChunks(mod, chunks, key) {
     digest = hash.digest("hex");
     splitMap[id] = digest;
   }
-  return `${key}~${digest}`;
+  digest = digest.substr(-8);
+  // subapp-web/lib/util.js will try to match <entryName>.~ to detect subapp bundles
+  return `${key}.~${digest}`;
 }
 
 function makeConfig() {


### PR DESCRIPTION
content hash in dev mode is bad, because it breaks HMR.

So just remove content hash from chunk names all together.