### PR TITLE
fix: correct prepare args

### DIFF
--- a/docs/guides/subapps.md
+++ b/docs/guides/subapps.md
@@ -153,8 +153,8 @@ export default reduxLoadSubApp({
   Component: connect(mapStateToProps, dispatch => ({ dispatch }))(Demo2),
   name: "Demo2",
   reduxReducers,
-  prepare: ({ initialData }) => {
-    return Promise.resolve(initialData || { value: 999 });
+  prepare: ({ context, request }) => {
+    return Promise.resolve({ value: 999 });
   }
 });
 ```

--- a/packages/create-app/template/src/demo2/subapp-demo2.js
+++ b/packages/create-app/template/src/demo2/subapp-demo2.js
@@ -45,7 +45,7 @@ export default reduxLoadSubApp({
   Component: connect(mapStateToProps, dispatch => ({ dispatch }))(Demo2),
   name: "Demo2",
   reduxReducers,
-  prepare: ({ initialData }) => {
-    return Promise.resolve(initialData || { value: 999 });
+  prepare: ({ context, request }) => {
+    return Promise.resolve({ value: 999 });
   }
 });


### PR DESCRIPTION
# problem

default args specify `initialData`, but `{ context, request }` are actually passed

# solution

update to use `{ context, request }`