### PR TITLE
fix issues related to hmr, isomorphic loading, error reporting

### DIFF
--- a/packages/subapp-web/lib/load.js
+++ b/packages/subapp-web/lib/load.js
@@ -111,7 +111,7 @@ Response: ${err || body}`
         // if we have to inline the subapp's JS bundle, we load it for production mode
         const src = Fs.readFileSync(Path.resolve("dist/js", bundleAsset.name)).toString();
         const ext = Path.extname(bundleAsset.name);
-        if (ext === ".js") {
+        if (ext === ".js" && !src.endsWith(".hot-update.js")) {
           inlineSubAppJs = `<script>/*${name}*/${src}</script>`;
         } else if (ext === ".css") {
           inlineSubAppJs = `<style id="${name}">${src}</style>`;
@@ -156,11 +156,11 @@ Response: ${err || body}`
               .concat(cdnJsBundles[ep])
               .reduce((a, jsBundle) => {
                 const ext = Path.extname(jsBundle);
-                if (ext === ".js") {
+                if (ext === ".js" && !jsBundle.endsWith(".hot-update.js")) {
                   if (context.user.headEntries) {
                     headSplits.push(`<link rel="preload" href="${jsBundle}" as="script">`);
                   }
-                  a.push(`<script src="${jsBundle}" async></script>`);
+                  a.push(`<script src="${jsBundle}" async crossorigin="anonymous"></script>`);
                 } else if (ext === ".css") {
                   if (context.user.headEntries) {
                     headSplits.push(`<link rel="stylesheet" href="${jsBundle}">`);

--- a/packages/xarc-app-dev/src/lib/app-dev-middleware.ts
+++ b/packages/xarc-app-dev/src/lib/app-dev-middleware.ts
@@ -54,7 +54,10 @@ export class AppDevMiddleware {
       const { refreshed, failed } = data.refreshModules.reduce(
         (agg, moduleName) => {
           moduleName = moduleName.split("|")[0];
-          if (!moduleName.startsWith("webpack/runtime")) {
+          if (
+            !moduleName.startsWith("webpack/runtime") &&
+            !moduleName.startsWith("container entry (default)")
+          ) {
             try {
               const xarcOptions = loadXarcOptions();
               const xarcCwd = xarcOptions.cwd;
@@ -85,8 +88,6 @@ export class AppDevMiddleware {
       }
     }
 
-    initialLoad = false;
-
     // activate extend require for isomorphic assets
     getXRequire().activate();
 
@@ -106,6 +107,8 @@ export class AppDevMiddleware {
           break;
         case WEBPACK_EVENT_ISOMORPHIC_CONFIG:
           getXRequire().initialize(data.config);
+          // Only mark initial load to be completed when isomorphic init is done.
+          initialLoad = false;
           break;
         case WEBPACK_EVENT_STATS:
           break;


### PR DESCRIPTION
- Don't inject hot-update bundles in the template to avoid below error:

![Screenshot 2022-11-22 at 12 06 13 AM](https://user-images.githubusercontent.com/3193886/203145422-d2f28d1e-45ea-42bf-a783-86e76d0bdd98.png)

- Add `crossorigin="anonymous"` to our scripts for error reporting. By default, error message will include only `Script Error.`
- Skip container entry to avoid errors while refreshing apps on server
<img width="1296" alt="Screenshot 2022-11-21 at 11 55 39 PM" src="https://user-images.githubusercontent.com/3193886/203146267-d6791cf8-ff61-4f65-8677-0039226974c9.png">

- Handle isomorphic loading e.g. images, css modules etc. during first load, the app will start before webpack finish compiling, so webpack will inform app that modules refreshed when they didn't. sets a one time flag to avoid refreshing when first start up, reset this one time flag only after isomorphic initialise is set.
