### PR TITLE
add unit test for xarc-subapp

### DIFF
--- a/packages/xarc-subapp/test/spec/browser/client-render-pipeline.spec.ts
+++ b/packages/xarc-subapp/test/spec/browser/client-render-pipeline.spec.ts
@@ -1,0 +1,60 @@
+import "jsdom-global/register";
+import { ClientRenderPipeline } from "../../../src/browser/client-render-pipeline";
+import { declareSubApp } from "../../../src/browser/index";
+import sinon from "sinon";
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+describe("client-render-pipeline", () => {
+  /* eslint-disable */
+  let spy1;
+  let spy2;
+  let subASRP;
+  let data;
+  before(() => {
+    spy1 = sinon.spy();
+    spy2 = sinon.spy();
+    const options = declareSubApp({
+      name: "test",
+      getModule: () => import("../../blah")
+    });
+
+    (options as any)._frameworkFactory = () => {
+      return {
+        prepareCSR: (data, that) => {
+          return {
+            then: cb => {
+              spy1();
+              cb(data);
+            }
+          };
+        },
+        startSubAppSync: spy2
+      };
+    };
+
+    data = {
+      ...options,
+      prepareOnly: false
+    };
+    subASRP = new ClientRenderPipeline(data);
+  });
+
+  it("ClientRenderPipeline", () => {
+    expect(subASRP).to.be.an("object");
+
+    subASRP.startPrepare();
+
+    expect(subASRP.waitForPrepare()).to.be.a("promise");
+    expect(subASRP.getPrepResult()).eql(data);
+    expect(subASRP.isPrepared()).true;
+    subASRP.executeRender();
+    expect(spy1.called).true;
+    expect(spy2.called).true;
+    expect(subASRP.start).to.be.an("function");
+    expect(subASRP._mount).to.be.an("function");
+    expect(subASRP._unmount).to.be.an("function");
+    expect(subASRP._reload).to.be.an("function");
+    /* eslint-enable */
+  });
+});

