### PR TITLE
[fix] disable nonce for script,style or both

### DIFF
--- a/packages/xarc-subapp/src/node/init-v2.ts
+++ b/packages/xarc-subapp/src/node/init-v2.ts
@@ -194,13 +194,13 @@ export function initSubApp(setupContext: any, setupToken: Partial<{ props: InitP
 
       const addScriptNonce = (text: string) => {
         return !scriptNonceAttr
-          ? text
+          ? text && text.replace(/{{SCRIPT_NONCE}}/g, "")
           : text && text.replace(/{{SCRIPT_NONCE}}/g, context.user.scriptNonceAttr);
       };
 
       const addStyleNonce = (text: string) => {
         return !styleNonceAttr
-          ? text
+          ? text && text.replace(/{{STYLE_NONCE}}/g, "")
           : text && text.replace(/{{STYLE_NONCE}}/g, context.user.styleNonceAttr);
       };
 

--- a/packages/xarc-subapp/src/node/types.ts
+++ b/packages/xarc-subapp/src/node/types.ts
@@ -11,7 +11,7 @@ export type NonceInfo = {
   style?: boolean;
 
   /** nonce tokens */
-  tokens: {
+  tokens?: {
     all?: string;
     script?: string;
     style?: string;

--- a/packages/xarc-subapp/src/node/utils.ts
+++ b/packages/xarc-subapp/src/node/utils.ts
@@ -91,8 +91,12 @@ export function generateNonce(
   if (nonce) {
     if (nonce[tag] === false) {
       return { attr: "" };
+    } else if (nonce.tokens || nonce.generator) {
+      nonceToken = nonce.tokens[tag] || nonce.tokens.all || nonce.generator(tag);
+    } else {
+      nonceToken = nonceGenerator(tag);
+      nonce = { tokens: { all: nonceToken, [tag]: nonceToken } };
     }
-    nonceToken = nonce.tokens[tag] || nonce.tokens.all || nonce.generator(tag);
   } else {
     nonceToken = nonceGenerator(tag);
     nonce = { tokens: { all: nonceToken, [tag]: nonceToken } };

--- a/packages/xarc-subapp/test/spec/node/init-v2.spec.ts
+++ b/packages/xarc-subapp/test/spec/node/init-v2.spec.ts
@@ -100,8 +100,8 @@ describe("Test init-v2", () => {
       }
     };
     const result = initializer.process(context);
-    expect(result).contains(`<script{{SCRIPT_NONCE}}`);
-    expect(result).contains(`<link{{STYLE_NONCE}}`);
+    expect(result).to.not.contain(`<script{{SCRIPT_NONCE}}`);
+    expect(result).to.not.contain(`<link{{STYLE_NONCE}}`);
   });
 
   it("test initSubApp without CDN Map", () => {


### PR DESCRIPTION
Allow users to disable nonce for script, style or both.

1. To disable nonce for both:

   `nonce: false`
2. To disable nonce just for style and use default nonce settings for script:
       `nonce: {
            style: false
        }`
3. To disable nonce just for script and use default nonce setting for style:
     `nonce: {
           script: false
        }`