### PR TITLE
Fix xaa version to avoid breaking change

### DIFF
--- a/packages/xarc-jsx-renderer/package.json
+++ b/packages/xarc-jsx-renderer/package.json
@@ -81,7 +81,7 @@
     "munchy": "^1.0.9",
     "optional-require": "^1.1.6",
     "require-at": "^1.0.6",
-    "xaa": "^1.4.0"
+    "xaa": "1.7.1"
   },
   "nyc": {
     "extends": [

--- a/packages/xarc-render-context/package.json
+++ b/packages/xarc-render-context/package.json
@@ -61,7 +61,7 @@
     "munchy": "^1.0.9",
     "optional-require": "^1.1.6",
     "require-at": "^1.0.6",
-    "xaa": "^1.5.0"
+    "xaa": "1.7.1"
   },
   "nyc": {
     "extends": [


### PR DESCRIPTION
Temporarily fixing xaa version to 1.7.1 as the new version is breaking the jsx-renderer/xarc-render-context