### PR TITLE
[major] node-sass replaced with sass

### DIFF
--- a/packages/xarc-opt-sass/package.json
+++ b/packages/xarc-opt-sass/package.json
@@ -21,7 +21,8 @@
   "author": "Electrode (http://www.electrode.io/)",
   "contributors": [
     "Joel Chen <xchen@walmartlabs.com>",
-    "Shubham Sharma <shubham.sharma3@walmart.com>"
+    "Shubham Sharma <shubham.sharma3@walmart.com>",
+    "Rahul Kumar <rahul.kumar1@walmart.com>"
   ],
   "license": "Apache-2.0",
   "scripts": {
@@ -31,7 +32,7 @@
     "prepare": "shx cp node_modules/opt-archetype-check/xarc-opt-check.js ."
   },
   "dependencies": {
-    "node-sass": "^8.0.0",
+    "sass": "^1.58.0",
     "sass-loader": "^13.2.0"
   },
   "devDependencies": {

--- a/packages/xarc-opt-sass/package.json
+++ b/packages/xarc-opt-sass/package.json
@@ -21,8 +21,7 @@
   "author": "Electrode (http://www.electrode.io/)",
   "contributors": [
     "Joel Chen <xchen@walmartlabs.com>",
-    "Shubham Sharma <shubham.sharma3@walmart.com>",
-    "Rahul Kumar <rahul.kumar1@walmart.com>"
+    "Shubham Sharma <shubham.sharma3@walmart.com>"
   ],
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Replaced node-sass package with sass@1.58.0 as node-sass is deprecated 3 years ago.