### PR TITLE
build(minor): upgrade ModuleFederation plugin and Webpack to v5.74.0

### DIFF
--- a/packages/xarc-webpack/package.json
+++ b/packages/xarc-webpack/package.json
@@ -51,7 +51,7 @@
     "optional-require": "^1.1.6",
     "require-at": "^1.0.6",
     "url-loader": "^4.1.0",
-    "webpack": "^5.33.2",
+    "webpack": "^5.74.0",
     "webpack-cli": "4.8.0",
     "webpack-config-composer": "^1.1.6",
     "webpack-stats-plugin": "^1.0.3",

--- a/packages/xarc-webpack/src/container/ModuleFederationPlugin.ts
+++ b/packages/xarc-webpack/src/container/ModuleFederationPlugin.ts
@@ -5,7 +5,7 @@
 /* eslint-disable */
 
 // const { validate } = require("schema-utils");
-const schema = require("webpack/schemas/plugins/container/ModuleFederationPlugin.json");
+const isValidExternalsType = require("webpack/schemas/plugins/container/ExternalsType.check.js");
 const SharePlugin = require("webpack/lib/sharing/SharePlugin");
 const ContainerReferencePlugin = require("webpack/lib/container/ContainerReferencePlugin");
 
@@ -22,8 +22,6 @@ export class ModuleFederationPlugin {
    * @param {ModuleFederationPluginOptions} options options
    */
   constructor(options) {
-    // validate(schema, options, { name: "Module Federation Plugin" });
-
     this._options = options;
   }
 
@@ -38,30 +36,32 @@ export class ModuleFederationPlugin {
     const library = options.library || { type: "var", name: options.name };
 
     const remoteType =
-      options.remoteType ||
-      (options.library && schema.definitions.ExternalsType.enum.includes(options.library.type)
-        ? /** @type {ExternalsType} */ options.library.type
-        : "script");
-
-    if (library && !compiler.options.output.enabledLibraryTypes.includes(library.type)) {
-      compiler.options.output.enabledLibraryTypes.push(library.type);
-    }
-
-    compiler.hooks.afterPlugins.tap("ModuleFederationPlugin", () => {
-      if (
-        options.exposes &&
-        (Array.isArray(options.exposes)
-          ? options.exposes.length > 0
-          : Object.keys(options.exposes).length > 0)
-      ) {
-        new ContainerPlugin({
-          name: options.name,
-          entry: options.entry,
-          library,
-          filename: options.filename,
-          exposes: options.exposes
-        }).apply(compiler);
-      }
+			options.remoteType ||
+			(options.library && isValidExternalsType(options.library.type)
+				? /** @type {ExternalsType} */ (options.library.type)
+				: "script");
+		if (
+			library &&
+			!compiler.options.output.enabledLibraryTypes.includes(library.type)
+		) {
+			compiler.options.output.enabledLibraryTypes.push(library.type);
+		}
+		compiler.hooks.afterPlugins.tap("ModuleFederationPlugin", () => {
+			if (
+				options.exposes &&
+				(Array.isArray(options.exposes)
+					? options.exposes.length > 0
+					: Object.keys(options.exposes).length > 0)
+			) {
+				new ContainerPlugin({
+					name: options.name,
+					library,
+					filename: options.filename,
+					runtime: options.runtime,
+					shareScope: options.shareScope,
+					exposes: options.exposes
+				}).apply(compiler);
+			}
       if (
         options.remotes &&
         (Array.isArray(options.remotes)
@@ -70,6 +70,7 @@ export class ModuleFederationPlugin {
       ) {
         new ContainerReferencePlugin({
           remoteType,
+          shareScope: options.shareScope,
           remotes: options.remotes
         }).apply(compiler);
       }

--- a/packages/xarc-webpack/src/container/ModuleFederationPlugin.ts
+++ b/packages/xarc-webpack/src/container/ModuleFederationPlugin.ts
@@ -40,12 +40,9 @@ export class ModuleFederationPlugin {
 			(options.library && isValidExternalsType(options.library.type)
 				? /** @type {ExternalsType} */ (options.library.type)
 				: "script");
-		if (
-			library &&
-			!compiler.options.output.enabledLibraryTypes.includes(library.type)
-		) {
-			compiler.options.output.enabledLibraryTypes.push(library.type);
-		}
+		if (library && !compiler.options.output.enabledLibraryTypes.includes(library.type)) {
+      compiler.options.output.enabledLibraryTypes.push(library.type);
+    }
 		compiler.hooks.afterPlugins.tap("ModuleFederationPlugin", () => {
 			if (
 				options.exposes &&


### PR DESCRIPTION
- Manually upgraded cloned code of `ModuleFederation` plugin in `xarc-webpack` package to match Webpack's v5.74.0 update.
- Webpack minor version upgrade to v5.74.0 in `xarc-webpack` package.