### PR TITLE
fix types issues in multiple packages

### DIFF
--- a/packages/electrode-react-webapp/package.json
+++ b/packages/electrode-react-webapp/package.json
@@ -72,6 +72,7 @@
     "@babel/register": "^7.4.4",
     "benchmark": "^2.1.4",
     "electrode-archetype-njs-module-dev": "^3.0.3",
+    "chai": "4.3.6",
     "electrode-redux-router-engine": "../electrode-redux-router-engine",
     "electrode-server": "^1.8.0",
     "electrode-server2": "./electrode-server2",

--- a/packages/subapp-server/package.json
+++ b/packages/subapp-server/package.json
@@ -45,6 +45,7 @@
     "@babel/preset-react": "^7.16.7",
     "@babel/register": "^7.17.7",
     "electrode-archetype-njs-module-dev": "^3.0.3",
+    "chai": "4.3.6",
     "electrode-server": "^3.3.0",
     "run-verify": "^1.2.6",
     "@xarc/fastify-server": "^3.3.0"

--- a/packages/subapp-server/test/spec/fastify-plugin.spec.js
+++ b/packages/subapp-server/test/spec/fastify-plugin.spec.js
@@ -52,7 +52,7 @@ describe("fastify-plugin", function () {
   it("invokes subappServer's setup if it exists", async () => {
     const server = await require("@xarc/fastify-server")({
       deferStart: true,
-      connection: { port: 0, host: "localhost" }
+      connection: { port: 9001, host: "localhost" }
     });
 
     const srcDir = Path.join(__dirname, "../data/fastify-plugin-test");

--- a/packages/subapp-server/test/spec/fastify-plugin.spec.js
+++ b/packages/subapp-server/test/spec/fastify-plugin.spec.js
@@ -52,7 +52,7 @@ describe("fastify-plugin", function () {
   it("invokes subappServer's setup if it exists", async () => {
     const server = await require("@xarc/fastify-server")({
       deferStart: true,
-      connection: { port: 9001, host: "localhost" }
+      connection: { port: 3005, host: "localhost" }
     });
 
     const srcDir = Path.join(__dirname, "../data/fastify-plugin-test");

--- a/packages/webpack-config-composer/package.json
+++ b/packages/webpack-config-composer/package.json
@@ -42,7 +42,7 @@
     "@typescript-eslint/parser": "^4.11.0",
     "@xarc/module-dev": "^4.0.0",
     "babel-eslint": "^10.1.0",
-    "chai": "^4.2.0",
+    "chai": "4.3.6",
     "eslint": "^7.16.0",
     "eslint-config-walmart": "^2.2.1",
     "eslint-plugin-filenames": "^1.1.0",

--- a/packages/xarc-react-redux/package.json
+++ b/packages/xarc-react-redux/package.json
@@ -38,7 +38,7 @@
     "@testing-library/react": "^13.2.0",
     "@types/chai": "^4.3.1",
     "@types/mocha": "^9.1.1",
-    "@types/node": "^17.0.34",
+    "@types/node": "^18.11.9",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^18.0.4",
     "@types/sinon": "^10.0.11",

--- a/packages/xarc-react-router/package.json
+++ b/packages/xarc-react-router/package.json
@@ -35,7 +35,7 @@
     "@testing-library/react": "^13.2.0",
     "@types/chai": "^4.3.1",
     "@types/mocha": "^9.1.1",
-    "@types/node": "^17.0.35",
+    "@types/node": "^18.11.9",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.5",
     "@types/sinon": "^10.0.11",

--- a/packages/xarc-react/package.json
+++ b/packages/xarc-react/package.json
@@ -36,7 +36,7 @@
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@types/chai": "^4.3.1",
     "@types/mocha": "^9.1.1",
-    "@types/node": "^17.0.34",
+    "@types/node": "^18.11.9",
     "@types/react": "^16.9.49",
     "@types/react-dom": "^18.0.4",
     "@types/sinon": "^10.0.11",
@@ -56,9 +56,9 @@
     "sinon": "^14.0.0",
     "sinon-chai": "^3.7.0",
     "source-map-support": "^0.5.21",
-    "ts-node": "^10.7.0",
-    "typedoc": "^0.22.15",
-    "typescript": "^4.6.4"
+    "ts-node": "^10.9.1",
+    "typedoc": "^0.23.21",
+    "typescript": "^4.9.3"
   },
   "files": [
     "dist",

--- a/packages/xarc-webpack/package.json
+++ b/packages/xarc-webpack/package.json
@@ -65,7 +65,7 @@
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^7.0.2",
-    "@types/node": "^13.7.6",
+    "@types/node": "^18.11.9",
     "@types/sinon": "^9.0.0",
     "@types/sinon-chai": "^3.2.4",
     "@typescript-eslint/eslint-plugin": "^2.21.0",
@@ -85,9 +85,9 @@
     "sinon": "^7.2.6",
     "sinon-chai": "^3.3.0",
     "source-map-support": "^0.5.16",
-    "ts-node": "^8.6.2",
+    "ts-node": "^10.9.1",
     "typedoc": "^0.17.4",
-    "typescript": "^3.8.3"
+    "typescript": "^4.9.3"
   },
   "engines": {
     "node": ">= 12",


### PR DESCRIPTION
- Fix assertion failures due `deep-equals` package. 
A patch version bump on `chai` was causing major upgrade on `deep-equals` package. This lead to multiple failures in packages that use `deep-equal` assertions. As of now, with this PR, lock the chai version to avoid these assertion failures. This would unblock pending PRs. A better approach would be to update the assertion statement itself so that we can continue with chai upgrades in future. But since there are many such failures, deferring it to a later PR. 

- Upgrade `@types/node` to fix types issues on running `fun bootstrap`. 