### PR TITLE
added: mechanism to defer initial state read for sub apps

### DIFF
--- a/packages/subapp-web/lib/load.js
+++ b/packages/subapp-web/lib/load.js
@@ -282,7 +282,7 @@ ${dynInitialState}<script>${xarc}.startSubAppOnLoad({
  name:"${name}",
  ${elementId}serverSideRendering:${Boolean(props.serverSideRendering)},
  ${inlineStr}${groupStr}clientProps:${clientProps},
- initialState:${initialStateScript}
+ getInitialState:function(){return ${initialStateScript}}
 });</script>
 `);
       };


### PR DESCRIPTION
hey @jchip and @christianlent! I can't actually seem to get fyn bootstrap to run successfully, so i'm struggling to run tests, etc. 

So i figured I'd at least send this PR to clarify what I'm suggesting we do. 

Basically, this would allow us to run `instance.getInitialState()` and thereby defer the reading of that data instead of blocking on that with the inline script (as we discussed).