### PR TITLE
[minor][feat] add custom renderer support for SSR.

### DIFF
--- a/packages/subapp-react/lib/framework-lib.js
+++ b/packages/subapp-react/lib/framework-lib.js
@@ -59,6 +59,12 @@ class FrameworkLib {
   }
 
   renderTo(element, options) {
+    const { subAppServer } = this.ref;
+
+    if (typeof subAppServer.renderer === "function") {
+      return subAppServer.renderer(element, options);
+    }
+
     if (options.useStream) {
       assert(!options.suspenseSsr, "useStream and suspense SSR together are not supported");
       if (options.hydrateServerData) {

--- a/packages/subapp-react/test/spec/ssr-framework.spec.js
+++ b/packages/subapp-react/test/spec/ssr-framework.spec.js
@@ -2,6 +2,7 @@
 
 const url = require("url");
 const React = require("react"); // eslint-disable-line
+const ReactDOMServer = require("react-dom/server");
 const lib = require("../../lib");
 const { withRouter } = require("react-router");
 const { Route, Switch } = require("react-router-dom"); // eslint-disable-line
@@ -188,7 +189,6 @@ describe("SSR React framework", function () {
     const res = await framework.handleSSR();
     expect(res).contains("Hello foo bar");
   });
-
 
   it("should render Component from subapp with initial props from server's prepare while using attachInitialState", async () => {
     const framework = new lib.FrameworkLib({
@@ -421,5 +421,30 @@ describe("SSR React framework", function () {
     });
     const res = await framework.handleSSR();
     expect(res).contains("Hello test path<");
+  });
+
+  it("should render subapp with custom renderer e.g. css in js solution", async () => {
+    const Component = () => {
+      return <div>Hello test path</div>;
+    };
+
+    const framework = new lib.FrameworkLib({
+      subApp: {
+        Component
+      },
+      subAppServer: {
+        renderer: (element, options) => {
+          return "<h1>Rendered via Custom renderer</h1>";
+        }
+      },
+      options: { serverSideRendering: true },
+      context: {
+        user: {
+          request: { url: url.parse("http://localhost/test") }
+        }
+      }
+    });
+    const res = await framework.handleSSR();
+    expect(res).contains("Rendered via Custom renderer");
   });
 });


### PR DESCRIPTION
This is to support use cases like css in js e.g. Rendering Styled Components on server


e.g.  in `server` entry (server.js)

```
import {ServerStyleSheet} from "styled-components";
import ReactDOM from "react-dom/server";

export default {
renderer(element, options) {
   const sheet = new ServerStyleSheet();
   try {
      const html = ReactDOMServer.renderToString(.  // This can be renderToNodeStream or Static markup/stream depending on option. 
                              sheet.collectStyles(element)
       );
      const styleTags = sheet.getStyleTags(); 

      return styleTags + html;
    } catch (error) {
        console.log(error);
    }
}
