### PR TITLE
Loading subapps from a different repo

### DIFF
--- a/packages/subapp-server/lib/setup-hapi-routes.js
+++ b/packages/subapp-server/lib/setup-hapi-routes.js
@@ -115,8 +115,7 @@ function setupRouteRender({ subAppsByPath, srcDir, routeOptions }) {
       // else: assume dir under srcDir
       // TBD: handle it being a module
       if (x.indexOf("/") === -1) {
-        const xSrcDir = options.srcDir || "lib";
-        x = Path.resolve("node_modules", x, xSrcDir);
+        x = Path.dirname(require.resolve(`${x}`));
       }
       return {
         subapp: subAppsByPath[Path.isAbsolute(x) ? x : Path.resolve(srcDir, x)],

--- a/packages/subapp-server/lib/setup-hapi-routes.js
+++ b/packages/subapp-server/lib/setup-hapi-routes.js
@@ -112,9 +112,9 @@ function setupRouteRender({ subAppsByPath, srcDir, routeOptions }) {
         x = x[0];
       }
       // absolute: use as path
+      // is module: resolve module path
       // else: assume dir under srcDir
-      // TBD: handle it being a module
-      if (x.indexOf("/") === -1) {
+      if (options.module) {
         x = Path.dirname(require.resolve(`${x}/package.json`));
       }
       return {

--- a/packages/subapp-server/lib/setup-hapi-routes.js
+++ b/packages/subapp-server/lib/setup-hapi-routes.js
@@ -108,12 +108,16 @@ function setupRouteRender({ subAppsByPath, srcDir, routeOptions }) {
     routeOptions.__internals.subApps = [].concat(routeOptions.subApps).map(x => {
       let options = {};
       if (Array.isArray(x)) {
-        options = x[1];
+        options = x[1] || {};
         x = x[0];
       }
       // absolute: use as path
       // else: assume dir under srcDir
       // TBD: handle it being a module
+      if (x.indexOf("/") === -1) {
+        const xSrcDir = options.srcDir || "lib";
+        x = Path.resolve("node_modules", x, xSrcDir);
+      }
       return {
         subapp: subAppsByPath[Path.isAbsolute(x) ? x : Path.resolve(srcDir, x)],
         options

--- a/packages/subapp-server/lib/setup-hapi-routes.js
+++ b/packages/subapp-server/lib/setup-hapi-routes.js
@@ -108,14 +108,19 @@ function setupRouteRender({ subAppsByPath, srcDir, routeOptions }) {
     routeOptions.__internals.subApps = [].concat(routeOptions.subApps).map(x => {
       let options = {};
       if (Array.isArray(x)) {
-        options = x[1] || {};
+        options = x[1];
         x = x[0];
       }
       // absolute: use as path
       // module: resolve module path
       // else: assume dir under srcDir
-      if (options.module) {
-        x = Path.dirname(require.resolve(`${x}/package.json`));
+      if (!x.startsWith(".") && !x.startsWith("/")) {
+        const subAppPath = optionalRequire.resolve(x);
+        if (subAppPath) {
+          const { manifest, subAppOptions } = require(x);
+          x = manifest ? Path.dirname(subAppPath) : x;
+          options = subAppOptions || {};
+        }
       }
       return {
         subapp: subAppsByPath[Path.isAbsolute(x) ? x : Path.resolve(srcDir, x)],

--- a/packages/subapp-server/lib/setup-hapi-routes.js
+++ b/packages/subapp-server/lib/setup-hapi-routes.js
@@ -115,7 +115,7 @@ function setupRouteRender({ subAppsByPath, srcDir, routeOptions }) {
       // else: assume dir under srcDir
       // TBD: handle it being a module
       if (x.indexOf("/") === -1) {
-        x = Path.dirname(require.resolve(`${x}`));
+        x = Path.dirname(require.resolve(`${x}/package.json`));
       }
       return {
         subapp: subAppsByPath[Path.isAbsolute(x) ? x : Path.resolve(srcDir, x)],

--- a/packages/subapp-server/lib/setup-hapi-routes.js
+++ b/packages/subapp-server/lib/setup-hapi-routes.js
@@ -106,7 +106,7 @@ function setupRouteRender({ subAppsByPath, srcDir, routeOptions }) {
   // load subapps for the route
   if (routeOptions.subApps) {
     routeOptions.__internals.subApps = [].concat(routeOptions.subApps).map(x => {
-      let options = {};
+      let options;
       if (Array.isArray(x)) {
         options = x[1];
         x = x[0];
@@ -119,12 +119,12 @@ function setupRouteRender({ subAppsByPath, srcDir, routeOptions }) {
         if (subAppPath) {
           const { manifest, subAppOptions } = require(x);
           x = manifest ? Path.dirname(subAppPath) : x;
-          options = subAppOptions || {};
+          options = options || subAppOptions;
         }
       }
       return {
         subapp: subAppsByPath[Path.isAbsolute(x) ? x : Path.resolve(srcDir, x)],
-        options
+        options: options || {}
       };
     });
   }

--- a/packages/subapp-server/lib/setup-hapi-routes.js
+++ b/packages/subapp-server/lib/setup-hapi-routes.js
@@ -112,7 +112,7 @@ function setupRouteRender({ subAppsByPath, srcDir, routeOptions }) {
         x = x[0];
       }
       // absolute: use as path
-      // is module: resolve module path
+      // module: resolve module path
       // else: assume dir under srcDir
       if (options.module) {
         x = Path.dirname(require.resolve(`${x}/package.json`));

--- a/packages/subapp-util/lib/index.js
+++ b/packages/subapp-util/lib/index.js
@@ -184,7 +184,7 @@ function scanSubAppsFromDir(srcDir, maxLevel = Infinity) {
       try {
         const manifest = manifests[modName];
         validateModuleManifest(manifest);
-        const modFullDir = Path.dirname(require.resolve(`${modName}/package.json`));
+        const modFullDir = Path.dirname(require.resolve(modName));
         const subapp = Object.assign({ subAppDir: modName, module: true }, manifest);
         subApps[manifest.name] = subApps[MAP_BY_PATH_SYM][modFullDir] = subapp;
       } catch (error) {

--- a/packages/subapp-util/lib/index.js
+++ b/packages/subapp-util/lib/index.js
@@ -169,11 +169,10 @@ function scanSubAppsFromDir(srcDir, maxLevel = Infinity) {
       const manifests = es6Require(Path.join(fullSrcDir, module));
       Object.keys(manifests).forEach(modName => {
         const manifest = manifests[modName];
-        const modSrcDir = manifest.srcDir || "lib";
-        const modFullSrcDir = Path.resolve("node_modules", modName, modSrcDir);
+        const modFullDir = Path.dirname(require.resolve(`${modName}`));
         const subapp = Object.assign({ subAppDir: modName, module: true }, manifest);
-        scanSubAppAdditions(modFullSrcDir, subapp);
-        subApps[manifest.name] = subApps[MAP_BY_PATH_SYM][modFullSrcDir] = subapp;
+        scanSubAppAdditions(modFullDir, subapp);
+        subApps[manifest.name] = subApps[MAP_BY_PATH_SYM][modFullDir] = subapp;
       });
       return null;
     } catch (error) {
@@ -261,9 +260,8 @@ function loadSubAppByName(name) {
   const container = getSubAppContainer();
   const subAppDir = manifest.subAppDir;
   // load subapp's entry
-  const modSrcDir = manifest.srcDir || "lib";
   const fullSubappDir = manifest.module
-    ? Path.resolve("node_modules", subAppDir, modSrcDir)
+    ? Path.dirname(require.resolve(`${subAppDir}`))
     : Path.resolve(appSrcDir(), subAppDir);
 
   xrequire(Path.join(fullSubappDir, manifest.entry));
@@ -281,9 +279,8 @@ function loadSubAppServerByName(name) {
   const manifest = subAppManifest()[name];
   const { subAppDir, serverEntry } = manifest;
 
-  const modSrcDir = manifest.srcDir || "lib";
   const fullSubappDir = manifest.module
-    ? Path.resolve("node_modules", subAppDir, modSrcDir)
+    ? Path.dirname(require.resolve(`${subAppDir}`))
     : Path.resolve(appSrcDir(), subAppDir);
 
   if (serverEntry) {
@@ -304,9 +301,8 @@ function refreshSubAppByName(name) {
   const manifest = subAppManifest()[name];
   const { subAppDir } = manifest;
 
-  const modSrcDir = manifest.srcDir || "lib";
   const fullSubappDir = manifest.module
-    ? Path.resolve("node_modules", subAppDir, modSrcDir)
+    ? Path.dirname(require.resolve(`${subAppDir}`))
     : Path.resolve(appSrcDir(), subAppDir);
 
   const entryFullPath = xrequire.resolve(Path.join(fullSubappDir, manifest.entry));

--- a/packages/subapp-util/lib/index.js
+++ b/packages/subapp-util/lib/index.js
@@ -34,7 +34,9 @@ const validateModuleManifest = manifest => {
   const entries = _.pick(manifest, ["entry", "serverEntry", "reducers"]);
   Object.keys(entries).forEach(x => {
     if (!Path.isAbsolute(entries[x])) {
-      throw new Error(`Error: manifest ${x} requires absolute path`);
+      throw new Error(
+        `Could not resolve subapp ${x} "${entries[x]}". Please provide absolute path to the ${x} in subapp manifest`
+      );
     }
   });
 };

--- a/packages/subapp-util/lib/index.js
+++ b/packages/subapp-util/lib/index.js
@@ -35,7 +35,8 @@ const validateModuleManifest = manifest => {
   Object.keys(entries).forEach(x => {
     if (!Path.isAbsolute(entries[x])) {
       throw new Error(
-        `Could not resolve subapp ${x} "${entries[x]}". Please provide absolute path to the ${x} in subapp manifest`
+        `Could not resolve subapp ${x} "${entries[x]}".\
+ Please provide absolute path to the ${x} in subapp manifest`
       );
     }
   });

--- a/packages/xarc-webpack/lib/partials/entry.js
+++ b/packages/xarc-webpack/lib/partials/entry.js
@@ -11,6 +11,7 @@ const AppMode = archetype.AppMode;
 const chalk = require("chalk");
 const logger = require("@xarc/app/lib/logger");
 const mkdirp = require("mkdirp");
+const requireFromPath = require("require-from-path");
 
 const DEV_HMR_DIR = ".__dev_hmr";
 
@@ -52,9 +53,13 @@ function makeEntryPartial() {
   }
 
   function genSubAppHmrEntry(hmrDir, isDev, manifest) {
-    const modOutputDir = manifest.outputDir || "dist";
+    let moduleDir;
+    if (manifest.module) {
+      moduleDir = Path.dirname(require.resolve(`${manifest.subAppDir}`));
+    }
+
     let subAppReq = manifest.module
-      ? Path.resolve("node_modules", `${manifest.subAppDir}/${modOutputDir}/${manifest.entry}`)
+      ? requireFromPath(moduleDir).resolve(`./${manifest.entry}`)
       : `${manifest.subAppDir}/${manifest.entry}`;
 
     // subapp has built-in code to handle HMR accept
@@ -71,7 +76,7 @@ function makeEntryPartial() {
 
     if (manifest.reducers) {
       const subAppReducers = manifest.module
-        ? Path.resolve("node_modules", `${manifest.subAppDir}/${modOutputDir}/reducers`)
+        ? requireFromPath(moduleDir).resolve(`./${manifest.reducers}`)
         : `../${manifest.subAppDir}/reducers`;
       reducerHmrCode = `
 import { getReduxCreateStore } from "subapp-redux";

--- a/packages/xarc-webpack/lib/partials/entry.js
+++ b/packages/xarc-webpack/lib/partials/entry.js
@@ -11,7 +11,6 @@ const AppMode = archetype.AppMode;
 const chalk = require("chalk");
 const logger = require("@xarc/app/lib/logger");
 const mkdirp = require("mkdirp");
-const requireFromPath = require("require-from-path");
 
 const DEV_HMR_DIR = ".__dev_hmr";
 

--- a/packages/xarc-webpack/lib/partials/entry.js
+++ b/packages/xarc-webpack/lib/partials/entry.js
@@ -53,14 +53,7 @@ function makeEntryPartial() {
   }
 
   function genSubAppHmrEntry(hmrDir, isDev, manifest) {
-    let moduleDir;
-    if (manifest.module) {
-      moduleDir = Path.dirname(require.resolve(`${manifest.subAppDir}`));
-    }
-
-    let subAppReq = manifest.module
-      ? requireFromPath(moduleDir).resolve(`./${manifest.entry}`)
-      : `${manifest.subAppDir}/${manifest.entry}`;
+    let subAppReq = manifest.module ? manifest.entry : `${manifest.subAppDir}/${manifest.entry}`;
 
     // subapp has built-in code to handle HMR accept
     // or not running in webpack dev mode
@@ -76,7 +69,7 @@ function makeEntryPartial() {
 
     if (manifest.reducers) {
       const subAppReducers = manifest.module
-        ? requireFromPath(moduleDir).resolve(`./${manifest.reducers}`)
+        ? manifest.reducers
         : `../${manifest.subAppDir}/reducers`;
       reducerHmrCode = `
 import { getReduxCreateStore } from "subapp-redux";

--- a/packages/xarc-webpack/lib/partials/entry.js
+++ b/packages/xarc-webpack/lib/partials/entry.js
@@ -52,21 +52,27 @@ function makeEntryPartial() {
   }
 
   function genSubAppHmrEntry(hmrDir, isDev, manifest) {
-    let subAppReq = `${manifest.subAppDir}/${manifest.entry}`;
+    const modOutputDir = manifest.outputDir || "dist";
+    let subAppReq = manifest.module
+      ? Path.resolve("node_modules", `${manifest.subAppDir}/${modOutputDir}/${manifest.entry}`)
+      : `${manifest.subAppDir}/${manifest.entry}`;
+
     // subapp has built-in code to handle HMR accept
     // or not running in webpack dev mode
     // => do not generate HMR accept code
     if (manifest.hmrSelfAccept || !isDev) {
-      return `./${subAppReq}`;
+      return manifest.module ? subAppReq : `./${subAppReq}`;
     }
 
     const hmrEntry = `hmr-${manifest.subAppDir.replace(/[\/\\]/g, "-")}.js`;
-    subAppReq = `../${subAppReq}`;
+    subAppReq = manifest.module ? subAppReq : `../${subAppReq}`;
 
     let reducerHmrCode = "";
 
     if (manifest.reducers) {
-      const subAppReducers = `../${manifest.subAppDir}/reducers`;
+      const subAppReducers = manifest.module
+        ? Path.resolve("node_modules", `${manifest.subAppDir}/${modOutputDir}/reducers`)
+        : `../${manifest.subAppDir}/reducers`;
       reducerHmrCode = `
 import { getReduxCreateStore } from "subapp-redux";
 import reducers from "${subAppReducers}";

--- a/packages/xarc-webpack/package.json
+++ b/packages/xarc-webpack/package.json
@@ -42,7 +42,6 @@
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "optional-require": "^1.0.0",
     "require-at": "^1.0.2",
-    "require-from-path": "^1.0.4",
     "url-loader": "^0.6.2",
     "webpack": "^4.41.0",
     "webpack-config-composer": "^1.1.3",

--- a/packages/xarc-webpack/package.json
+++ b/packages/xarc-webpack/package.json
@@ -42,6 +42,7 @@
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "optional-require": "^1.0.0",
     "require-at": "^1.0.2",
+    "require-from-path": "^1.0.4",
     "url-loader": "^0.6.2",
     "webpack": "^4.41.0",
     "webpack-config-composer": "^1.1.3",

--- a/samples/demo-tree-shaking/package.json
+++ b/samples/demo-tree-shaking/package.json
@@ -55,6 +55,7 @@
     "lodash": "^4.17.10",
     "milligram": "^1.3.0",
     "react-intl": "^3.11.0",
+    "intl-format-cache": "4.2.46",
     "react-notify-toast": "^0.4.1",
     "react-router-config": "^5.1.1"
   },

--- a/samples/react-jest-app/package.json
+++ b/samples/react-jest-app/package.json
@@ -62,7 +62,7 @@
     "@xarc/app-dev": "^5.3.4",
     "electrode-archetype-opt-critical-css": "^1.0.3",
     "electrode-archetype-opt-eslint": "^1.0.3",
-    "electrode-archetype-opt-jest": "^25.0.0",
+    "electrode-archetype-opt-jest": "^26.0.0",
     "electrode-archetype-opt-less": "^1.0.2",
     "electrode-archetype-opt-mocha": "^1.0.3",
     "electrode-archetype-opt-phantomjs": "^1.0.2",
@@ -80,8 +80,7 @@
       "electrode-auto-ssr": "../../packages/electrode-auto-ssr"
     },
     "devDependencies": {
-      "@xarc/app-dev": "../../packages/xarc-app-dev",
-      "electrode-archetype-opt-jest": "../../packages/electrode-archetype-opt-jest"
+      "@xarc/app-dev": "../../packages/xarc-app-dev"
     }
   },
   "optionalDependencies": {}


### PR DESCRIPTION
Directory structure of individual subapps:

```
my-sub-app
├── README.md
├── package.json
├── src
........├── index.js
........├── subapp.js
........├── server.js
........├── reducers.js
```
Each subapp should be exporting the manifest and sub-app options as below

```
const subAppOptions = {
  serverSideRendering: false
};

const manifest = {
  type: "app",
  name: "Demo1",
  entry: require.resolve("./subapp"),
  serverEntry: require.resolve("./server"),
  reducers: require.resolve("./reducers")
};

module.exports = { subAppOptions, manifest `};
```

The users must provide absolute paths for `entry`, `serverEntry` and `reducers`
**Publishing** : The code must be transpiled to node executable format before publishing the package.

**Main app:**

Create a file named `subapps-modules.js` in `src` and export the manifests for all the subapp modules

```
const demo1 = require("demo1");
const demo2 = require("demo2");

module.exports = {
  demo1: demo1.manifest,
  demo2: demo2.manifest
};
```
Update the routes file to load the subapp module.

```
export default {
"/home": {
    pageTitle: "Welcome to home",
    subApps: ["demo1", "demo2"]
  }
}
```

Main app can also customize the options for subapp as below.

```
"/home": {
    pageTitle: "Welcome to home",
    subApps: [["demo1", subAppOptions], ["demo2", subAppOptions]]
  }
}
```