### PR TITLE
Csp directive

### DIFF
--- a/common/changes/subapp-server/csp-directive_2024-03-01-04-51.json
+++ b/common/changes/subapp-server/csp-directive_2024-03-01-04-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "subapp-server",
+      "comment": "Ablity to add CSP directives by application.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "subapp-server"
+}

--- a/packages/subapp-server/lib/fastify-plugin.js
+++ b/packages/subapp-server/lib/fastify-plugin.js
@@ -39,14 +39,14 @@ function makeRouteHandler({ path, routeRenderer, routeOptions }) {
 
   return async (request, reply) => {
     try {
-      const { styleNonce = "", scriptNonce = ""} = setCSPNonce({ routeOptions });
+      const { styleNonce = "", scriptNonce = "" } = setCSPNonce({ routeOptions });
 
       // wait for webpack stats to be valid if webpackDev
       if (webpackDev) {
         await until(() => request.app.webpackDev.valid === true, 400);
         console.log(`Webpack stats valid: ${request.app.webpackDev.valid}`);
       }
-      
+
       const context = await routeRenderer({
         useStream,
         mode: "",
@@ -58,11 +58,11 @@ function makeRouteHandler({ path, routeRenderer, routeOptions }) {
 
       let cspHeader;
       /** If csp headers are provided by application in route options then use that otherwise generate CSP headers */
-      if(routeOptions.cspHeaderValues instanceof Function ){
+      if (routeOptions.cspHeaderValues instanceof Function) {
         const rawCSPHeader = routeOptions.cspHeaderValues({ styleNonce, scriptNonce });
         // Replace newline characters and spaces
         cspHeader = rawCSPHeader.replace(/\s{2,}/g, " ").trim();
-      }else{
+      } else {
         cspHeader = getCSPHeader({ styleNonce, scriptNonce });
       }
       if (cspHeader) {
@@ -84,7 +84,6 @@ function makeRouteHandler({ path, routeRenderer, routeOptions }) {
         reply.code(status);
         return reply.send(data);
       }
-      
     } catch (err) {
       reply.status(HttpStatusCodes.INTERNAL_SERVER_ERROR);
       if (process.env.NODE_ENV !== "production") {

--- a/packages/subapp-server/lib/fastify-plugin.js
+++ b/packages/subapp-server/lib/fastify-plugin.js
@@ -25,7 +25,8 @@ const {
   updateFullTemplate,
   setCSPNonce,
   getCSPHeader,
-  until
+  until,
+  setCSPDirectives
 } = require("./utils");
 
 const routesFromFile = require("./routes-from-file");
@@ -39,7 +40,8 @@ function makeRouteHandler({ path, routeRenderer, routeOptions }) {
 
   return async (request, reply) => {
     try {
-      const { styleNonce = "", scriptNonce = "" } = setCSPNonce({ routeOptions });
+      const { styleNonce = "", scriptNonce = ""} = setCSPNonce({ routeOptions });
+      const {directiveNonce = ""} = setCSPDirectives({routeOptions})
 
       // wait for webpack stats to be valid if webpackDev
       if (webpackDev) {
@@ -56,7 +58,8 @@ function makeRouteHandler({ path, routeRenderer, routeOptions }) {
       const data = context.result;
       const status = data.status;
 
-      const cspHeader = getCSPHeader({ styleNonce, scriptNonce });
+      const cspHeader = getCSPHeader({ styleNonce, scriptNonce, directiveNonce });
+      console.log('RahulCSP ', cspHeader)
 
       if (cspHeader) {
         reply.header("Content-Security-Policy", cspHeader);

--- a/packages/subapp-server/lib/fastify-plugin.js
+++ b/packages/subapp-server/lib/fastify-plugin.js
@@ -41,7 +41,7 @@ function makeRouteHandler({ path, routeRenderer, routeOptions }) {
   return async (request, reply) => {
     try {
       const { styleNonce = "", scriptNonce = ""} = setCSPNonce({ routeOptions });
-      const {directiveNonce = ""} = setCSPDirectives({routeOptions})
+      const directiveNonce = setCSPDirectives({routeOptions})
 
       // wait for webpack stats to be valid if webpackDev
       if (webpackDev) {
@@ -59,7 +59,6 @@ function makeRouteHandler({ path, routeRenderer, routeOptions }) {
       const status = data.status;
 
       const cspHeader = getCSPHeader({ styleNonce, scriptNonce, directiveNonce });
-      console.log('RahulCSP ', cspHeader)
 
       if (cspHeader) {
         reply.header("Content-Security-Policy", cspHeader);

--- a/packages/subapp-server/lib/fastify-plugin.js
+++ b/packages/subapp-server/lib/fastify-plugin.js
@@ -58,8 +58,8 @@ function makeRouteHandler({ path, routeRenderer, routeOptions }) {
 
       let cspHeader;
       /** If csp headers are provided by application in route options then use that otherwise generate CSP headers */
-      if(routeOptions.getCSPHeader && typeof routeOptions.getCSPHeader === "function"){
-        const rawCSPHeader = routeOptions.getCSPHeader({ styleNonce, scriptNonce });
+      if(routeOptions.cspHeaderValues instanceof Function ){
+        const rawCSPHeader = routeOptions.cspHeaderValues({ styleNonce, scriptNonce });
         // Replace newline characters and spaces
         cspHeader = rawCSPHeader.replace(/\s{2,}/g, " ").trim();
       }else{

--- a/packages/subapp-server/lib/utils.js
+++ b/packages/subapp-server/lib/utils.js
@@ -202,10 +202,13 @@ function setCSPDirectives({routeOptions}){
    * Check if cspDirectives is present in routerOptions and cspDirectives is an Object
    */
   if(routeOptions.cspDirectives && typeof routeOptions.cspDirectives === "object"){
-    const data = Object.entries(routeOptions.cspDirectives).map(([key,value]) => {
-      return ` ${key} ${value}`
+    const data = Object.entries(routeOptions.cspDirectives).filter(([key,value]) => {
+      /** Check if script-src or style-src is explicitly set as additional directives */
+      if(key !== 'script-src' && key !== 'style-src'){
+        return ` ${key} ${value}`
+      }
     });
-    routeOptions.cspDirectivesValue = data.join(";");
+    routeOptions.cspDirectivesValue = data.join("; ");
   }
   return routeOptions.cspDirectivesValue;
 }

--- a/packages/subapp-server/lib/utils.js
+++ b/packages/subapp-server/lib/utils.js
@@ -47,9 +47,7 @@ function getDefaultRouteOptions() {
     cspNonce: false, 
     templateFile: Path.join(__dirname, "..", "resources", "index-page"),
     cdn: {},
-    reporting: { enable: false },
-    cspDirectives: undefined,
-    cspDirectivesValue : undefined
+    reporting: { enable: false }
   };
 }
 
@@ -197,23 +195,7 @@ function setCSPNonce({ routeOptions }) {
   return routeOptions.cspNonceValue;
 }
 
-function setCSPDirectives({routeOptions}){
-  /**
-   * Check if cspDirectives is present in routerOptions and cspDirectives is an Object
-   */
-  if(routeOptions.cspDirectives && typeof routeOptions.cspDirectives === "object"){
-    const data = Object.entries(routeOptions.cspDirectives).filter(([key,value]) => {
-      /** Check if script-src or style-src is explicitly set as additional directives */
-      if(key !== 'script-src' && key !== 'style-src'){
-        return ` ${key} ${value}`
-      }
-    });
-    routeOptions.cspDirectivesValue = data.join("; ");
-  }
-  return routeOptions.cspDirectivesValue;
-}
-
-function getCSPHeader({ styleNonce = "", scriptNonce = "", directiveNonce = "" }) {
+function getCSPHeader({ styleNonce = "", scriptNonce = "" }) {
   const unsafeEval = process.env.NODE_ENV !== "production" ? 
         `'unsafe-eval'` : "";
 
@@ -221,9 +203,7 @@ function getCSPHeader({ styleNonce = "", scriptNonce = "", directiveNonce = "" }
   
   const scriptSrc = scriptNonce ? `script-src 'nonce-${scriptNonce}' 'strict-dynamic' ${unsafeEval}; `: "";
 
-  const directiveSrc = directiveNonce ? `${directiveNonce};`: "";
-
-  return `${scriptSrc}${styleSrc}${directiveSrc}`;
+  return `${scriptSrc}${styleSrc}`;
 }
 
 /**
@@ -254,6 +234,5 @@ module.exports = {
   invokeTemplateProcessor,
   setCSPNonce,
   getCSPHeader,
-  until,
-  setCSPDirectives
+  until
 };

--- a/packages/subapp-server/lib/utils.js
+++ b/packages/subapp-server/lib/utils.js
@@ -203,7 +203,7 @@ function setCSPDirectives({routeOptions}){
    */
   if(routeOptions.cspDirectives && typeof routeOptions.cspDirectives === "object"){
     const data = Object.entries(routeOptions.cspDirectives).map(([key,value]) => {
-      return ` ${key} ${value} `
+      return ` ${key} ${value}`
     });
     routeOptions.cspDirectivesValue = data.join(";");
   }
@@ -218,7 +218,7 @@ function getCSPHeader({ styleNonce = "", scriptNonce = "", directiveNonce = "" }
   
   const scriptSrc = scriptNonce ? `script-src 'nonce-${scriptNonce}' 'strict-dynamic' ${unsafeEval}; `: "";
 
-  const directiveSrc = directiveNonce ? `${directiveNonce} ;`: "";
+  const directiveSrc = directiveNonce ? `${directiveNonce};`: "";
 
   return `${scriptSrc}${styleSrc}${directiveSrc}`;
 }

--- a/packages/subapp-server/lib/utils.js
+++ b/packages/subapp-server/lib/utils.js
@@ -23,9 +23,12 @@ const updateFullTemplate = (baseDir, options) => {
 };
 
 function getDefaultRouteOptions() {
-  const { settings = {}, devServer = {}, fullDevServer = {}, httpDevServer = {} } = getDevProxy
-    ? getDevProxy()
-    : {};
+  const {
+    settings = {},
+    devServer = {},
+    fullDevServer = {},
+    httpDevServer = {}
+  } = getDevProxy ? getDevProxy() : {};
   const { webpackDev, useDevProxy } = settings;
   // temporary location to write build artifacts in dev mode
   const buildArtifacts = ".etmp";
@@ -42,9 +45,9 @@ function getDefaultRouteOptions() {
     buildArtifacts,
     prodBundleBase: "/js",
     devBundleBase: "/js",
-    cspNonceValue: undefined, 
+    cspNonceValue: undefined,
     // if `true`, electrode will generate nonce and add CSP header
-    cspNonce: false, 
+    cspNonce: false,
     templateFile: Path.join(__dirname, "..", "resources", "index-page"),
     cdn: {},
     reporting: { enable: false }
@@ -143,46 +146,49 @@ function nonceGenerator(_) {
 /**
  * Sets CSP nonce to routeOptions and returns the nonce value
  * cspNonce - boolean || object || string
- * 
- * @param {*} param0 
+ *
+ * @param {*} param0
  * @returns nonce value
  */
 function setCSPNonce({ routeOptions }) {
   let nonce = nonceGenerator();
-  
-  switch(typeof routeOptions.cspNonce) {
+
+  switch (typeof routeOptions.cspNonce) {
     // if cspNonce is a string, electrode validates it for nonce value and uses the same to set CSP header
     case "string": {
-      assert(routeOptions.cspNonce.match(/^[A-Za-z0-9+=\/]{22}$/), "Error: unable to set CSP header. Invalid nonce value passed!");
+      assert(
+        routeOptions.cspNonce.match(/^[A-Za-z0-9+=\/]{22}$/),
+        "Error: unable to set CSP header. Invalid nonce value passed!"
+      );
 
       routeOptions.cspNonceValue = {
         styleNonce: routeOptions.cspNonce,
         scriptNonce: routeOptions.cspNonce
       };
       break;
-    };
+    }
 
-    // if cspNonce is true, electrode will generate nonce and sets CSP header for both 
+    // if cspNonce is true, electrode will generate nonce and sets CSP header for both
     // styles and script.
     case "boolean": {
-      nonce = !!routeOptions.cspNonce === true ? nonce : ""
+      nonce = !!routeOptions.cspNonce === true ? nonce : "";
       routeOptions.cspNonceValue = {
         styleNonce: nonce,
         scriptNonce: nonce
       };
       break;
-    };
-    // if cspHeader is an object, app should explicitly enable it for script and/or style. 
+    }
+    // if cspHeader is an object, app should explicitly enable it for script and/or style.
     // cspHeader: { style: true } - will enable nonce only for styles
     case "object": {
       routeOptions.cspNonceValue = {
         styleNonce: routeOptions.cspNonce && !!routeOptions.cspNonce.style === true ? nonce : "",
-        scriptNonce: routeOptions.cspNonce && !!routeOptions.cspNonce.script  === true ? nonce : ""
+        scriptNonce: routeOptions.cspNonce && !!routeOptions.cspNonce.script === true ? nonce : ""
       };
       break;
-    };
+    }
     // TODO: add 'case' so that app can pass a nonce generator function.
-    
+
     default: {
       routeOptions.cspNonceValue = {
         styleNonce: "",
@@ -191,35 +197,36 @@ function setCSPNonce({ routeOptions }) {
       break;
     }
   }
-  
+
   return routeOptions.cspNonceValue;
 }
 
 function getCSPHeader({ styleNonce = "", scriptNonce = "" }) {
-  const unsafeEval = process.env.NODE_ENV !== "production" ? 
-        `'unsafe-eval'` : "";
+  const unsafeEval = process.env.NODE_ENV !== "production" ? `'unsafe-eval'` : "";
 
   const styleSrc = styleNonce ? `style-src 'nonce-${styleNonce}' 'strict-dynamic';` : "";
-  
-  const scriptSrc = scriptNonce ? `script-src 'nonce-${scriptNonce}' 'strict-dynamic' ${unsafeEval}; `: "";
+
+  const scriptSrc = scriptNonce
+    ? `script-src 'nonce-${scriptNonce}' 'strict-dynamic' ${unsafeEval}; `
+    : "";
 
   return `${scriptSrc}${styleSrc}`;
 }
 
 /**
- * Wait for a condition and execute rest of the code. 
+ * Wait for a condition and execute rest of the code.
  * @param conditionFunction - A function that returns conditions to be waited for.
  * @param maxWait - Max duration (in ms) to wait before promise resolves to avoid indefinite wait.
  * @returns A promise that resolves after given condition in conditionFunction is satisfied or after the max wait time.
  */
 function until(conditionFunction, maxWait) {
-  const poll = (resolve) => {
+  const poll = resolve => {
     if (conditionFunction()) {
       resolve();
     } else {
       setTimeout(_ => poll(resolve), maxWait);
     }
-  }
+  };
 
   return new Promise(poll);
 }

--- a/packages/subapp-server/lib/utils.js
+++ b/packages/subapp-server/lib/utils.js
@@ -47,7 +47,9 @@ function getDefaultRouteOptions() {
     cspNonce: false, 
     templateFile: Path.join(__dirname, "..", "resources", "index-page"),
     cdn: {},
-    reporting: { enable: false }
+    reporting: { enable: false },
+    cspDirectives: undefined,
+    cspDirectivesValue : undefined
   };
 }
 
@@ -195,7 +197,17 @@ function setCSPNonce({ routeOptions }) {
   return routeOptions.cspNonceValue;
 }
 
-function getCSPHeader({ styleNonce = "", scriptNonce = "" }) {
+function setCSPDirectives({routeOptions}){
+  if(routeOptions.cspDirectives){
+    let str='';
+    const directivesArr = Object.entries(routeOptions.cspDirectives);
+    const data = directivesArr.map(([key,value]) => str + ` ${key} ${value} `);
+    routeOptions.cspDirectivesValue = data;
+  }
+  return routeOptions.cspDirectivesValue;
+}
+
+function getCSPHeader({ styleNonce = "", scriptNonce = "", directiveNonce = "" }) {
   const unsafeEval = process.env.NODE_ENV !== "production" ? 
         `'unsafe-eval'` : "";
 
@@ -203,7 +215,9 @@ function getCSPHeader({ styleNonce = "", scriptNonce = "" }) {
   
   const scriptSrc = scriptNonce ? `script-src 'nonce-${scriptNonce}' 'strict-dynamic' ${unsafeEval}; `: "";
 
-  return `${scriptSrc}${styleSrc}`;
+  const directiveSrc = directiveNonce ? `${directiveNonce} ${unsafeEval}; `: "";
+
+  return `${scriptSrc}${styleSrc}${directiveSrc}`;
 }
 
 /**
@@ -234,5 +248,6 @@ module.exports = {
   invokeTemplateProcessor,
   setCSPNonce,
   getCSPHeader,
-  until
+  until,
+  setCSPDirectives
 };

--- a/packages/subapp-server/lib/utils.js
+++ b/packages/subapp-server/lib/utils.js
@@ -198,11 +198,14 @@ function setCSPNonce({ routeOptions }) {
 }
 
 function setCSPDirectives({routeOptions}){
-  if(routeOptions.cspDirectives){
-    let str='';
-    const directivesArr = Object.entries(routeOptions.cspDirectives);
-    const data = directivesArr.map(([key,value]) => str + ` ${key} ${value} `);
-    routeOptions.cspDirectivesValue = data;
+  /**
+   * Check if cspDirectives is present in routerOptions and cspDirectives is an Object
+   */
+  if(routeOptions.cspDirectives && typeof routeOptions.cspDirectives === "object"){
+    const data = Object.entries(routeOptions.cspDirectives).map(([key,value]) => {
+      return ` ${key} ${value} `
+    });
+    routeOptions.cspDirectivesValue = data.join(";");
   }
   return routeOptions.cspDirectivesValue;
 }
@@ -215,7 +218,7 @@ function getCSPHeader({ styleNonce = "", scriptNonce = "", directiveNonce = "" }
   
   const scriptSrc = scriptNonce ? `script-src 'nonce-${scriptNonce}' 'strict-dynamic' ${unsafeEval}; `: "";
 
-  const directiveSrc = directiveNonce ? `${directiveNonce} ${unsafeEval}; `: "";
+  const directiveSrc = directiveNonce ? `${directiveNonce} ;`: "";
 
   return `${scriptSrc}${styleSrc}${directiveSrc}`;
 }

--- a/samples/poc-subappv1-csp/src/routes.js
+++ b/samples/poc-subappv1-csp/src/routes.js
@@ -36,8 +36,6 @@ const setCSPHeaderValues = ({styleNonce, scriptNonce}) => {
  * Option 3 - Selectively set boolean flag for `cspNonce`. { style: true } will add nonce only 
  * for styles
  * 
- * Option 4 - write a function which would return list of CSP directives and values as string
- * and pass that "function" to getCSPHeader
  */
 
 export default {
@@ -49,7 +47,7 @@ export default {
     cspNonce: true,
     // cspNonce: { style: true }, // { script: true }
     //  cspNonce: cspNonceValue,
-    getCSPHeader: setCSPHeaderValues,
+    cspHeaderValues: setCSPHeaderValues,
     criticalCSS: path.join(__dirname, "./server/critical.css"),
     ...commonRouteOptions
   }

--- a/samples/poc-subappv1-csp/src/routes.js
+++ b/samples/poc-subappv1-csp/src/routes.js
@@ -1,6 +1,5 @@
 const path = require("path");
 const { cspNonceValue } = require("./server/utils");
-
 const subAppOptions = {
   serverSideRendering: false,
 };
@@ -11,15 +10,19 @@ const commonRouteOptions = {
   tokenHandlers,
 };
 /**
- * to set CSP directives pass the cspDirectives as an object
- * key should be the name of the directive
- * value should be the value of the directive.
+ * 
+ * @param {*} param0 
+ * @returns CSP header value as string
  */
-const additionalDirective = {
-  "frame-src": "'self' allowed-site.example.com",
-  "prefetch-src": "'none'",
-  "manifest-src": "'none'",
-  "script-src": "'self"
+const setCSPHeaderValues = ({styleNonce, scriptNonce}) => {
+  const cspHeader = `
+                script-src 'self' 'nonce-${scriptNonce}' 'strict-dynamic' 'unsafe-eval';
+                style-src 'self' 'nonce-${styleNonce}' 'strict-dynamic' 'unsafe-eval';
+                font-src 'self';
+                object-src 'none';
+                form-action 'self';
+              `;
+      return cspHeader;
 };
 
 /**
@@ -31,6 +34,9 @@ const additionalDirective = {
  * 
  * Option 3 - Selectively set boolean flag for `cspNonce`. { style: true } will add nonce only 
  * for styles
+ * 
+ * Option 4 - write a function which would return list of CSP directives and values as string
+ * and pass that "function" to getCSPHeader
  */
 
 export default {
@@ -41,8 +47,8 @@ export default {
     // Enable one of these to use CSP header
     cspNonce: true,
     // cspNonce: { style: true }, // { script: true }
-    // cspNonce: cspNonceValue,
-    cspDirectives: additionalDirective,
+    //  cspNonce: cspNonceValue,
+    getCSPHeader: setCSPHeaderValues,
     criticalCSS: path.join(__dirname, "./server/critical.css"),
     ...commonRouteOptions
   }

--- a/samples/poc-subappv1-csp/src/routes.js
+++ b/samples/poc-subappv1-csp/src/routes.js
@@ -11,8 +11,9 @@ const commonRouteOptions = {
 };
 /**
  * 
- * @param {*} param0 
- * @returns CSP header value as string
+ * @param {string} styleNonce Value
+ * @param {string} scriptNonce Value
+ * @returns {string} CSP header value
  */
 const setCSPHeaderValues = ({styleNonce, scriptNonce}) => {
   const cspHeader = `

--- a/samples/poc-subappv1-csp/src/routes.js
+++ b/samples/poc-subappv1-csp/src/routes.js
@@ -18,7 +18,8 @@ const commonRouteOptions = {
 const additionalDirective = {
   "frame-src": "'self' allowed-site.example.com",
   "prefetch-src": "'none'",
-  "manifest-src": "'none'"
+  "manifest-src": "'none'",
+  "script-src": "'self"
 };
 
 /**

--- a/samples/poc-subappv1-csp/src/routes.js
+++ b/samples/poc-subappv1-csp/src/routes.js
@@ -10,6 +10,16 @@ const tokenHandlers = [path.join(__dirname, "./server/token-handler")];
 const commonRouteOptions = {
   tokenHandlers,
 };
+/**
+ * to set CSP directives pass the cspDirectives as an object
+ * key should be the name of the directive
+ * value should be the value of the directive.
+ */
+const additionalDirective = {
+  "frame-src": "'self' allowed-site.example.com",
+  "prefetch-src": "'none'",
+  "manifest-src": "'none'"
+};
 
 /**
  * To set CSP header
@@ -31,6 +41,7 @@ export default {
     cspNonce: true,
     // cspNonce: { style: true }, // { script: true }
     // cspNonce: cspNonceValue,
+    cspDirectives: additionalDirective,
     criticalCSS: path.join(__dirname, "./server/critical.css"),
     ...commonRouteOptions
   }


### PR DESCRIPTION
Add ablity for applications to set their CSP headers which may include style-src & script-src. Applications can set their nonce value or use default nonce value provided by electrode as usual. 

getCSPHeader is added in route options, which accepts a function. In this function application can generate the CSP and return it as string.