### PR TITLE
[fix] lock webpack-cli version to 4.8.0 to avoid breaking changes in 4…

### DIFF
--- a/packages/xarc-webpack/package.json
+++ b/packages/xarc-webpack/package.json
@@ -52,7 +52,7 @@
     "require-at": "^1.0.6",
     "url-loader": "^4.1.0",
     "webpack": "^5.33.2",
-    "webpack-cli": "^4.6.0",
+    "webpack-cli": "4.8.0",
     "webpack-config-composer": "^1.1.5",
     "webpack-stats-plugin": "^1.0.3",
     "xsh": "^0.4.5"


### PR DESCRIPTION
….9.0

Locking `webpack-cli` to `4.8.0` as our build is failing with version `4.9.0`