### PR TITLE
fix: windows path issue

### DIFF
--- a/packages/xarc-app-dev/src/lib/index.ts
+++ b/packages/xarc-app-dev/src/lib/index.ts
@@ -14,7 +14,7 @@ export { fastifyPlugin } from "./webpack-dev-fastify";
 export { expressMiddleware } from "./webpack-dev-express";
 export { koaMiddleware } from "./webpack-dev-koa";
 
-const makeEslintRcFile = file => Path.posix.join(__dirname, "../config/eslint", file);
+const makeEslintRcFile = file => Path.join(__dirname, "../config/eslint", file);
 
 /** path to built-in eslintrc for React test code */
 export const eslintRcReactTest = makeEslintRcFile(".eslintrc-react-test");


### PR DESCRIPTION
"npm run lint" throwing error in windows.
"Path.posix.join" combine path according to unix system only (i.e  forward slash)
It is not working in windows. After replacing it with "Path.join" It is working fine.