### PR TITLE
[fix]: upgrade xarc-opt-sass to pass node 16 build

### DIFF
--- a/packages/xarc-opt-sass/package.json
+++ b/packages/xarc-opt-sass/package.json
@@ -30,8 +30,8 @@
     "prepare": "shx cp node_modules/opt-archetype-check/xarc-opt-check.js ."
   },
   "dependencies": {
-    "node-sass": "^4.9.3",
-    "sass-loader": "^6.0.6"
+    "node-sass": "^7.0.1",
+    "sass-loader": "^13.0.2"
   },
   "devDependencies": {
     "opt-archetype-check": "../opt-archetype-check",


### PR DESCRIPTION
- Upgraded `node-sass` dependency to V7
- Upgraded `sass-loader` dependency to V13