### PR TITLE
fix: disable dev admin interactivity in CI

### DIFF
--- a/packages/xarc-app-dev/lib/dev-admin/admin-server.js
+++ b/packages/xarc-app-dev/lib/dev-admin/admin-server.js
@@ -14,9 +14,11 @@ const WebpackDevRelay = require("./webpack-dev-relay");
 const { displayLogs } = require("./log-reader");
 const { fork } = require("child_process");
 const ConsoleIO = require("./console-io");
+const AutomationIO = require("./automation-io");
 const winstonLogger = require("@xarc/app/lib/winston-logger");
 const winston = require("winston");
 const logger = winstonLogger(winston, false);
+const isCI = require("is-ci");
 const { doCleanup } = require("./cleanup");
 const xaa = require("xaa");
 const { formUrl } = require("../utils");
@@ -61,7 +63,8 @@ class AdminServer {
     // Any out-of-band writes to the terminal with process.stdout or console
     // will mess up the in place progress display that log-update handles
     //
-    this._io = (options && options.inputOutput) || new ConsoleIO();
+    this._io =
+      (options && options.inputOutput) || (isCI ? new AutomationIO("Dev Admin") : new ConsoleIO());
 
     this._shutdown = false;
     this._fullAppLogUrl = formUrl({ ...fullDevServer, path: controlPaths.appLog });

--- a/packages/xarc-app-dev/lib/dev-admin/admin-server.js
+++ b/packages/xarc-app-dev/lib/dev-admin/admin-server.js
@@ -63,8 +63,12 @@ class AdminServer {
     // Any out-of-band writes to the terminal with process.stdout or console
     // will mess up the in place progress display that log-update handles
     //
-    this._io =
-      (options && options.inputOutput) || (isCI ? new AutomationIO("Dev Admin") : new ConsoleIO());
+    const defaultIo = () => {
+      const autoIo = args.source.interactive === "cli" ? !args.source.interactive : isCI;
+      return autoIo ? new AutomationIO("Dev Admin") : new ConsoleIO();
+    };
+
+    this._io = (options && options.inputOutput) || defaultIo();
 
     this._shutdown = false;
     this._fullAppLogUrl = formUrl({ ...fullDevServer, path: controlPaths.appLog });

--- a/packages/xarc-app-dev/lib/dev-admin/automation-io.js
+++ b/packages/xarc-app-dev/lib/dev-admin/automation-io.js
@@ -1,0 +1,39 @@
+"use strict";
+
+/* eslint-disable no-console, no-process-exit */
+
+class AutomationIO {
+  constructor(name) {
+    console.log(`
+=================================================================================================
+= ${name} is using AutomationIO - There will be no interactivity and only stdout will be shown.
+=================================================================================================
+`);
+  }
+
+  setup() {}
+
+  async getUserInput() {
+    return new Promise(resolve => {
+      setTimeout(() => resolve({}), 500);
+    });
+  }
+
+  show(...args) {
+    console.log(...args);
+  }
+
+  write() {}
+
+  addItem() {}
+
+  updateItem() {}
+
+  removeItem() {}
+
+  exit() {
+    process.exit();
+  }
+}
+
+module.exports = AutomationIO;

--- a/packages/xarc-app-dev/lib/dev-admin/index.js
+++ b/packages/xarc-app-dev/lib/dev-admin/index.js
@@ -5,13 +5,22 @@ const NixClap = require("nix-clap");
 const parsed = new NixClap()
   .init({
     exec: {
-      type: "string"
+      type: "string",
+      desc: "program/js to execute as the app server"
     },
     ext: {
-      type: "string"
+      type: "string",
+      desc: "file extensions to watch"
     },
     watch: {
-      type: "string array"
+      type: "string array",
+      desc: "directories and files to watch"
+    },
+    interactive: {
+      alias: "int",
+      type: "boolean",
+      default: true,
+      desc: "disable interactivity (no-interactive to turn off)"
     }
   })
   .parse();

--- a/packages/xarc-app-dev/package.json
+++ b/packages/xarc-app-dev/package.json
@@ -62,6 +62,7 @@
     "filter-scan-dir": "^1.0.9",
     "fs-extra": "^0.30.0",
     "identity-obj-proxy": "^3.0.0",
+    "is-ci": "^2.0.0",
     "isomorphic-loader": "^3.1.0",
     "lodash": "^4.13.1",
     "log-update": "^4.0.0",


### PR DESCRIPTION
If `clap dev` is being used in CI env, then dev admin will not have interactivity capabilities enabled.

![Screen Shot 2020-06-11 at 9 48 00 AM](https://user-images.githubusercontent.com/5876741/84416320-e6127680-abc8-11ea-8fde-9605c564a49e.png)
