### PR TITLE
[patch] provide original error for debug purposes

### DIFF
--- a/packages/subapp-server/lib/setup-hapi-routes.js
+++ b/packages/subapp-server/lib/setup-hapi-routes.js
@@ -185,8 +185,10 @@ async function setupRoutesFromFile(srcDir, server, pluginOpts) {
 
         const data = context.result;
         const status = data.status;
-
-        if (status === undefined) {
+        if (data instanceof Error) {
+          // rethrow to get default error behavior below with helpful errors in dev mode
+          throw data;
+        } else if (status === undefined) {
           return h.response(data).type("text/html; charset=UTF-8").code(200);
         } else if (HttpStatus.redirect[status]) {
           return h.redirect(data.path).code(status);


### PR DESCRIPTION
Previously it simply ended up with 
```
Error: Cannot wrap an error
    at new module.exports (...@hapi/hoek/lib/error.js:23:19)
    at Object.module.exports [as assert] (...@hapi/hoek/lib/assert.js:20:11)
    at internals.Toolkit.response (...@hapi/hapi/lib/toolkit.js:174:14)
    at handler (...subapp-server/lib/setup-hapi-routes.js:189:14)
```

Now it would provide you with the underlying issue, such as

```
TypeError: Class constructor IndexPage cannot be invoked without 'new' at JsxRenderer._render (...electrode-react-webapp/lib/jsx/JsxRenderer.js:188:25) at handleElementResult (...electrode-react-webapp/lib/jsx/JsxRenderer.js:156:30) at JsxRenderer._render (/...electrode-react-webapp/lib/jsx/JsxRenderer.js:179:14) at Promise.each.then  etc etc
```
