### PR TITLE
await on RenderOutput::close()

### DIFF
--- a/packages/xarc-jsx-renderer/src/JsxRenderer.ts
+++ b/packages/xarc-jsx-renderer/src/JsxRenderer.ts
@@ -76,7 +76,7 @@ export class JsxRenderer {
       await each(this._beforeRenders, (r: any) => r.beforeRender(context));
       await this._render(this._template, context, 0, defer);
       await defer.promise;
-      const result = context.output.close();
+      const result = await context.output.close();
       await each(this._afterRenders, (r: any) => r.afterRender(context));
       context.result = context.isVoidStop ? context.voidResult : result;
       return context;


### PR DESCRIPTION
`RenderOutput::close()` returns a Promise in some use-cases. Hence need to `await` if calling it.
Otherwise the app might throw `Cannot wrap a promise` error.

`RenderOutput::close()` returns a promise in it's else part here: https://github.com/electrode-io/electrode/blob/28dea6de7ef88f07318274b25c1d9a42a046864e/packages/xarc-render-context/src/RenderOutput.ts#L73