### PR TITLE
feat(node-sass): update node-sass and sass-loader to support node v16

### DIFF
--- a/packages/xarc-opt-sass/package.json
+++ b/packages/xarc-opt-sass/package.json
@@ -30,8 +30,8 @@
     "prepare": "shx cp node_modules/opt-archetype-check/xarc-opt-check.js ."
   },
   "dependencies": {
-    "node-sass": "^4.9.3",
-    "sass-loader": "^6.0.6"
+    "node-sass": "^6.0.1",
+    "sass-loader": "^7.3.1"
   },
   "devDependencies": {
     "opt-archetype-check": "../opt-archetype-check",


### PR DESCRIPTION
Update node-sass and sass-loader dependencies to support node v16 installation for the @xarc/opt-sass package