### PR TITLE
[patch][bug] fix source map load issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -518,3 +518,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .fynpo
+
+# Sample apps
+samples/**/dist
+samples/**/lib

--- a/packages/xarc-webpack/src/partials/dev.ts
+++ b/packages/xarc-webpack/src/partials/dev.ts
@@ -77,7 +77,7 @@ module.exports = function() {
       filename: `${nsTag}[name].bundle.dev.js`,
       chunkFilename: `${nsTag}[name].bundle.dev.js`
     },
-    devtool: xarcOptions.webpack.devtool || 'eval-cheap-module-source-map',
+    devtool: xarcOptions.webpack.devtool || "eval-cheap-module-source-map",
     // TODO: why is this here and duplicates what's in extract-style partial?  This is causing
     // duplicate CSS bundles to be generated in dev mode.
     // Comment out for now

--- a/packages/xarc-webpack/src/partials/dev.ts
+++ b/packages/xarc-webpack/src/partials/dev.ts
@@ -77,7 +77,7 @@ module.exports = function() {
       filename: `${nsTag}[name].bundle.dev.js`,
       chunkFilename: `${nsTag}[name].bundle.dev.js`
     },
-    devtool: xarcOptions.webpack.devtool || false,
+    devtool: xarcOptions.webpack.devtool || 'eval-cheap-module-source-map',
     // TODO: why is this here and duplicates what's in extract-style partial?  This is causing
     // duplicate CSS bundles to be generated in dev mode.
     // Comment out for now

--- a/samples/poc-subapp-redux/package.json
+++ b/samples/poc-subapp-redux/package.json
@@ -30,42 +30,34 @@
     "npm": ">= 5"
   },
   "scripts": {
-    "dev": "clap -q dev",
-    "test": "clap check",
-    "build": "clap build"
+    "dev": "xrun electrode/dev",
+    "test": "xrun electrode/check",
+    "build": "xrun electrode/build"
   },
