### PR TITLE
pass default namespace to getBundleAssets inside cdn-map.js

### DIFF
--- a/packages/subapp-web/lib/init.js
+++ b/packages/subapp-web/lib/init.js
@@ -70,6 +70,8 @@ module.exports = function setup(setupContext) {
     });`;
   }
 
+  const namespaceScriptJs = namespace ? `window.__default__namespace="${namespace}";` : "";
+
   const scriptId = namespace ? namespace : "bundle";
 
   const webSubAppJs = `<script id="${scriptId}Assets" type="application/json">
@@ -77,6 +79,7 @@ ${JSON.stringify(bundleAssets)}
 </script>
 <script>/*LJ*/${loadJs}/*LJ*/
 ${webpackJsonpJS}
+${namespaceScriptJs}
 ${clientJs}
 ${cdnJs}
 ${inlineRuntimeJS}

--- a/packages/subapp-web/src/cdn-map.js
+++ b/packages/subapp-web/src/cdn-map.js
@@ -42,5 +42,5 @@
   };
 
   // initialize bundle assets
-  xv1.getBundleAssets();
+  xv1.getBundleAssets(w.__default__namespace);
 })(window);

--- a/packages/subapp-web/test/spec/init.spec.js
+++ b/packages/subapp-web/test/spec/init.spec.js
@@ -39,6 +39,7 @@ describe("init", function () {
     expect(context.user.assets).to.be.ok;
     expect(initJs).contains(`<script id="bundleAssets" type="application/json">`);
     expect(initJs).contains(`<script>/*LJ*/`);
+    expect(initJs).not.contains(`window.__default__namespace="testNameSpace";`);
   });
 
   it("should return assets as JSON script and loadJs for a given namespace", () => {
@@ -67,6 +68,7 @@ describe("init", function () {
     expect(context.user.assets).to.be.ok;
     expect(initJs).contains(`<script id="testNameSpaceAssets" type="application/json">`);
     expect(initJs).contains(`<script>/*LJ*/`);
+    expect(initJs).contains(`window.__default__namespace="testNameSpace";`);
   });
 
   it("it should load runtime.bundle.js inline and mark includedBundles.runtime to true", () => {


### PR DESCRIPTION
cdn map gets added only for deployed application. This helps in running app in standalone mode.

cc @jchip 