### PR TITLE
Server side support for css modules

### DIFF
--- a/packages/xarc-app/package.json
+++ b/packages/xarc-app/package.json
@@ -40,7 +40,7 @@
     "babel-plugin-react-css-modules": "^5.2.6",
     "css-modules-require-hook": "^4.0.2",
     "ignore-styles": "^5.0.1",
-    "isomorphic-loader": "^4.0.5",
+    "isomorphic-loader": "^4.2.0",
     "optional-require": "^1.0.0",
     "subapp-util": "^1.1.1"
   },

--- a/packages/xarc-webpack/src/partials/extract-style.ts
+++ b/packages/xarc-webpack/src/partials/extract-style.ts
@@ -2,6 +2,7 @@
 import * as Path from "path";
 
 import { loadXarcOptions } from "../util/load-xarc-options";
+import { xAppRequire } from "@xarc/app";
 
 const detectCssModule = require("../util/detect-css-module");
 
@@ -24,6 +25,9 @@ const sassLoader = optSassRequire.resolve("sass-loader");
 // LESS support
 const optLessRequire = getOptRequire(["@xarc/opt-less", "electrode-archetype-opt-less"]);
 const lessLoader = optLessRequire.resolve("less-loader");
+
+// isomorphic-loader
+const isomorphicLoader = xAppRequire.resolve("isomorphic-loader");
 
 function loadPostCss() {
   const optPostcssRequire = getOptRequire(["@xarc/opt-postcss", "electrode-archetype-opt-postcss"]);
@@ -130,7 +134,7 @@ module.exports = function() {
       hmr: isDevelopment,
       reload: isDevelopment,
       publicPath: "",
-      esModule: true,
+      esModule: !isModule,
       modules: Boolean(isModule)
     }
   });
@@ -148,7 +152,11 @@ module.exports = function() {
     enableCssModule && {
       _name: `extract-css-modules`,
       test: /\.css$/,
-      use: [miniCssExtractLoader(true), ...getCssQueryUse(true)],
+      use: [
+        isomorphicLoader,
+        miniCssExtractLoader(true),
+        ...getCssQueryUse(true)
+      ],
       include: cssModuleRegExp
     }
   );
@@ -172,6 +180,7 @@ module.exports = function() {
         _name: `extract-css-modules-scss`,
         test: /\.(scss|sass)$/,
         use: [
+          isomorphicLoader,
           miniCssExtractLoader(true),
           ...getCssQueryUse(true).concat({ loader: sassLoader } as any)
         ],
@@ -197,7 +206,11 @@ module.exports = function() {
       enableCssModule && {
         _name: `extract-css-modules-stylus`,
         test: /\.styl$/,
-        use: [miniCssExtractLoader(true), ...getCssQueryUse(true).concat(stylusQuery)],
+        use: [
+          isomorphicLoader,
+          miniCssExtractLoader(true),
+          ...getCssQueryUse(true).concat(stylusQuery)
+        ],
         include: cssModuleRegExp
       }
     );
@@ -221,6 +234,7 @@ module.exports = function() {
         _name: `extract-css-modules-less`,
         test: /\.less$/,
         use: [
+          isomorphicLoader,
           miniCssExtractLoader(true),
           ...getCssQueryUse(true).concat({ loader: lessLoader } as any)
         ],


### PR DESCRIPTION
https://jira.walmart.com/browse/CEECORE-1960

To support below usage for css modules with SSR

```
import styles from "./demo1.module.css";
 
<div className={styles.demo1}>
```

Related PR - https://github.com/electrode-io/isomorphic-loader/pull/25