### PR TITLE
Fix dll loading issue inside  monorepo

### DIFF
--- a/packages/xarc-webpack/src/util/dll-util.ts
+++ b/packages/xarc-webpack/src/util/dll-util.ts
@@ -68,10 +68,10 @@ const verifyVersions = info => {
   Object.keys(versions).forEach(pkgDir => {
     const pkgInfo = versions[pkgDir];
     const modName = pkgInfo.name;
-    const pkgNmDir = Path.posix.join("node_modules", pkgDir);
+    const pkgNmDir = Path.dirname(require.resolve(`${modName}/package.json`));
     let pkg;
     try {
-      pkg = requireAt(Path.resolve(pkgNmDir), "./package.json");
+      pkg = requireAt(pkgNmDir, "./package.json");
     } catch (err) {
       logger.info(
         "Electrode DLL module",


### PR DESCRIPTION
Currently it assumes that packages are directly under `node_modules` of current directory.

Instead, use node module resolution to figure out the correct path for package dir.

Also, use `<package-name>/package.json` to handle the `main` and `browser` fields.

cc @jchip @divyakarippath 