### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,75 @@
+# 1/17/2023
+
+## Packages
+
+### Directly Updated
+
+- `@xarc/react@1.0.1` `(1.0.0 => 1.0.1)`
+- `@xarc/react-redux@1.0.1` `(1.0.0 => 1.0.1)`
+- `@xarc/react-router@1.0.1` `(1.0.0 => 1.0.1)`
+- `@xarc/webpack@11.1.4` `(11.1.3 => 11.1.4)`
+- `electrode-archetype-webpack-dll@3.0.0` `(2.0.4 => 3.0.0)`
+- `electrode-archetype-webpack-dll-dev@3.0.0` `(2.0.4 => 3.0.0)`
+- `electrode-react-webapp@5.0.1` `(5.0.0 => 5.0.1)`
+- `subapp-server@2.0.1` `(2.0.0 => 2.0.1)`
+- `webpack-config-composer@1.1.7` `(1.1.6 => 1.1.7)`
+
+### Lerna Updated
+
+- `@xarc/app-dev@11.0.2` `(11.0.1 => 11.0.2)`
+- `@xarc/app-dev@11.0.2` `(11.0.1 => 11.0.2)`
+- `@xarc/react-redux-observable@1.0.1` `(1.0.0 => 1.0.1)`
+- `@xarc/react-redux-saga@1.0.1` `(1.0.0 => 1.0.1)`
+
+## Commits
+
+- `packages/xarc-react`
+
+  - fix types issues in multiple packages ([#1918](https://github.com/electrode-io/electrode/pull/1918)) [commit](http://github.com/electrode-io/electrode/commit/ce8d69497b3af15502d2c49f36e6878ea74f76a2)
+
+- `packages/xarc-react-redux`
+
+  - fix types issues in multiple packages ([#1918](https://github.com/electrode-io/electrode/pull/1918)) [commit](http://github.com/electrode-io/electrode/commit/ce8d69497b3af15502d2c49f36e6878ea74f76a2)
+
+- `packages/xarc-react-router`
+
+  - fix types issues in multiple packages ([#1918](https://github.com/electrode-io/electrode/pull/1918)) [commit](http://github.com/electrode-io/electrode/commit/ce8d69497b3af15502d2c49f36e6878ea74f76a2)
+
+- `packages/xarc-webpack`
+
+  - [patch][bug] fix source map load issue ([#1914](https://github.com/electrode-io/electrode/pull/1914)) [commit](http://github.com/electrode-io/electrode/commit/e515e9a53c9239fb3fd7bb7ec6a668dfe654624e)
+  - fix types issues in multiple packages ([#1918](https://github.com/electrode-io/electrode/pull/1918)) [commit](http://github.com/electrode-io/electrode/commit/ce8d69497b3af15502d2c49f36e6878ea74f76a2)
+
+- `packages/electrode-archetype-webpack-dll`
+
+  - feat: commit to bump up webpack versions ([#1938](https://github.com/electrode-io/electrode/pull/1938)) [commit](http://github.com/electrode-io/electrode/commit/17aa45e73ca042ad4f485d5f7778f6ab4663fbe9)
+  - major: commit to bump up webpack versions ([#1937](https://github.com/electrode-io/electrode/pull/1937)) [commit](http://github.com/electrode-io/electrode/commit/21f0c6eb9c29d77e76337a3060ba1d8d9d7f01e9)
+  - upgrade to dll archetype to use webpack5 ([#1917](https://github.com/electrode-io/electrode/pull/1917)) [commit](http://github.com/electrode-io/electrode/commit/90d18b8f288dc6008122b4ca1de9b196b203afe5)
+  - [major] small commit to bump up dll packages major versions due to webpack version upgrades in previous commits ([#1939](https://github.com/electrode-io/electrode/pull/1939)) [commit](http://github.com/electrode-io/electrode/commit/8c688d2c11bfa0dc491a0db01681abfb724f0442)
+
+- `packages/electrode-archetype-webpack-dll-dev`
+
+  - feat: commit to bump up webpack versions ([#1938](https://github.com/electrode-io/electrode/pull/1938)) [commit](http://github.com/electrode-io/electrode/commit/17aa45e73ca042ad4f485d5f7778f6ab4663fbe9)
+  - major: commit to bump up webpack versions ([#1937](https://github.com/electrode-io/electrode/pull/1937)) [commit](http://github.com/electrode-io/electrode/commit/21f0c6eb9c29d77e76337a3060ba1d8d9d7f01e9)
+  - upgrade to dll archetype to use webpack5 ([#1917](https://github.com/electrode-io/electrode/pull/1917)) [commit](http://github.com/electrode-io/electrode/commit/90d18b8f288dc6008122b4ca1de9b196b203afe5)
+  - [major] small commit to bump up dll packages major versions due to webpack version upgrades in previous commits ([#1939](https://github.com/electrode-io/electrode/pull/1939)) [commit](http://github.com/electrode-io/electrode/commit/8c688d2c11bfa0dc491a0db01681abfb724f0442)
+
+- `packages/electrode-react-webapp`
+
+  - fix types issues in multiple packages ([#1918](https://github.com/electrode-io/electrode/pull/1918)) [commit](http://github.com/electrode-io/electrode/commit/ce8d69497b3af15502d2c49f36e6878ea74f76a2)
+
+- `packages/subapp-server`
+
+  - fix types issues in multiple packages ([#1918](https://github.com/electrode-io/electrode/pull/1918)) [commit](http://github.com/electrode-io/electrode/commit/ce8d69497b3af15502d2c49f36e6878ea74f76a2)
+
+- `packages/webpack-config-composer`
+
+  - fix types issues in multiple packages ([#1918](https://github.com/electrode-io/electrode/pull/1918)) [commit](http://github.com/electrode-io/electrode/commit/ce8d69497b3af15502d2c49f36e6878ea74f76a2)
+
+- `MISC`
+
+  - fix: sample applications ([#1923](https://github.com/electrode-io/electrode/pull/1923)) [commit](http://github.com/electrode-io/electrode/commit/1e48af1a71c351c4b3cb90d25d80bf9a9b2cb615)
+
 # 10/21/2022
 
 ## Packages

--- a/packages/electrode-archetype-webpack-dll-dev/package.json
+++ b/packages/electrode-archetype-webpack-dll-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrode-archetype-webpack-dll-dev",
-  "version": "2.0.4",
+  "version": "3.0.0",
   "description": "Electrode Archetype to build webpack DLLs",
   "main": "index.js",
   "scripts": {
@@ -23,7 +23,7 @@
     "uglifyjs-webpack-plugin": "^2.0.1",
     "webpack": "^5.75.0",
     "webpack-cli": "^4.8.0",
-    "webpack-config-composer": "^1.1.6",
+    "webpack-config-composer": "^1.1.7",
     "webpack-stats-plugin": "^1.1.1",
     "xclap": "^0.2.53",
     "xsh": "^0.4.4"
@@ -32,7 +32,7 @@
     "electrode-archetype-njs-module-dev": "^3.0.3"
   },
   "peerDependencies": {
-    "electrode-archetype-webpack-dll": "2.0.4"
+    "electrode-archetype-webpack-dll": "3.0.0"
   },
   "nyc": {
     "all": true,

--- a/packages/electrode-archetype-webpack-dll/package.json
+++ b/packages/electrode-archetype-webpack-dll/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrode-archetype-webpack-dll",
-  "version": "2.0.4",
+  "version": "3.0.0",
   "description": "Electrode Archetype to build webpack DLLs",
   "main": "arch-clap-tasks.js",
   "scripts": {},

--- a/packages/electrode-react-webapp/package.json
+++ b/packages/electrode-react-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrode-react-webapp",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Hapi plugin that provides a default React web app template",
   "main": "index.js",
   "scripts": {

--- a/packages/subapp-server/package.json
+++ b/packages/subapp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subapp-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Electrode SubApp app server support",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/webpack-config-composer/package.json
+++ b/packages/webpack-config-composer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-config-composer",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Flexible webpack config partials composing",
   "homepage": "http://www.electrode.io",
   "main": "lib/index.js",

--- a/packages/xarc-app-dev/package.json
+++ b/packages/xarc-app-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xarc/app-dev",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "description": "Electrode X application development support",
   "main": "lib/index.js",
   "homepage": "http://www.electrode.io",
@@ -58,7 +58,7 @@
     "@xarc/dev-base": "^0.1.0",
     "@xarc/run": "^1.0.5",
     "@xarc/subapp": "^0.3.4",
-    "@xarc/webpack": "^11.1.3",
+    "@xarc/webpack": "^11.1.4",
     "ansi-to-html": "^0.7.2",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-minify-dead-code-elimination": "^0.5.2",

--- a/packages/xarc-react-redux-observable/package.json
+++ b/packages/xarc-react-redux-observable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xarc/react-redux-observable",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "xarc React.js application redux observable support",
   "main": "dist-node-cjs/node/index.js",
   "module": "dist-node-esm/node/index.js",
@@ -27,7 +27,7 @@
     "react-dom": "*"
   },
   "dependencies": {
-    "@xarc/react-redux": "^1.0.0",
+    "@xarc/react-redux": "^1.0.1",
     "redux-observable": "^1.2.0",
     "rxjs": "^6.6.3",
     "tslib": "^2.1.0"

--- a/packages/xarc-react-redux-saga/package.json
+++ b/packages/xarc-react-redux-saga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xarc/react-redux-saga",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "xarc React.js application redux saga support",
   "main": "dist-node-cjs/node/index.js",
   "module": "dist-node-esm/node/index.js",
@@ -27,7 +27,7 @@
     "react-dom": "*"
   },
   "dependencies": {
-    "@xarc/react-redux": "^1.0.0",
+    "@xarc/react-redux": "^1.0.1",
     "redux-saga": "^1.1.3",
     "tslib": "^2.1.0"
   },

--- a/packages/xarc-react-redux/package.json
+++ b/packages/xarc-react-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xarc/react-redux",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "xarc React.js application redux support",
   "main": "dist-node-cjs/node/index.js",
   "module": "dist-node-esm/node/index.js",

--- a/packages/xarc-react-router/package.json
+++ b/packages/xarc-react-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xarc/react-router",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "xarc React Router support for SubApp version 2",
   "main": "dist-node-cjs/node/index.js",
   "module": "dist-node-esm/node/index.js",

--- a/packages/xarc-react/package.json
+++ b/packages/xarc-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xarc/react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "xarc web app platform support for React framework",
   "main": "dist-node-cjs/node/index.js",
   "module": "dist-node-esm/node/index.js",

--- a/packages/xarc-webpack/package.json
+++ b/packages/xarc-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xarc/webpack",
-  "version": "11.1.3",
+  "version": "11.1.4",
   "description": "Electrode X webpack config",
   "main": "lib/index.js",
   "homepage": "http://www.electrode.io",
@@ -53,13 +53,13 @@
     "url-loader": "^4.1.0",
     "webpack": "^5.74.0",
     "webpack-cli": "4.8.0",
-    "webpack-config-composer": "^1.1.6",
+    "webpack-config-composer": "^1.1.7",
     "webpack-stats-plugin": "^1.0.3",
     "xsh": "^0.4.5"
   },
   "peerDependencies": {
     "@xarc/app": "^11.0.1",
-    "@xarc/app-dev": "^11.0.1"
+    "@xarc/app-dev": "^11.0.2"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",


### PR DESCRIPTION
Changes included in this release. 

- Fix source map load issue - By default we are setting `webpack` configuration `devtool: false`. Looks like a recent change and we get above source-map load warning if you have dev tools open. This was causing the app to stop responding when you have dev tools open. So passing down the inline-source-map configuration through `xrun-tasks'` webpack configuration.

- Fix types issues in multiple packages

- Fix assertion failures due `deep-equals` package.

- A patch version bump on chai was causing major upgrade on deep-equals package. This lead to multiple failures in packages that use deep-equal assertions. As of now, with this PR, lock the chai version to avoid these assertion failures. This would unblock pending PRs. A better approach would be to update the assertion statement itself so that we can continue with chai upgrades in future. But since there are many such failures, deferring it to a later PR.

- Upgrade `@types/node` in packages to fix types issues while running `fun bootstrap`.

- Fix loading issues in a few sample applications

Please see [CHANGELOG.md](https://github.com/electrode-io/electrode/blob/fd60ba7a963d3d4c96f5b25ac1f25ffef22aaa7b/CHANGELOG.md) for more information