### PR TITLE
create-app: take app directory as argument

### DIFF
--- a/packages/xarc-create-app/package.json
+++ b/packages/xarc-create-app/package.json
@@ -34,6 +34,7 @@
     "@babel/core": "^7.6.2",
     "@babel/preset-env": "^7.6.2",
     "babel-loader": "^8.0.6",
+    "chalker": "^1.2.0",
     "lodash": "^4.17.15",
     "opfs": "^1.1.1",
     "prompts": "^2.3.2",

--- a/packages/xarc-create-app/src/check-dir.js
+++ b/packages/xarc-create-app/src/check-dir.js
@@ -2,13 +2,13 @@
 const Fs = require("opfs");
 const prompts = require("prompts");
 
-async function checkDir() {
+async function checkDir(dirName) {
   const existDirFiles = await Fs.readdir(process.cwd());
   if (existDirFiles.length > 0) {
     const response = await prompts({
       type: "confirm",
       name: "overwrite",
-      message: "Your directory is not empty, write to it?"
+      message: `Your directory '${dirName}' is not empty, write to it?`
     });
 
     return response.overwrite;

--- a/packages/xarc-create-app/src/create.js
+++ b/packages/xarc-create-app/src/create.js
@@ -6,9 +6,13 @@ const sortDeps = require("./sort-obj-keys");
 const checkDir = require("./check-dir");
 const makePkg = require("../template/_package");
 const _ = require("lodash");
+const prepareAppDir = require("./prep-app-dir");
+const ck = require("chalker");
 
 async function create() {
-  const dirOk = await checkDir();
+  const appDir = await prepareAppDir();
+  const dirOk = await checkDir(appDir);
+
   if (!dirOk) {
     console.log("bye");
     return;
@@ -28,7 +32,16 @@ async function create() {
   shcmd.cp("-R", Path.join(srcDir, "_gitignore"), Path.resolve(".gitignore"));
   shcmd.cp("-R", Path.join(srcDir, "README.md"), Path.resolve("README.md"));
 
-  console.log("created react/node webapp - please check README.md for info.");
+  console.log(ck`
+Created react/node webapp in directory '${appDir}'. To start development, please run:
+
+<cyan>cd ${appDir}
+npm install
+npm run dev</>
+
+For more info, please check the README.md file.
+
+`);
 }
 
 module.exports = create;

--- a/packages/xarc-create-app/src/create.js
+++ b/packages/xarc-create-app/src/create.js
@@ -14,7 +14,7 @@ async function create() {
   const dirOk = await checkDir(appDir);
 
   if (!dirOk) {
-    console.log("bye");
+    console.log(`Not able to write to directory '${appDir}'. bye.`);
     return;
   }
 

--- a/packages/xarc-create-app/src/prep-app-dir.js
+++ b/packages/xarc-create-app/src/prep-app-dir.js
@@ -1,0 +1,37 @@
+"use strict";
+
+const Fs = require("opfs");
+const Path = require("path");
+
+async function prepareAppDir() {
+  const appDirName = process.argv[2];
+  if (!appDirName) {
+    console.log(`
+Usage: @xarc/create-app <app-directory>
+
+  - pass '.' to use current directory
+`);
+    process.exit(1);
+  }
+
+  if (appDirName === ".") {
+    const dirName = Path.basename(process.cwd());
+    console.log(`Using current directory '${dirName}' to create @xarc/app`);
+    return dirName;
+  }
+
+  try {
+    await Fs.mkdir(appDirName);
+  } catch (err) {
+    if (err.code !== "EEXIST") {
+      console.log(`Failed to create app directory '${appDirName}'`);
+      process.exit(1);
+    }
+  }
+
+  process.chdir(appDirName);
+
+  return appDirName;
+}
+
+module.exports = prepareAppDir;

--- a/packages/xarc-create-app/template/_package.js
+++ b/packages/xarc-create-app/template/_package.js
@@ -30,18 +30,18 @@ module.exports = (base, merge) => {
       npm: ">= 6"
     },
     dependencies: {
-      "@xarc/app": "^8.1.1",
+      "@xarc/app": "^8.1.5",
       "@xarc/fastify-server": "^1.1.0",
-      react: "^16.13.1",
       "react-dom": "^16.13.1",
       "react-redux": "^7.2.0",
-      redux: "^4.0.5",
-      "subapp-react": "~0.0.18",
-      "subapp-redux": "^1.0.27",
-      "subapp-server": "^1.2.1"
+      "subapp-react": "~0.0.19",
+      "subapp-redux": "^1.0.28",
+      "subapp-server": "^1.2.2",
+      react: "^16.13.1",
+      redux: "^4.0.5"
     },
     devDependencies: {
-      "@xarc/app-dev": "^8.1.1"
+      "@xarc/app-dev": "^8.1.5"
     }
   };
 


### PR DESCRIPTION
simplify quick start instruction to be:

`npm init @xarc/app my-app`

further instruction will be shown by the create code.

```
Created react/node webapp in directory 'my-app'. To start development, please run:

cd my-app
npm install
npm run dev

For more info, please check the README.md file.
```