### PR TITLE
fix: update dependencies to resolve build issues

### DIFF
--- a/packages/webpack-config-composer/package.json
+++ b/packages/webpack-config-composer/package.json
@@ -55,7 +55,7 @@
     "sinon": "^9.2.2",
     "sinon-chai": "^3.5.0",
     "source-map-support": "^0.5.19",
-    "ts-node": "^9.1.1",
+    "ts-node": "^10.7.0",
     "typedoc": "^0.20.13",
     "typescript": "^4.1.3"
   },

--- a/packages/xarc-app-dev/package.json
+++ b/packages/xarc-app-dev/package.json
@@ -131,7 +131,7 @@
     "sinon": "^9.2.2",
     "sinon-chai": "^3.5.0",
     "source-map-support": "^0.5.19",
-    "ts-node": "^9.1.1",
+    "ts-node": "^10.7.0",
     "typedoc": "^0.20.13",
     "typescript": "^4.1.3"
   },

--- a/packages/xarc-app-dev/src/lib/dev-admin/log-view.js
+++ b/packages/xarc-app-dev/src/lib/dev-admin/log-view.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-magic-numbers, no-use-before-define, no-unused-vars */
 /* eslint-disable no-console, max-statements, no-param-reassign, complexity */
-/* global window, document, EventSource, fetch */
+/* global window, document, EventSource */
 
 //  c is from json-formatter-js.js, keep it loaded ahead of log-view.js
 /* eslint-disable no-undef */

--- a/packages/xarc-react/test/spec/node/index.spec.tsx
+++ b/packages/xarc-react/test/spec/node/index.spec.tsx
@@ -19,14 +19,16 @@ describe("createDynamicComponent", function () {
     expect(container.getNames()).contains("test");
     expect(Component).to.be.a("function");
 
+    // data-reactroot isn't getting created due to Context.Provider
+    // see https://github.com/facebook/react/issues/15012
     const html = renderToString(<Component />);
     expect(html).to.equal(
-      `<div data-reactroot="">subapp <!-- -->test<!-- --> component loading... </div>`
+      `<div>subapp <!-- -->test<!-- --> component loading... </div>`
     );
 
     await container.get("test")._getModule();
 
     const html2 = renderToString(<Component />);
-    expect(html2).to.equal(`<div data-reactroot="">hello</div>`);
+    expect(html2).to.equal(`<div>hello</div>`);
   });
 });

--- a/packages/xarc-subapp/package.json
+++ b/packages/xarc-subapp/package.json
@@ -76,7 +76,7 @@
     "sinon": "^9.2.2",
     "sinon-chai": "^3.5.0",
     "source-map-support": "^0.5.19",
-    "ts-node": "^9.1.1",
+    "ts-node": "^10.7.0",
     "typedoc": "^0.20.13",
     "typescript": "^4.1.3",
     "xsh": "^0.4.5"

--- a/samples/react-jest-app/package.json
+++ b/samples/react-jest-app/package.json
@@ -65,7 +65,8 @@
     "@xarc/opt-less": "^1.0.2",
     "@xarc/opt-mocha": "^1.0.0",
     "@xarc/opt-postcss": "^1.0.4",
-    "@xarc/opt-stylus": "^1.0.2"
+    "@xarc/opt-stylus": "^1.0.2",
+    "cheerio": "=1.0.0-rc.10"
   },
   "fyn": {
     "dependencies": {

--- a/samples/stylus-sample/package.json
+++ b/samples/stylus-sample/package.json
@@ -53,7 +53,8 @@
     "@xarc/opt-karma": "^1.0.0",
     "@xarc/opt-mocha": "^1.0.0",
     "@xarc/opt-postcss": "^1.0.0",
-    "@xarc/opt-stylus": "^1.0.0"
+    "@xarc/opt-stylus": "^1.0.0",
+    "cheerio": "=1.0.0-rc.10"
   },
   "fyn": {
     "dependencies": {


### PR DESCRIPTION
With typescript version 4.7.2, tests are failing in webpack-config-composer, xarc-app-dev, xarc-subapp packages. Updated the version of ts-node to fix this.

data-reactroot isn't getting created due to Context.Provider, so removed it from xarc-react test case

enzyme breaks with cheerio version v1.0.0-rc.11, so had to set cheerio to =1.0.0-rc.10 version in samples/stylus-sample, samples/react-jest-app to resolve this issue

Reference :
https://github.com/facebook/jest/issues/12655
https://github.com/facebook/react/issues/15012
https://github.com/enzymejs/enzyme/issues/2558