### PR TITLE
enable extra module for remote entry to support CDN mapping

### DIFF
--- a/packages/xarc-react-query/test/spec/browser-index.spec.tsx
+++ b/packages/xarc-react-query/test/spec/browser-index.spec.tsx
@@ -81,7 +81,7 @@ describe("reactQueryFeature browser", function () {
 
     const element = await waitFor(() => screen.getByText("test"), { timeout: 500 });
 
-    expect(element.innerHTML).contains(`<p>{"msg":"foo","queryKey":["test"]}</p>`);
+    expect(element.innerHTML).contains(`<p>{"msg":"foo","queryKey":"test"}</p>`);
   });
 
   it("should render subapp with react-query when input component does not exist", async () => {

--- a/packages/xarc-react-query/test/spec/node-index.spec.tsx
+++ b/packages/xarc-react-query/test/spec/node-index.spec.tsx
@@ -79,7 +79,7 @@ describe("reactQueryFeature node.js", function () {
     const str = renderToString(<result.Component />);
 
     expect(str).equals(
-      `<div>test <p>{&quot;msg&quot;:&quot;foo&quot;,&quot;queryKey&quot;:[&quot;test&quot;]}</p></div>`
+      `<div>test <p>{&quot;msg&quot;:&quot;foo&quot;,&quot;queryKey&quot;:&quot;test&quot;}</p></div>`
     );
   });
 
@@ -126,7 +126,7 @@ describe("reactQueryFeature node.js", function () {
 
     const element = await waitFor(() => screen.getByText("test"), { timeout: 500 });
 
-    expect(element.innerHTML).equal(`test <p>{"msg":"foo","queryKey":["test"]}</p>`);
+    expect(element.innerHTML).equal(`test <p>{"msg":"foo","queryKey":"test"}</p>`);
   });
 
   it("should render subapp with react-query if it fails on fetching data when doing SSR", async () => {
@@ -173,7 +173,7 @@ describe("reactQueryFeature node.js", function () {
 
     const element = await waitFor(() => screen.getByText("test"), { timeout: 500 });
 
-    expect(element.innerHTML).contains(`<p>{"msg":"foo","queryKey":["test"]}</p>`);
+    expect(element.innerHTML).contains(`<p>{"msg":"foo","queryKey":"test"}</p>`);
   });
 
   it("should render subapp with react-query when input component does not exist", async () => {

--- a/packages/xarc-webpack/package.json
+++ b/packages/xarc-webpack/package.json
@@ -51,8 +51,8 @@
     "optional-require": "^1.0.2",
     "require-at": "^1.0.6",
     "url-loader": "^4.1.0",
-    "webpack": "^5.24.3",
-    "webpack-cli": "^4.5.0",
+    "webpack": "^5.33.2",
+    "webpack-cli": "^4.6.0",
     "webpack-config-composer": "^1.1.3",
     "webpack-stats-plugin": "^1.0.3",
     "xsh": "^0.4.5"

--- a/packages/xarc-webpack/src/client/webpack5-jsonp-cdn.ts
+++ b/packages/xarc-webpack/src/client/webpack5-jsonp-cdn.ts
@@ -16,8 +16,14 @@ function setup(w: any) {
   const originalPublicPath = __webpack_public_path__;
   __webpack_public_path__ = "";
 
+  const xarc = w.xarcV2 || w.xarcV1;
+
+  if (xarc && typeof __remoteCdnMapping !== "undefined") {
+    xarc.cdnUpdate({ md: __remoteCdnMapping });
+  }
+
   const getCdnMapSrc = originalSrc => {
-    const src = w.xarcV2 && w.xarcV2.cdnMap(originalSrc);
+    const src = xarc && xarc.cdnMap(originalSrc);
     return src && src !== originalSrc ? src : null;
   };
 

--- a/packages/xarc-webpack/src/container/ContainerPlugin.ts
+++ b/packages/xarc-webpack/src/container/ContainerPlugin.ts
@@ -3,29 +3,31 @@
 	Author Tobias Koppers @sokra, Zackary Jackson @ScriptedAlchemy, Marais Rossouw @maraisr
 */
 
-"use strict";
+/* eslint-disable */
 
-const { validate } = require("schema-utils");
-const schema = require("../../schemas/plugins/container/ContainerPlugin.json");
-const ContainerEntryDependency = require("./ContainerEntryDependency");
-const ContainerEntryModuleFactory = require("./ContainerEntryModuleFactory");
-const ContainerExposedDependency = require("./ContainerExposedDependency");
-const { parseOptions } = require("./options");
+// const { validate } = require("schema-utils");
+// const schema = require("webpack/schemas/plugins/container/ContainerPlugin.json");
+const ContainerEntryDependency = require("webpack/lib/container/ContainerEntryDependency");
+const ContainerEntryModuleFactory = require("webpack/lib/container/ContainerEntryModuleFactory");
+const ContainerExposedDependency = require("webpack/lib/container/ContainerExposedDependency");
+const { parseOptions } = require("webpack/lib/container/options");
 
 /** @typedef {import("../../declarations/plugins/container/ContainerPlugin").ContainerPluginOptions} ContainerPluginOptions */
 /** @typedef {import("../Compiler")} Compiler */
 
 const PLUGIN_NAME = "ContainerPlugin";
 
-class ContainerPlugin {
+export class ContainerPlugin {
+  _options: any;
   /**
    * @param {ContainerPluginOptions} options options
    */
   constructor(options) {
-    validate(schema, options, { name: "Container Plugin" });
+    // validate(schema, options, { name: "Container Plugin" });
 
     this._options = {
       name: options.name,
+      entry: options.entry,
       shareScope: options.shareScope || "default",
       library: options.library || {
         type: "var",
@@ -52,13 +54,27 @@ class ContainerPlugin {
    * @returns {void}
    */
   apply(compiler) {
-    const { name, exposes, shareScope, filename, library } = this._options;
+    const { name, exposes, shareScope, filename, library, entry } = this._options;
 
     compiler.options.output.enabledLibraryTypes.push(library.type);
 
-    compiler.hooks.make.tapAsync(PLUGIN_NAME, (compilation, callback) => {
+    if (entry) {
+      compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+        const EntryPlugin = require("webpack/lib/EntryPlugin");
+        for (const ent of [].concat(entry)) {
+          new EntryPlugin(compilation.options.context, ent, {
+            name
+          }).apply(compiler);
+        }
+        return true;
+      });
+    }
+
+    // setting stage to 1 to ensure the remote runtime module is the last one added
+    compiler.hooks.make.tapAsync({ name: PLUGIN_NAME, stage: 1 }, (compilation, callback) => {
       const dep = new ContainerEntryDependency(name, exposes, shareScope);
       dep.loc = { name };
+
       compilation.addEntry(
         compilation.options.context,
         dep,
@@ -84,5 +100,3 @@ class ContainerPlugin {
     });
   }
 }
-
-module.exports = ContainerPlugin;

--- a/packages/xarc-webpack/src/container/ContainerPlugin.ts
+++ b/packages/xarc-webpack/src/container/ContainerPlugin.ts
@@ -1,0 +1,88 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra, Zackary Jackson @ScriptedAlchemy, Marais Rossouw @maraisr
+*/
+
+"use strict";
+
+const { validate } = require("schema-utils");
+const schema = require("../../schemas/plugins/container/ContainerPlugin.json");
+const ContainerEntryDependency = require("./ContainerEntryDependency");
+const ContainerEntryModuleFactory = require("./ContainerEntryModuleFactory");
+const ContainerExposedDependency = require("./ContainerExposedDependency");
+const { parseOptions } = require("./options");
+
+/** @typedef {import("../../declarations/plugins/container/ContainerPlugin").ContainerPluginOptions} ContainerPluginOptions */
+/** @typedef {import("../Compiler")} Compiler */
+
+const PLUGIN_NAME = "ContainerPlugin";
+
+class ContainerPlugin {
+  /**
+   * @param {ContainerPluginOptions} options options
+   */
+  constructor(options) {
+    validate(schema, options, { name: "Container Plugin" });
+
+    this._options = {
+      name: options.name,
+      shareScope: options.shareScope || "default",
+      library: options.library || {
+        type: "var",
+        name: options.name
+      },
+      filename: options.filename || undefined,
+      exposes: parseOptions(
+        options.exposes,
+        item => ({
+          import: Array.isArray(item) ? item : [item],
+          name: undefined
+        }),
+        item => ({
+          import: Array.isArray(item.import) ? item.import : [item.import],
+          name: item.name || undefined
+        })
+      )
+    };
+  }
+
+  /**
+   * Apply the plugin
+   * @param {Compiler} compiler the compiler instance
+   * @returns {void}
+   */
+  apply(compiler) {
+    const { name, exposes, shareScope, filename, library } = this._options;
+
+    compiler.options.output.enabledLibraryTypes.push(library.type);
+
+    compiler.hooks.make.tapAsync(PLUGIN_NAME, (compilation, callback) => {
+      const dep = new ContainerEntryDependency(name, exposes, shareScope);
+      dep.loc = { name };
+      compilation.addEntry(
+        compilation.options.context,
+        dep,
+        {
+          name,
+          filename,
+          library
+        },
+        error => {
+          if (error) return callback(error);
+          callback();
+        }
+      );
+    });
+
+    compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation, { normalModuleFactory }) => {
+      compilation.dependencyFactories.set(
+        ContainerEntryDependency,
+        new ContainerEntryModuleFactory()
+      );
+
+      compilation.dependencyFactories.set(ContainerExposedDependency, normalModuleFactory);
+    });
+  }
+}
+
+module.exports = ContainerPlugin;

--- a/packages/xarc-webpack/src/container/ModuleFederationPlugin.ts
+++ b/packages/xarc-webpack/src/container/ModuleFederationPlugin.ts
@@ -1,0 +1,80 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra and Zackary Jackson @ScriptedAlchemy
+*/
+
+"use strict";
+
+const { validate } = require("schema-utils");
+const schema = require("../../schemas/plugins/container/ModuleFederationPlugin.json");
+const SharePlugin = require("../sharing/SharePlugin");
+const ContainerPlugin = require("./ContainerPlugin");
+const ContainerReferencePlugin = require("./ContainerReferencePlugin");
+
+/** @typedef {import("../../declarations/plugins/container/ModuleFederationPlugin").ExternalsType} ExternalsType */
+/** @typedef {import("../../declarations/plugins/container/ModuleFederationPlugin").ModuleFederationPluginOptions} ModuleFederationPluginOptions */
+/** @typedef {import("../../declarations/plugins/container/ModuleFederationPlugin").Shared} Shared */
+/** @typedef {import("../Compiler")} Compiler */
+
+class ModuleFederationPlugin {
+  /**
+   * @param {ModuleFederationPluginOptions} options options
+   */
+  constructor(options) {
+    validate(schema, options, { name: "Module Federation Plugin" });
+
+    this._options = options;
+  }
+
+  /**
+   * Apply the plugin
+   * @param {Compiler} compiler the compiler instance
+   * @returns {void}
+   */
+  apply(compiler) {
+    const { _options: options } = this;
+    const library = options.library || { type: "var", name: options.name };
+    const remoteType =
+      options.remoteType ||
+      (options.library && schema.definitions.ExternalsType.enum.includes(options.library.type)
+        ? /** @type {ExternalsType} */ options.library.type
+        : "script");
+    if (library && !compiler.options.output.enabledLibraryTypes.includes(library.type)) {
+      compiler.options.output.enabledLibraryTypes.push(library.type);
+    }
+    compiler.hooks.afterPlugins.tap("ModuleFederationPlugin", () => {
+      if (
+        options.exposes &&
+        (Array.isArray(options.exposes)
+          ? options.exposes.length > 0
+          : Object.keys(options.exposes).length > 0)
+      ) {
+        new ContainerPlugin({
+          name: options.name,
+          library,
+          filename: options.filename,
+          exposes: options.exposes
+        }).apply(compiler);
+      }
+      if (
+        options.remotes &&
+        (Array.isArray(options.remotes)
+          ? options.remotes.length > 0
+          : Object.keys(options.remotes).length > 0)
+      ) {
+        new ContainerReferencePlugin({
+          remoteType,
+          remotes: options.remotes
+        }).apply(compiler);
+      }
+      if (options.shared) {
+        new SharePlugin({
+          shared: options.shared,
+          shareScope: options.shareScope
+        }).apply(compiler);
+      }
+    });
+  }
+}
+
+module.exports = ModuleFederationPlugin;

--- a/packages/xarc-webpack/src/container/ModuleFederationPlugin.ts
+++ b/packages/xarc-webpack/src/container/ModuleFederationPlugin.ts
@@ -2,26 +2,27 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra and Zackary Jackson @ScriptedAlchemy
 */
+/* eslint-disable */
 
-"use strict";
+// const { validate } = require("schema-utils");
+const schema = require("webpack/schemas/plugins/container/ModuleFederationPlugin.json");
+const SharePlugin = require("webpack/lib/sharing/SharePlugin");
+const ContainerReferencePlugin = require("webpack/lib/container/ContainerReferencePlugin");
 
-const { validate } = require("schema-utils");
-const schema = require("../../schemas/plugins/container/ModuleFederationPlugin.json");
-const SharePlugin = require("../sharing/SharePlugin");
-const ContainerPlugin = require("./ContainerPlugin");
-const ContainerReferencePlugin = require("./ContainerReferencePlugin");
+import { ContainerPlugin } from "./ContainerPlugin";
 
 /** @typedef {import("../../declarations/plugins/container/ModuleFederationPlugin").ExternalsType} ExternalsType */
 /** @typedef {import("../../declarations/plugins/container/ModuleFederationPlugin").ModuleFederationPluginOptions} ModuleFederationPluginOptions */
 /** @typedef {import("../../declarations/plugins/container/ModuleFederationPlugin").Shared} Shared */
 /** @typedef {import("../Compiler")} Compiler */
 
-class ModuleFederationPlugin {
+export class ModuleFederationPlugin {
+  _options: any;
   /**
    * @param {ModuleFederationPluginOptions} options options
    */
   constructor(options) {
-    validate(schema, options, { name: "Module Federation Plugin" });
+    // validate(schema, options, { name: "Module Federation Plugin" });
 
     this._options = options;
   }
@@ -33,15 +34,19 @@ class ModuleFederationPlugin {
    */
   apply(compiler) {
     const { _options: options } = this;
+
     const library = options.library || { type: "var", name: options.name };
+
     const remoteType =
       options.remoteType ||
       (options.library && schema.definitions.ExternalsType.enum.includes(options.library.type)
         ? /** @type {ExternalsType} */ options.library.type
         : "script");
+
     if (library && !compiler.options.output.enabledLibraryTypes.includes(library.type)) {
       compiler.options.output.enabledLibraryTypes.push(library.type);
     }
+
     compiler.hooks.afterPlugins.tap("ModuleFederationPlugin", () => {
       if (
         options.exposes &&
@@ -51,6 +56,7 @@ class ModuleFederationPlugin {
       ) {
         new ContainerPlugin({
           name: options.name,
+          entry: options.entry,
           library,
           filename: options.filename,
           exposes: options.exposes
@@ -76,5 +82,3 @@ class ModuleFederationPlugin {
     });
   }
 }
-
-module.exports = ModuleFederationPlugin;

--- a/packages/xarc-webpack/src/partials/entry.ts
+++ b/packages/xarc-webpack/src/partials/entry.ts
@@ -222,7 +222,7 @@ if (module.hot) {
     //
     // need to insert CDN mapping code for webpack jsonp in production mode
     //
-    const jsonpCdn = !process.env.WEBPACK_DEV && "@xarc/app-dev/scripts/webpack5-jsonp-cdn";
+    const jsonpCdn = !process.env.WEBPACK_DEV && require.resolve("../client/webpack5-jsonp-cdn");
 
     if (polyfill) {
       const coreJs = "core-js";

--- a/packages/xarc-webpack/src/partials/prod-mode.ts
+++ b/packages/xarc-webpack/src/partials/prod-mode.ts
@@ -6,6 +6,9 @@ module.exports = function() {
   const xarcOptions = loadXarcOptions();
 
   return {
-    mode: xarcOptions.webpack.minify ? "production" : "development"
+    mode: "production",
+    optimization: {
+      minimize: xarcOptions.webpack.minify
+    }
   };
 };

--- a/samples/poc-subapp-min-fastify/config/default.js
+++ b/samples/poc-subapp-min-fastify/config/default.js
@@ -14,7 +14,7 @@ module.exports = {
       module: "@xarc/app-dev/lib/webpack-dev-fastify",
       enable: process.env.WEBPACK_DEV === "true"
     },
-    "subapp-server": { options: { insertTokenIds: true } }
+    "subapp-server": { options: { insertTokenIds: true, cdn: { enable: true } } }
   },
   connection: {
     host: process.env.HOST,

--- a/samples/poc-subapp-min-fastify/src/home/subapp-home.js
+++ b/samples/poc-subapp-min-fastify/src/home/subapp-home.js
@@ -10,7 +10,7 @@ async function loadRemoteModule(scope, module) {
   const container = window[scope]; // or get the container somewhere else
   // Initialize the container, it may provide shared modules
   await container.init(__webpack_share_scopes__.default);
-  const factory = await window[scope].get(module);
+  const factory = await window[scope].get(module, scope);
   const Module = factory();
   return Module;
 }

--- a/samples/poc-subapp-min-fastify/xclap.js
+++ b/samples/poc-subapp-min-fastify/xclap.js
@@ -4,7 +4,7 @@
 
 // process.env.SERVER_ES6 = true;
 
-process.env.APP_SERVER_PORT = 3100;
+// process.env.APP_SERVER_PORT = 3100;
 
 /*
  * Enable webpack's NodeSourcePlugin to simulate NodeJS libs in browser

--- a/samples/poc-subapp/fyn-lock.yaml
+++ b/samples/poc-subapp/fyn-lock.yaml
@@ -1722,33 +1722,33 @@ $pkg:
    '@webassemblyjs/ast': 1.11.0
    '@xtuc/long': 4.2.2
 '@webpack-cli/configtest':
- _latest: 1.0.1
+ _latest: 1.0.2
  _:
-  ^1.0.1: 1.0.1
- 1.0.1:
-  $: sha512-B+4uBUYhpzDXmwuo3V9yBH6cISwxEI4J+NO5ggDaGEEHb0osY/R7MzeKc0bHURXQuZjMM4qD+bSJCKIuI3eNBQ==
-  _: 'https://npme.walmart.com/@webpack-cli/configtest/-/configtest-1.0.1.tgz'
+  ^1.0.2: 1.0.2
+ 1.0.2:
+  $: sha512-3OBzV2fBGZ5TBfdW50cha1lHDVf9vlvRXnjpVbJBa20pSZQaSkMJZiwA8V2vD9ogyeXn8nU5s5A6mHyf5jhMzA==
+  _: 'https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.2.tgz'
   peerDependencies:
    webpack: '4.x.x || 5.x.x'
    webpack-cli: 4.x.x
 '@webpack-cli/info':
- _latest: 1.2.2
+ _latest: 1.2.3
  _:
-  ^1.2.2: 1.2.2
- 1.2.2:
-  $: sha512-5U9kUJHnwU+FhKH4PWGZuBC1hTEPYyxGSL5jjoBI96Gx8qcYJGOikpiIpFoTq8mmgX3im2zAo2wanv/alD74KQ==
-  _: 'https://npme.walmart.com/@webpack-cli/info/-/info-1.2.2.tgz'
+  ^1.2.3: 1.2.3
+ 1.2.3:
+  $: sha512-lLek3/T7u40lTqzCGpC6CAbY6+vXhdhmwFRxZLMnRm6/sIF/7qMpT8MocXCRQfz0JAh63wpbXLMnsQ5162WS7Q==
+  _: 'https://registry.npmjs.org/@webpack-cli/info/-/info-1.2.3.tgz'
   dependencies:
    envinfo: ^7.7.3
   peerDependencies:
    webpack-cli: 4.x.x
 '@webpack-cli/serve':
- _latest: 1.3.0
+ _latest: 1.3.1
  _:
-  ^1.3.0: 1.3.0
- 1.3.0:
-  $: sha512-k2p2VrONcYVX1wRRrf0f3X2VGltLWcv+JzXRBDmvCxGlCeESx4OXw91TsWeKOkp784uNoVQo313vxJFHXPPwfw==
-  _: 'https://npme.walmart.com/@webpack-cli/serve/-/serve-1.3.0.tgz'
+  ^1.3.1: 1.3.1
+ 1.3.1:
+  $: sha512-0qXvpeYO6vaNoRBI52/UsbcaBydJCggoBBnIo/ovQQdn6fug0BgwsjorV1hVS7fMqGVTZGcVxv8334gjmbj5hw==
+  _: 'https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.3.1.tgz'
   peerDependencies:
    webpack-cli: 4.x.x
 '@xarc/app':
@@ -1986,8 +1986,8 @@ $pkg:
    optional-require: ^1.0.2
    require-at: ^1.0.6
    url-loader: ^4.1.0
-   webpack: ^5.24.3
-   webpack-cli: ^4.5.0
+   webpack: ^5.33.2
+   webpack-cli: ^4.6.0
    webpack-config-composer: ^1.1.3
    webpack-stats-plugin: ^1.0.3
    xsh: ^0.4.5
@@ -9392,12 +9392,12 @@ wbuf:
   dependencies:
    minimalistic-assert: ^1.0.0
 webpack:
- _latest: 5.27.0
+ _latest: 5.33.2
  _:
-  ^5.24.3: 5.27.0
- 5.27.0:
-  $: sha512-So7grHu//UyJ+80VrNHjWwW6WSZkfWWD6a7NV/88r8G92PO6TYOGzbtTiZBwbPVkx6LVP8OYvHD+IxuJ2KBz4g==
-  _: 'https://npme.walmart.com/webpack/-/webpack-5.27.0.tgz'
+  ^5.33.2: 5.33.2
+ 5.33.2:
+  $: sha512-X4b7F1sYBmJx8mlh2B7mV5szEkE0jYNJ2y3akgAP0ERi0vLCG1VvdsIxt8lFd4st6SUy0lf7W0CCQS566MBpJg==
+  _: 'https://registry.npmjs.org/webpack/-/webpack-5.33.2.tgz'
   dependencies:
    '@types/eslint-scope': ^3.7.0
    '@types/estree': ^0.0.46
@@ -9423,17 +9423,17 @@ webpack:
    watchpack: ^2.0.0
    webpack-sources: ^2.1.1
 webpack-cli:
- _latest: 4.5.0
+ _latest: 4.6.0
  _:
-  ^4.5.0: 4.5.0
- 4.5.0:
-  $: sha512-wXg/ef6Ibstl2f50mnkcHblRPN/P9J4Nlod5Hg9HGFgSeF8rsqDGHJeVe4aR26q9l62TUJi6vmvC2Qz96YJw1Q==
-  _: 'https://npme.walmart.com/webpack-cli/-/webpack-cli-4.5.0.tgz'
+  ^4.6.0: 4.6.0
+ 4.6.0:
+  $: sha512-9YV+qTcGMjQFiY7Nb1kmnupvb1x40lfpj8pwdO/bom+sQiP4OBMKjHq29YQrlDWDPZO9r/qWaRRywKaRDKqBTA==
+  _: 'https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.6.0.tgz'
   dependencies:
    '@discoveryjs/json-ext': ^0.5.0
-   '@webpack-cli/configtest': ^1.0.1
-   '@webpack-cli/info': ^1.2.2
-   '@webpack-cli/serve': ^1.3.0
+   '@webpack-cli/configtest': ^1.0.2
+   '@webpack-cli/info': ^1.2.3
+   '@webpack-cli/serve': ^1.3.1
    colorette: ^1.2.1
    commander: ^7.0.0
    enquirer: ^2.3.6
@@ -9455,6 +9455,7 @@ webpack-config-composer:
   _: ../../packages/webpack-config-composer
   dependencies:
    lodash: ^4.13.1
+   tslib: ^2.1.0
 webpack-dev-middleware:
  _latest: 4.1.0
  _:

--- a/samples/poc-subapp/xclap.js
+++ b/samples/poc-subapp/xclap.js
@@ -14,6 +14,7 @@ const deps = require("./package.json").dependencies;
 
 loadDevTasks(xrun, {
   webpackOptions: {
+    minify: true,
     v1RemoteSubApps: {
       name: "poc-subapp",
       subAppsToExpose: ["Deal", "Extras"],


### PR DESCRIPTION
webpack 5 module federation remote entry doesn't allow user to add modules to it.  So copied relevant files out and modify them directly to add CDN mapping module to remote entry.
