### PR TITLE
Set ui config to route options

### DIFF
--- a/packages/subapp-server/lib/fastify-plugin.js
+++ b/packages/subapp-server/lib/fastify-plugin.js
@@ -92,6 +92,8 @@ async function registerFastifyRoutesFromFile({ fastify, srcDir, routes, topOpts 
 
     const routeOptions = Object.assign({}, topOpts, route);
 
+    routeOptions.uiConfig = _.get(fastify, "settings.app.config.ui", {});
+
     const routeRenderer = routesFromFile.setupRouteTemplate({
       subAppsByPath,
       srcDir,
@@ -136,6 +138,8 @@ async function registerFastifyRoutesFromDir({ fastify, topOpts, routes }) {
       topOpts,
       _.pick(route, ["pageTitle", "bundleChunkSelector", "templateFile", "selectTemplate"])
     );
+
+    routeOptions.uiConfig = _.get(fastify, "settings.app.config.ui", {});
 
     assert(
       routeOptions.templateFile,

--- a/packages/subapp-server/lib/register-routes.js
+++ b/packages/subapp-server/lib/register-routes.js
@@ -26,6 +26,8 @@ module.exports = function registerRoutes({ routes, topOpts, server }) {
       _.pick(route, ["pageTitle", "bundleChunkSelector", "templateFile", "selectTemplate"])
     );
 
+    routeOptions.uiConfig = _.get(server, "settings.app.config.ui", {});
+
     assert(
       routeOptions.templateFile,
       `subapp-server: route ${routeInfo.name} must define templateFile`

--- a/packages/subapp-server/lib/setup-hapi-routes.js
+++ b/packages/subapp-server/lib/setup-hapi-routes.js
@@ -61,6 +61,8 @@ async function registerRoutesFromFile({ server, srcDir, routes, topOpts }) {
     const route = routes[path];
     const routeOptions = Object.assign({}, topOpts, route);
 
+    routeOptions.uiConfig = _.get(server, "settings.app.config.ui", {});
+
     // setup the template for rendering the route
     const routeRenderer = routesFromFile.setupRouteTemplate({
       subAppsByPath,


### PR DESCRIPTION
Fixes https://jira.walmart.com/browse/CEECORE-2000

Basepath was not getting updated in `@walmart/electrode-ui-config` which was causing the issue. Setting `uiConfig` in `routeOptions` will fix this.

In `@gtp/x-index`, dynamic data token handler will read the `uiConfig` from `routeOptions` and set it to `window._wml.config`. `@walmart/electrode-ui-config` reads the ui config and basepath from there and update the fullApiPath accordingly.