### PR TITLE
Must add babel-plugin-react-css-modules as a direct dependency

### DIFF
--- a/packages/xarc-app/package.json
+++ b/packages/xarc-app/package.json
@@ -30,6 +30,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.8.3",
+    "babel-plugin-react-css-modules": "^5.2.6",
     "css-modules-require-hook": "^4.0.2",
     "ignore-styles": "^5.0.1",
     "isomorphic-loader": "^3.1.0",


### PR DESCRIPTION
According to installation instructions

https://github.com/gajus/babel-plugin-react-css-modules#installation
> you must install babel-plugin-react-css-modules as a direct dependency of the project

It is still a part of electrode-archetype-opt-postcss as an optional dependency