### PR TITLE
Fix CSS Modules generated scope name based on prod vs dev mode.

### DIFF
--- a/packages/xarc-app/src/index.ts
+++ b/packages/xarc-app/src/index.ts
@@ -83,9 +83,10 @@ export function load(
          */
         babelRegister?: any;
         /**
-         * if true, then load and setup CSS module runtime for node.js
+         * - boolean: if true, then load and setup CSS module runtime for node.js
+         * - object: options to be passed to cssModuleHook
          */
-        cssModuleHook?: boolean;
+        cssModuleHook?: boolean | object;
         /**
          * if no CSS module hook, then a default ignore hook is load to avoid errors
          * when trying to load CSS modules.
@@ -147,10 +148,10 @@ export function load(
    * https://github.com/webpack/css-loader#local-scope
    * https://github.com/css-modules/postcss-modules-scope
    */
-  if (options.cssModuleHook === true) {
+  if (options.cssModuleHook === true || Object.keys(options.cssModuleHook).length > 0) {
     const opts = Object.assign(
       {
-        generateScopedName: "[name]__[local]___[hash:base64:5]",
+        generateScopedName: `${process.env.NODE_ENV === "production" ? "" : "[name]__[local]___"}[hash:base64:5]`,
         extensions: [".scss", ".styl", ".less", ".css"],
         preprocessCss: function(css, filename) {
           if (filename.endsWith(".styl")) {


### PR DESCRIPTION
Issue: Currently css modules with SSR works only during dev mode. It is because the generated class name during ssr  (css-require-hook) vs webpack build uses different generated scope names.

Also, there is strict check for `options.cssModuleHook` as boolean but code expects an object to get the generated Scope name from user land. Users won't be able to override the generatedScopeName value.

Fix: Allow objects to be passed from users to control options passed to css module require hook and default to short names for production mode.

cc @jchip @divyakarippath 