### PR TITLE
Fix the missing return. This was causing the issue in not invoking the route initialize method

### DIFF
--- a/packages/subapp-web/lib/init.js
+++ b/packages/subapp-web/lib/init.js
@@ -68,9 +68,9 @@ ${inlineRuntimeJS}
   // check if any subapp has server side code with initialize method and load them
   const { subApps } = setupContext.routeOptions.__internals;
   const subAppServers = subApps
-    .map(({ subapp }) => {
-      subappUtil.loadSubAppServerByName(subapp.name, false);
-    })
+    .map(({ subapp }) =>
+      subappUtil.loadSubAppServerByName(subapp.name, false)
+    )
     .filter(x => x && x.initialize);
 
   return {


### PR DESCRIPTION
Fixing the missing return statement. This was resulting in all the `initialize` method getting ignored.

cc @divyakarippath @jchip 