### PR TITLE
Hotpatch jsxrenderer

### DIFF
--- a/packages/subapp-server/package.json
+++ b/packages/subapp-server/package.json
@@ -28,8 +28,8 @@
   ],
   "dependencies": {
     "@hapi/boom": "^7.4.1",
-    "@xarc/webapp": "^1.0.0",
-    "@xarc/jsx-renderer": "^1.0.0",
+    "@xarc/webapp": "file:../xarc-webapp",
+    "@xarc/jsx-renderer": "file:../xarc-jsx-renderer",
     "filter-scan-dir": "^1.0.9",
     "http-status-codes": "^1.3.0",
     "optional-require": "^1.0.0",

--- a/packages/subapp-server/package.json
+++ b/packages/subapp-server/package.json
@@ -28,8 +28,8 @@
   ],
   "dependencies": {
     "@hapi/boom": "^7.4.1",
-    "@xarc/webapp": "file:../xarc-webapp",
-    "@xarc/jsx-renderer": "file:../xarc-jsx-renderer",
+    "@xarc/webapp": "../../packages/xarc-webapp",
+    "@xarc/jsx-renderer": "../../packages/xarc-jsx-renderer",
     "filter-scan-dir": "^1.0.9",
     "http-status-codes": "^1.3.0",
     "optional-require": "^1.0.0",

--- a/packages/xarc-webapp/package.json
+++ b/packages/xarc-webapp/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "xarc-webapp",
-  "version": "1.0.1",
+  "name": "@xarc/webapp",
+  "version": "0.0.1",
   "description": "",
   "main": "dist/index.js",
   "directories": {


### PR DESCRIPTION
changed the name, version, and incoming dependency path to be in line with other pre-publish package.