--- a/packages/xarc-subapp/test/spec/browser/index.spec.ts
+++ b/packages/xarc-subapp/test/spec/browser/index.spec.ts
@@ -8,6 +8,7 @@ import {
 import { envHooks } from "../../../src/subapp/index";
 import { describe, it } from "mocha";
 import { expect } from "chai";
+import sinon from "sinon";
 
 describe("browser index", () => {
   afterEach(() => {
@@ -51,6 +52,27 @@ describe("browser index", () => {
 
       expect(subapp._module).to.equal(mod);
       expect(mod.subapp.Component()).to.equal("hello"); // eslint-disable-line
+
+      const stub = sinon.stub().returns("testabc");
+      subapp._renderPipelines = [
+        { csrData: { inlineId: "test1" } } as any,
+        { csrData: { inlineId: "test2" } } as any
+      ];
+      subapp._pipelineFactory = (obj => {
+        return {
+          start: stub
+        };
+      }) as any;
+      expect(
+        subapp._start({
+          csrData: {
+            inlineId: "test1"
+          }
+        } as any)
+      ).eql("testabc");
+
+      //  eslint-disable-next-line
+      expect(stub.called).true;
     });
   });
 

--- a/packages/xarc-subapp/test/spec/browser/xarc-cdn-map.spec.ts
+++ b/packages/xarc-subapp/test/spec/browser/xarc-cdn-map.spec.ts
@@ -5,14 +5,19 @@ import { describe, it } from "mocha";
 import { expect } from "chai";
 require("jsdom-global")("", { url: "https://localhost/" }); //  eslint-disable-line
 
-const mockWindow = Object.assign({}, window);
+let mockWindow;
 describe("xarcCdnMap", () => {
+  beforeEach(() => {
+    mockWindow = Object.assign({}, window);
+  });
+
   it("should xarcCdnMap return undefined when window not having xarcV2 attribute", () => {
     expect(xarcCdnMap(mockWindow)).undefined; //  eslint-disable-line
   });
 
   it("should xarcCdnMap add subapp2 global attribute and method on window object", () => {
     xarcV2Client(mockWindow);
+    mockWindow._wml = undefined;
     xarcCdnMap(mockWindow);
     const xarcV2 = (mockWindow as any).xarcV2;
     expect(xarcV2).to.be.an("object");
@@ -24,5 +29,39 @@ describe("xarcCdnMap", () => {
     expect((mockWindow as any)._wml.cdn.md)
       .equal(xarcV2.rt.md)
       .eql({});
+  });
+
+  it("should cdnUpdate", () => {
+    xarcV2Client(mockWindow);
+    xarcCdnMap(mockWindow);
+    const xarcV2 = (mockWindow as any).xarcV2;
+    xarcV2.rt = { md: {} };
+    xarcV2.cdnUpdate(
+      {
+        md: {
+          a: "1",
+          b: "2"
+        }
+      },
+      true
+    );
+
+    expect(xarcV2.rt.md).eql({
+      a: "1",
+      b: "2"
+    });
+  });
+
+  it("should cdnMap return CDN URL for key in the mapping", () => {
+    xarcV2Client(mockWindow);
+    xarcCdnMap(mockWindow);
+    const xarcV2 = (mockWindow as any).xarcV2;
+    xarcV2.rt = {
+      md: {
+        file: "content"
+      }
+    };
+    expect(xarcV2.cdnMap("file2")).eql(undefined);
+    expect(xarcV2.cdnMap("file")).eql("content");
   });
 });

--- a/packages/xarc-subapp/test/spec/browser/xarc-subapp-v2.spec.ts
+++ b/packages/xarc-subapp/test/spec/browser/xarc-subapp-v2.spec.ts
@@ -3,14 +3,17 @@ import { xarcV2Client } from "../../../src/browser/xarc-subapp-v2";
 import { describe, it } from "mocha";
 import { expect } from "chai";
 require("jsdom-global")("", { url: "https://localhost/" }); //  eslint-disable-line
+import { declareSubApp, getContainer } from "../../../src/browser";
 
-const mockWindow = Object.assign({}, window);
+let mockWindow;
 let xarcV2;
 describe("xarcV2Client", () => {
   before(() => {
+    mockWindow = Object.assign({}, window);
     xarcV2Client(mockWindow);
     xarcV2 = (mockWindow as any).xarcV2;
   });
+
   it("should xarcV2Client add attributes on window object", () => {
     expect(xarcV2).to.be.an("object");
     expect(xarcV2.IS_BROWSER).true; //  eslint-disable-line
@@ -36,5 +39,47 @@ describe("xarcV2Client", () => {
     expect(xarcV2.start).to.be.a("function");
     expect(xarcV2.dyn).to.be.a("function");
     expect(xarcV2.debug).to.be.a("function");
+  });
+
+  it("should xarcV2Client methods works correctly", () => {
+    expect(xarcV2.cdnMap("123")).eql("123");
+    expect(xarcV2.getOnLoadStart("test")).eql([]);
+    expect(xarcV2.start()).to.be.a("promise");
+    expect(xarcV2.dyn("id-1")).eql({});
+    expect(xarcV2.debug()).eql(undefined);
+  });
+
+  it("should addOnLoadStart", () => {
+    xarcV2.addOnLoadStart("test", "load");
+    expect(xarcV2.rt.onLoadStart).eql({ test: ["load"] });
+  });
+
+  it("should startSubAppOnLoad", () => {
+    xarcV2.rt.onLoadStart = {};
+    xarcV2.startSubAppOnLoad({ name: "test1" }, { a: "1", b: "2" });
+    expect(xarcV2.rt.onLoadStart).eql({
+      test1: [
+        {
+          a: "1",
+          b: "2",
+          name: "test1"
+        }
+      ]
+    });
+  });
+
+  it("should start", () => {
+    expect(xarcV2.start()).to.be.a("promise");
+
+    const container = getContainer();
+    const subapp = declareSubApp({
+      name: "test",
+      getModule: () => import("../../blah")
+    });
+    mockWindow = Object.assign({}, window);
+    xarcV2Client(mockWindow);
+    mockWindow._subapps = container;
+    xarcV2 = (mockWindow as any).xarcV2;
+    expect(xarcV2.start()).to.be.a("promise");
   });
 });

--- a/packages/xarc-subapp/test/spec/node/render-page.spec.ts
+++ b/packages/xarc-subapp/test/spec/node/render-page.spec.ts
@@ -1,0 +1,55 @@
+import { PageRenderer } from "../../../src/node/render-page";
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+describe("render-page", () => {
+  it("PageRenderer init successfully", async () => {
+    const pageOptions = {
+      prodAssetData: {
+        cdnMap: "mock-cdn-address",
+        pathMap: {
+          base: "mock-map-base",
+          a: "test-a"
+        }
+      },
+      devAssetData: {
+        cdnMap: "mock-cdn-address",
+        pathMap: {
+          base: "mock-map-base",
+          b: "test-b"
+        },
+        nonce: true,
+        namespace: "ns1"
+      },
+      subApps: [
+        {
+          name: "not-exist1",
+          ssr: true
+        },
+        {
+          name: "not-exist2"
+        }
+      ],
+      pageTitle: "test-page-title",
+      favicon: "test-icon",
+      charSet: "UTF-8",
+      templateInserts: {
+        head: {
+          begin: ["<link>test-link1</link>", "<link>test-link2</link>"],
+          contextReady: ["<p>test-context-ready1</p>", "<p>test-context-ready2</p>"],
+          end: ["<style>test-style1</style>", "<style>test-style2</style>"],
+          afterInit: ["<script>test-script1</script>", "<script>test-script2</script>"]
+        },
+        body: {
+          begin: ["<h1>Head1</h1>", "<h2>Head2</h2>"],
+          end: ["<foot>foot1</foot>", "<foot>foot2</foot>"],
+          beforeStart: ["<p>p1</p>", "<p>p2</p>"],
+          afterStart: ["<p>p3</p>", "<p>p4</p>"]
+        }
+      }
+    };
+    const pageRenderer = new PageRenderer(pageOptions);
+    expect(pageRenderer._getSSRSubAppNames()).eql(["not-exist1"]);
+    expect(pageRenderer.render({})).to.be.a("Promise");
+  });
+});

--- a/packages/xarc-subapp/test/spec/node/server-render-pipeline.spec.ts
+++ b/packages/xarc-subapp/test/spec/node/server-render-pipeline.spec.ts
@@ -1,0 +1,60 @@
+import { SubAppServerRenderPipeline } from "../../../src/node/server-render-pipeline";
+import { declareSubApp } from "../../../src/node/index";
+import sinon from "sinon";
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+describe("sever-render-pipeline", () => {
+  it("SubAppServerRenderPipeline", () => {
+    const spy1 = sinon.spy();
+    const spy2 = sinon.spy();
+    const options = declareSubApp({
+      name: "test",
+      getModule: () => import("../../blah")
+    });
+
+    const data = {
+      context: {
+        output: {
+          reserve: () => {
+            return {
+              add: spy1,
+              close: spy2
+            };
+          }
+        },
+        user: {
+          namespace: "test-namespace",
+          scriptNonceAttr: "nonce-test"
+        }
+      },
+      subapp: {
+        ...options,
+        _frameworkFactory: () => {
+          return {
+            prepareSSR: data1 => {
+              return {
+                then: cb => cb(data1)
+              };
+            }
+          };
+        }
+      },
+      options: options
+    };
+    const subASRP = new SubAppServerRenderPipeline(data);
+
+    expect(subASRP).to.be.an("object");
+
+    subASRP.startPrepare();
+
+    expect(subASRP.waitForPrepare()).to.be.a("promise");
+    expect(subASRP.getPrepResult()).eql(data);
+    /*  eslint-disable  */
+    expect(subASRP.isPrepared()).to.be.true;
+    subASRP.executeRender();
+    expect(spy1.called).true;
+    expect(spy2.called).true;
+    /*  eslint-enable  */
+  });
+});

--- a/packages/xarc-subapp/test/spec/node/start-v2.spec.ts
+++ b/packages/xarc-subapp/test/spec/node/start-v2.spec.ts
@@ -1,0 +1,44 @@
+import { startSubApp } from "../../../src/node/start-v2";
+import { SSR_PIPELINES } from "../../../src/node/utils";
+import sinon from "sinon";
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+describe("start-v2", () => {
+  it("startSubApp", () => {
+    const sSA = startSubApp();
+    expect(sSA).to.be.an("object");
+    const mockPSubAppFRes = new Promise((resolve, reject) => {
+      resolve({
+        Component: "test-component",
+        props: "test-props"
+      });
+    });
+    const context = {
+      user: {
+        scriptNonceAttr: "test-nonce",
+        request: {
+          [SSR_PIPELINES]: [
+            {
+              /* eslint-disable */
+              startPrepare: () => {},
+              waitForPrepare: () => mockPSubAppFRes,
+              isPrepared: () => false,
+              getPrepResult: () => {},
+              executeRender: sinon.spy(),
+              start: reload => new Promise((resolve, reject) => {}),
+              _reload: () => new Promise((resolve, reject) => {}),
+              _mount: info => {},
+              _unmount: info => {}
+              /* eslint-enable */
+            }
+          ]
+        }
+      }
+    };
+    expect(sSA.process(context)).eql(
+      `<!-- Starting SubApp -->\n<scripttest-nonce>window.xarcV2.start()</script>\n`
+    );
+    // expect(context.user.request[SSR_PIPELINES][0].executeRender.called).equal(true);
+  });
+});

--- a/packages/xarc-subapp/test/spec/node/xarc-subapp-v2-node.spec.ts
+++ b/packages/xarc-subapp/test/spec/node/xarc-subapp-v2-node.spec.ts
@@ -1,0 +1,25 @@
+import { xarcV2 } from "../../../src/node/xarc-subapp-v2-node";
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+describe("xarc-subapp-v2-node", () => {
+  it("xarcV2", () => {
+    expect(xarcV2).to.be.an("object");
+    /*  eslint-disable  */
+    expect(xarcV2.IS_BROWSER).false;
+    expect(xarcV2.HAS_WINDOW).false;
+    /*  eslint-enable  */
+
+    expect(xarcV2.version).eql(2000000);
+    expect(xarcV2.rt).eql({});
+    expect(xarcV2.cdnInit).to.be.a("function");
+    expect(xarcV2.cdnUpdate).to.be.a("function");
+    expect(xarcV2.addOnLoadStart).to.be.a("function");
+    expect(xarcV2.startSubAppOnLoad).to.be.a("function");
+    expect(xarcV2.dyn).to.be.a("function");
+    expect(xarcV2.debug).to.be.a("function");
+    expect(xarcV2.cdnMap("123")).eql("123");
+    expect(xarcV2.getOnLoadStart("name")).eql([]);
+    expect(xarcV2.start()).to.be.a("promise");
+  });
+});


### PR DESCRIPTION
----------------------------|---------|----------|---------|---------|------------------------------
File                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s            
----------------------------|---------|----------|---------|---------|------------------------------
All files                   |   83.13 |    73.04 |   70.13 |   83.12 |                              
 browser                    |   69.19 |    47.83 |   63.27 |   69.44 |                              
  client-render-pipeline.ts |   78.26 |        0 |   66.67 |   78.26 | 26-29,74                     
  index.ts                  |   57.14 |       45 |   35.71 |   57.38 | 114-158                      
  webpack4-jsonp.ts         |     100 |      100 |     100 |     100 |                              
  xarc-cdn-map.ts           |      96 |       75 |     100 |   95.83 | 27                           
  xarc-subapp-v2.ts         |   65.22 |    37.93 |   66.67 |   65.67 | ...0,159-163,168-171,193-197 
  xarcv2.ts                 |     100 |      100 |     100 |     100 |                              
 node                       |   90.17 |    86.21 |   78.95 |   90.11 |                              
  index.ts                  |   85.42 |      100 |   64.29 |   83.33 | 54-68                        
  init-context.ts           |     100 |      100 |     100 |     100 |                              
  init-v2.ts                |   98.46 |    96.88 |   92.31 |   98.46 | 100                          
  load-v2.ts                |     100 |      100 |     100 |     100 |                              
  render-page.ts            |      72 |    42.86 |   85.71 |   72.73 | 93-106                       
  server-render-pipeline.ts |   74.36 |    42.86 |    87.5 |   74.36 | 53,89-91,95-97,104-109       
  start-v2.ts               |     100 |    33.33 |     100 |     100 | 11-17                        
  utils.ts                  |     100 |      100 |     100 |     100 |                              
  webpack-stats.ts          |   92.86 |      100 |   83.33 |   92.31 | 42                           
  xarc-subapp-v2-node.ts    |   66.67 |       50 |   36.36 |   66.67 | 46,57-59                     
 subapp                     |   88.76 |    77.78 |   58.62 |   88.64 |                              
  client-render-pipeline.ts |   36.36 |      100 |    9.09 |   36.36 | 38-66                        
  envhooks.ts               |     100 |      100 |     100 |     100 |                              
  index.ts                  |    97.5 |    88.89 |   83.33 |    97.5 | 52                           
  subapp-ready.ts           |    91.3 |    56.25 |   83.33 |   90.91 | 80-81                        
  types.ts                  |     100 |      100 |     100 |     100 |                              
----------------------------|---------|----------|---------|---------|------------------------------

=============================== Coverage summary ===============================
Statements   : 83.13% ( 473/569 )
Branches     : 73.04% ( 168/230 )
Functions    : 70.13% ( 108/154 )
Lines        : 83.12% ( 458/551 )
================================================================================