-  "dependencies": {    
-    "@babel/runtime": "^7.17.9",
+  "dependencies": {
+    "@babel/runtime": "^7.20.1",
     "@module-federation/concat-runtime": "^0.0.1",
-    "@xarc/fastify-server": "^3.3.0",    
+    "@xarc/app": "11.0.1",
+    "@xarc/fastify-server": "^3.3.0",
     "electrode-confippet": "^1.7.1",
     "history": "^5.3.0",
     "html-webpack-plugin": "^5.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-redux": "^8.0.4",
+    "react-redux": "^8.0.5",
     "react-router": "^6.4.3",
     "react-router-dom": "^6.4.3",
     "redux": "^4.2.0",
-    "redux-logger": "^3.0.6"
+    "redux-logger": "^3.0.6",
+    "subapp-react": "1.0.0",
+    "subapp-redux": "2.0.0",
+    "subapp-server": "2.0.0",
+    "subapp-web": "2.0.0"
   },
   "devDependencies": {
-    "@xarc/app-dev": "^10.1.1",
-    "@xarc/opt-eslint": "^2.0.1",
+    "@xarc/app-dev": "^11.0.1",
+    "@xarc/opt-eslint": "^3.0.0",
     "@xarc/run": "^1.1.1"
-  },
-  "fyn": {
-    "dependencies": {
-      "@xarc/app": "../../packages/xarc-app",
-      "subapp-react": "../../packages/subapp-react",
-      "subapp-redux": "../../packages/subapp-redux",
-      "subapp-server": "../../packages/subapp-server",
-      "subapp-web": "../../packages/subapp-web"
-    },
-    "devDependencies": {
-      "@xarc/app-dev": "../../packages/xarc-app-dev",
-      "@xarc/opt-eslint": "../../packages/xarc-opt-eslint"
-    }
   },
   "prettier": {
     "printWidth": 100

--- a/samples/poc-subapp-redux/src/02.main-body/server.jsx
+++ b/samples/poc-subapp-redux/src/02.main-body/server.jsx
@@ -1,12 +1,11 @@
 import React from "react";
 import subApp from "./main-body";
-import Promise from "bluebird";
 import { StaticRouter } from "react-router-dom/server";
 
 module.exports = {
   prepare: async ({ request, context }) => {
-    return Promise.delay(50 + Math.random() * 1000)
-      .return({
+    return new Promise(resolve => setTimeout(resolve, 50 + Math.random() * 1000))
+      .then({
         number: 100,
         items: [
           {

--- a/samples/poc-subapp-redux/src/04.footer/server.jsx
+++ b/samples/poc-subapp-redux/src/04.footer/server.jsx
@@ -1,5 +1,4 @@
 import { Component } from "./subapp-footer";
-import Promise from "bluebird";
 
 module.exports = {
   initialize: () => {
@@ -7,7 +6,7 @@ module.exports = {
   },
   prepare: () => {
     // console.log("subapp footer server prepare");
-    return Promise.delay(50 + Math.random() * 1000).return({
+    return new Promise(resolve => setTimeout(resolve, 50 + Math.random() * 1000)).then({
       title: "Your Online Store Copyright"
     });
   },

--- a/samples/poc-subapp-redux/src/server-routes/default/index.js
+++ b/samples/poc-subapp-redux/src/server-routes/default/index.js
@@ -94,7 +94,7 @@ const Template = (
           />
         </div>
 
-        <div style="background: #e88f41; padding: 10px">
+       <div style="background: #e88f41; padding: 10px">
           <Require
             _id="subapp-web/lib/load"
             _concurrent
@@ -106,7 +106,7 @@ const Template = (
             serverSideRendering
             suspenseSsr
           />
-        </div>
+        </div> 
 
         <Require
           _id="subapp-web/lib/load"

--- a/samples/poc-subapp-redux/src/subapps/03.bottom/server.jsx
+++ b/samples/poc-subapp-redux/src/subapps/03.bottom/server.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import subApp from "./bottom";
-import Promise from "bluebird";
 import Fs from "fs";
 import { StaticRouter } from "react-router-dom/server";
 
@@ -26,7 +25,8 @@ export default {
       imagesData: filterImages
     };
     const store = subApp.reduxCreateStore(initialState);
-    return Promise.delay(50 + Math.random() * 500).return({
+    
+    return new Promise(resolve => setTimeout(resolve, 50 + Math.random() * 500)).then({
       initialState,
       store
     });

--- a/samples/poc-subapp-redux/xrun-tasks.js
+++ b/samples/poc-subapp-redux/xrun-tasks.js
@@ -14,6 +14,7 @@ const deps = require("./package.json").dependencies;
 
 loadDevTasks(xrun, {
   webpackOptions: {
-    minify: true
+    minify: true,
+    devtool: 'inline-source-map'
   }
 });

--- a/samples/poc-subapp/package.json
+++ b/samples/poc-subapp/package.json
@@ -30,13 +30,13 @@
     "npm": ">= 5"
   },
   "scripts": {
-    "dev": "clap -q dev",
-    "test": "clap check",
-    "build": "clap build"
+    "dev": "xrun electrode/dev",
+    "test": "xrun electrode/check",
+    "build": "xrun electrode/build"
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@module-federation/concat-runtime": "^0.0.1",    
+    "@module-federation/concat-runtime": "^0.0.1",
     "@xarc/fastify-server": "^2.0.0",
     "electrode-confippet": "^1.5.0",
     "history": "^5.3.0",
@@ -46,23 +46,16 @@
     "react-redux": "^8.0.4",
     "react-router": "^6.4.3",
     "react-router-dom": "^6.4.3",
-    "redux": "^4.2.0"
+    "redux": "^4.2.0",
+    "@xarc/app": "11.0.1",
+    "subapp-react": "1.0.0",
+    "subapp-redux": "2.0.0",
+    "subapp-server": "2.0.0",
+    "subapp-web": "2.0.0"
   },
-  "devDependencies": {    
-    "@xarc/opt-eslint": "^1.0.0"
-  },
-  "fyn": {
-    "dependencies": {
-      "@xarc/app": "../../packages/xarc-app",
-      "subapp-react": "../../packages/subapp-react",
-      "subapp-redux": "../../packages/subapp-redux",
-      "subapp-server": "../../packages/subapp-server",
-      "subapp-web": "../../packages/subapp-web"
-    },
-    "devDependencies": {
-      "@xarc/app-dev": "../../packages/xarc-app-dev",
-      "@xarc/opt-eslint": "../../packages/xarc-opt-eslint"
-    }
+  "devDependencies": {
+    "@xarc/opt-eslint": "^3.0.0",
+    "@xarc/app-dev": "11.0.1"
   },
   "prettier": {
     "printWidth": 100,

--- a/samples/poc-subapp/src/02.main-body/server.jsx
+++ b/samples/poc-subapp/src/02.main-body/server.jsx
@@ -1,12 +1,11 @@
 import React from "react";
 import subApp from "./main-body";
-import Promise from "bluebird";
 import { StaticRouter } from "react-router-dom/server";
 
 module.exports = {
   prepare: async ({ request, context }) => {
-    return Promise.delay(50 + Math.random() * 1000)
-      .return({
+    return new Promise(resolve => setTimeout(resolve, 50 + Math.random() * 1000))
+      .then({
         number: { value: 999 },
         items: [
           {

--- a/samples/poc-subapp/src/04.footer/server.jsx
+++ b/samples/poc-subapp/src/04.footer/server.jsx
@@ -1,5 +1,4 @@
 import { Component } from "./subapp-footer";
-import Promise from "bluebird";
 
 module.exports = {
   initialize: () => {
@@ -7,7 +6,8 @@ module.exports = {
   },
   prepare: () => {
     // console.log("subapp footer server prepare");
-    return Promise.delay(50 + Math.random() * 1000).return({
+    
+    return new Promise(resolve => setTimeout(resolve, 50 + Math.random() * 1000)).then({
       title: "Your Online Store Copyright"
     });
   },

--- a/samples/poc-subapp/src/subapps/03.bottom/server.jsx
+++ b/samples/poc-subapp/src/subapps/03.bottom/server.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import subApp from "./bottom";
 import { StaticRouter } from "react-router-dom/server";
-import Promise from "bluebird";
 import Fs from "fs";
 
 let filterImages;
@@ -26,7 +25,8 @@ export default {
       imagesData: filterImages
     };
     const store = subApp.reduxCreateStore(initialState);
-    return Promise.delay(50 + Math.random() * 500).return({
+    
+    return new Promise(resolve => setTimeout(resolve, 50 + Math.random() * 500)).then({
       initialState,
       store
     });

--- a/samples/poc-subapp/xrun-tasks.js
+++ b/samples/poc-subapp/xrun-tasks.js
@@ -15,6 +15,7 @@ const deps = require("./package.json").dependencies;
 loadDevTasks(xrun, {
   webpackOptions: {
     minify: true,
+    devtool: "inline-source-map",
     v1RemoteSubApps: {
       name: "poc-subapp",
       subAppsToExpose: ["Deal", "Extras"],

--- a/samples/subapp1-online-store/package.json
+++ b/samples/subapp1-online-store/package.json
@@ -29,42 +29,34 @@
     "npm": ">= 6"
   },
   "scripts": {
-    "dev": "clap -q dev",
-    "test": "clap check",
-    "build": "clap build"
+    "dev": "xrun electrode/dev",
+    "test": "xrun electrode/check",
+    "build": "xrun electrode/build"
   },
-  "dependencies": {    
-    "@babel/runtime": "^7.17.9",
+  "dependencies": {
+    "@babel/runtime": "^7.20.1",
     "@module-federation/concat-runtime": "^0.0.1",
-    "@xarc/fastify-server": "^3.3.0",    
+    "@xarc/fastify-server": "^3.3.0",
     "electrode-confippet": "^1.7.1",
     "history": "^5.3.0",
     "html-webpack-plugin": "^5.5.0",
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0",
-    "react-redux": "^8.0.1",
-    "react-router": "^6.3.0",
-    "react-router-dom": "^6.3.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-redux": "^8.0.5",
+    "react-router": "^6.4.3",
+    "react-router-dom": "^6.4.3",
     "redux": "^4.2.0",
-    "redux-logger": "^3.0.6"
+    "redux-logger": "^3.0.6",
+    "@xarc/app": "latest",
+    "subapp-react": "1.0.0",
+    "subapp-redux": "2.0.0",
+    "subapp-server": "2.0.0",
+    "subapp-web": "2.0.0"
   },
   "devDependencies": {
-    "@xarc/app-dev": "^10.1.1",
-    "@xarc/opt-eslint": "^2.0.1",
+    "@xarc/app-dev": "^11.0.1",
+    "@xarc/opt-eslint": "^3.0.0",
     "@xarc/run": "^1.1.1"
-  },
-  "fyn": {
-    "dependencies": {
-      "@xarc/app": "../../packages/xarc-app",
-      "subapp-react": "../../packages/subapp-react",
-      "subapp-redux": "../../packages/subapp-redux",
-      "subapp-server": "../../packages/subapp-server",
-      "subapp-web": "../../packages/subapp-web"
-    },
-    "devDependencies": {
-      "@xarc/app-dev": "../../packages/xarc-app-dev",
-      "@xarc/opt-eslint": "../../packages/xarc-opt-eslint"
-    }
   },
   "prettier": {
     "printWidth": 100

--- a/samples/subapp1-online-store/src/02.main-body/server.jsx
+++ b/samples/subapp1-online-store/src/02.main-body/server.jsx
@@ -1,13 +1,12 @@
 import React from "react";
 import subApp from "./main-body";
-import Promise from "bluebird";
 import { StaticRouter } from "react-router-dom/server";
 import {unstable_HistoryRouter as HistoryRouter, Routes, Router, BrowserRouter, Link} from "react-router-dom";
 
 module.exports = {
   prepare: async ({ request, context }) => {
-    return Promise.delay(50 + Math.random() * 1000)
-      .return({
+    return new Promise(resolve => setTimeout(resolve, 50 + Math.random() * 1000))
+      .then({
         number: 100,
         items: [
           {

--- a/samples/subapp1-online-store/src/03.footer/server.jsx
+++ b/samples/subapp1-online-store/src/03.footer/server.jsx
@@ -1,5 +1,4 @@
 import { Component } from "./subapp-footer";
-import Promise from "bluebird";
 
 module.exports = {
   initialize: () => {
@@ -7,7 +6,7 @@ module.exports = {
   },
   prepare: () => {
     // console.log("subapp footer server prepare");
-    return Promise.delay(50 + Math.random() * 1000).return({
+    return new Promise(resolve => setTimeout(resolve, 50 + Math.random() * 1000)).then({
       title: "Your Online Store Copyright"
     });
   },

--- a/samples/subapp1-online-store/xrun-tasks.js
+++ b/samples/subapp1-online-store/xrun-tasks.js
@@ -14,6 +14,7 @@ const deps = require("./package.json").dependencies;
 
 loadDevTasks(xrun, {
   webpackOptions: {
-    minify: true
+    minify: true,
+    devtool: 'inline-source-map'
   }
 });


### PR DESCRIPTION
This PR includes changes to,
- Fix source-map  load warning. 
   <img width="729" alt="Screen Shot 2022-11-18 at 4 19 33 PM" src="https://user-images.githubusercontent.com/1584121/202823797-e1d2b565-7481-4444-8156-5fa1cde18e4b.png">
   By default we are setting ``webpack`` configuration ``devtool: false``.  Looks like a recent change and we get above source-map load warning if you have dev tools open. This was causing the app to stop responding when you have dev tools open. So passing down the ``inline-source-map`` configuration through ``xrun-taslks'``s webpack configuration. 

- Setting a fallback ``devtool`` configuration to ``eval-cheap-module-source-map`` in  ``@xarc/webpack``

- Change ``clap`` references to ``xrun`` for ``poc-subapp``, `` poc-subapp-redux`` and ``subapp1-online-store``.

- Remove `bluebird` usage, instead use native ``promise`` in sample apps - ``poc-subapp``, `` poc-subapp-redux`` and ``subapp1-online-store``.  Bluebird is only need to support old browsers or EOL Node.js. Removing its reference from these sample applications  as its better to reference latest usage guidelines on sample applications.

#### Pending issues to resolve
- ``poc-subapp`` throws ``Error: Shared module is not available for eager consumption`` 
