### PR TITLE
fix: remove malicious opt-archetype-check dependency

### DIFF
--- a/packages/xarc-opt-eslint/package.json
+++ b/packages/xarc-opt-eslint/package.json
@@ -23,8 +23,7 @@
     "build": "echo \"Nothing to build. Just a placeholder\"",
     "test": "echo OK",
     "coverage": "echo OK",
-    "preinstall": "node xarc-opt-check.js",
-    "prepare": "shx cp node_modules/opt-archetype-check/xarc-opt-check.js ."
+    "preinstall": "node xarc-opt-check.js"
   },
   "dependencies": {
     "@babel/eslint-parser": "^7.25.1",
@@ -37,7 +36,6 @@
     "eslint-plugin-react": "^7.29.4"
   },
   "devDependencies": {
-    "opt-archetype-check": "1.0.0",
     "shx": "^0.3.4"
   },
   "xarcOptCheck": {

--- a/packages/xarc-opt-jest/package.json
+++ b/packages/xarc-opt-jest/package.json
@@ -23,8 +23,7 @@
     "build": "echo \"Nothing to build. Just a placeholder\"",
     "test": "echo OK",
     "coverage": "echo OK",
-    "preinstall": "node xarc-opt-check.js",
-    "prepare": "shx cp node_modules/opt-archetype-check/xarc-opt-check.js ."
+    "preinstall": "node xarc-opt-check.js"
   },
   "dependencies": {
     "@types/jest": "^29.5.3",
@@ -34,7 +33,6 @@
     "jest-environment-jsdom": "^29.6.2"
   },
   "devDependencies": {
-    "opt-archetype-check": "1.0.0",
     "shx": "^0.3.4"
   },
   "xarcOptCheck": {

--- a/packages/xarc-opt-karma/package.json
+++ b/packages/xarc-opt-karma/package.json
@@ -25,8 +25,7 @@
     "build": "echo \"Nothing to build. Just a placeholder\"",
     "test": "echo OK",
     "coverage": "echo OK",
-    "preinstall": "node xarc-opt-check.js",
-    "prepare": "shx cp node_modules/opt-archetype-check/xarc-opt-check.js ."
+    "preinstall": "node xarc-opt-check.js"
   },
   "dependencies": {
     "@types/mocha": "10.0.1",
@@ -53,7 +52,6 @@
     "sinon-chai": "^3.7.0"
   },
   "devDependencies": {
-    "opt-archetype-check": "1.0.0",
     "shx": "^0.3.4"
   },
   "xarcOptCheck": {

--- a/packages/xarc-opt-less/package.json
+++ b/packages/xarc-opt-less/package.json
@@ -23,15 +23,13 @@
     "build": "echo \"Nothing to build. Just a placeholder\"",
     "test": "echo OK",
     "coverage": "echo OK",
-    "preinstall": "node xarc-opt-check.js",
-    "prepare": "shx cp node_modules/opt-archetype-check/xarc-opt-check.js ."
+    "preinstall": "node xarc-opt-check.js"
   },
   "dependencies": {
     "less": "^3.9.0",
     "less-loader": "^4.1.0"
   },
   "devDependencies": {
-    "opt-archetype-check": "1.0.0",
     "shx": "^0.3.4"
   },
   "xarcOptCheck": {

--- a/packages/xarc-opt-mocha/package.json
+++ b/packages/xarc-opt-mocha/package.json
@@ -23,8 +23,7 @@
     "build": "echo \"Nothing to build. Just a placeholder\"",
     "test": "echo OK",
     "coverage": "echo OK",
-    "preinstall": "node xarc-opt-check.js",
-    "prepare": "shx cp node_modules/opt-archetype-check/xarc-opt-check.js ."
+    "preinstall": "node xarc-opt-check.js"
   },
   "dependencies": {
     "@types/mocha": "^10.0.1",
@@ -34,7 +33,6 @@
     "mocha": "^10.2.0"
   },
   "devDependencies": {
-    "opt-archetype-check": "1.0.0",
     "shx": "^0.4.0"
   },
   "xarcOptCheck": {

--- a/packages/xarc-opt-postcss/package.json
+++ b/packages/xarc-opt-postcss/package.json
@@ -16,8 +16,7 @@
     "build": "echo \"Nothing to build. Just a placeholder\"",
     "test": "echo OK",
     "coverage": "echo OK",
-    "preinstall": "node xarc-opt-check.js",
-    "prepare": "shx cp node_modules/opt-archetype-check/xarc-opt-check.js ."
+    "preinstall": "node xarc-opt-check.js"
   },
   "files": [
     "xarc-opt-check.js"
@@ -36,7 +35,6 @@
     "sugarss": "^4.0.1"
   },
   "devDependencies": {
-    "opt-archetype-check": "1.0.0",
     "shx": "^0.3.4"
   },
   "xarcOptCheck": {

--- a/packages/xarc-opt-preact/package.json
+++ b/packages/xarc-opt-preact/package.json
@@ -23,14 +23,12 @@
     "build": "echo \"Nothing to build. Just a placeholder\"",
     "test": "echo OK",
     "coverage": "echo OK",
-    "preinstall": "node xarc-opt-check.js",
-    "prepare": "shx cp node_modules/opt-archetype-check/xarc-opt-check.js ."
+    "preinstall": "node xarc-opt-check.js"
   },
   "dependencies": {
     "preact": "^10.0.5"
   },
   "devDependencies": {
-    "opt-archetype-check": "1.0.0",
     "shx": "^0.3.2"
   },
   "xarcOptCheck": {

--- a/packages/xarc-opt-react/package.json
+++ b/packages/xarc-opt-react/package.json
@@ -27,15 +27,13 @@
     "build": "echo \"Nothing to build. Just a placeholder\"",
     "test": "echo OK",
     "coverage": "echo OK",
-    "preinstall": "node xarc-opt-check.js",
-    "prepare": "shx cp node_modules/opt-archetype-check/xarc-opt-check.js ."
+    "preinstall": "node xarc-opt-check.js"
   },
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "opt-archetype-check": "1.0.0",
     "shx": "^0.3.2"
   },
   "xarcOptCheck": {

--- a/packages/xarc-opt-sass/package.json
+++ b/packages/xarc-opt-sass/package.json
@@ -24,15 +24,13 @@
     "build": "echo \"Nothing to build. Just a placeholder\"",
     "test": "echo OK",
     "coverage": "echo OK",
-    "preinstall": "node xarc-opt-check.js",
-    "prepare": "shx cp node_modules/opt-archetype-check/xarc-opt-check.js ."
+    "preinstall": "node xarc-opt-check.js"
   },
   "dependencies": {
     "sass": "^1.58.0",
     "sass-loader": "^13.2.0"
   },
   "devDependencies": {
-    "opt-archetype-check": "1.0.0",
     "shx": "^0.3.4"
   },
   "xarcOptCheck": {

--- a/packages/xarc-opt-stylus/package.json
+++ b/packages/xarc-opt-stylus/package.json
@@ -23,15 +23,13 @@
     "build": "echo \"Nothing to build. Just a placeholder\"",
     "test": "echo OK",
     "coverage": "echo OK",
-    "preinstall": "node xarc-opt-check.js",
-    "prepare": "shx cp node_modules/opt-archetype-check/xarc-opt-check.js ."
+    "preinstall": "node xarc-opt-check.js"
   },
   "dependencies": {
     "stylus": "^0.57.0",
     "stylus-relative-loader": "^4.0.0"
   },
   "devDependencies": {
-    "opt-archetype-check": "1.0.0",
     "shx": "^0.3.4"
   },
   "xarcOptCheck": {


### PR DESCRIPTION
Remove the opt-archetype-check@1.0.0 devDependency and the prepare script that copied from node_modules/opt-archetype-check across all 10 @xarc/opt-* packages. The package name was subject to dependency confusion (an internal private package name published maliciously to public npm).

Safe: xarc-opt-check.js is already committed in each package (md5-identical to the internal source), and no source imports the package. preinstall still runs the local committed file.